### PR TITLE
chore: tsconfig에서 미사용 baseUrl/paths 제거

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,11 +11,7 @@
     "esModuleInterop": true,
     "lib": ["esnext", "dom"],
     "skipLibCheck": true,
-    "noEmit": true,
-    "baseUrl": ".",
-    "paths": {
-      "@/*": ["src/*"]
-    }
+    "noEmit": true
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## Summary
- `tsconfig.json`의 `baseUrl`/`paths`(`@/*`) 옵션을 제거.
- TypeScript 6부터 `baseUrl`이 deprecation 경고에서 빌드 차단 에러로 격상되어 #131(TS v6 업데이트 PR)이 실패 중.
- 코드에서 `@/...` import 사용처가 0건이라 alias 자체를 들어낸다 (vite의 `resolve.alias`는 별개라 그대로 유지).

## 동기
#131 머지를 막던 `tsconfig.json(15,5): error TS5101: Option 'baseUrl' is deprecated and will stop functioning in TypeScript 7.0.` 에러 해소.
