### PR TITLE
docs(residual-work): §0 최우선 — react-hooks 7.1 신규 룰 위반 14건 정리 계획

### DIFF
--- a/docs/residual-work.md
+++ b/docs/residual-work.md
@@ -10,6 +10,182 @@
 
 ---
 
+## 0. [최우선] eslint-plugin-react-hooks 7.1 신규 룰 위반 정리
+
+> 2026-05-21 작업. 다음 세션 진입 시 이 섹션부터 처리할 것.
+> 컨텍스트: #164(`chore: eslint v10 + eslint-plugin-react-hooks 7.1
+업그레이드`, squash `ab49cdc`)에서 lint v10 메이저로 올리면서
+> react-hooks 7.1의 신규 룰 두 개가 기존 코드 14건을 잡아냈다. 의존성
+> 업그레이드와 코드 수정을 분리하기 위해 두 룰만 **임시 off**로 머지함
+> ([eslint.config.mjs](../eslint.config.mjs) L31-L35 TODO 주석 참조).
+> 이 섹션은 본 임시 disable을 걷어내기 위한 정리 작업 명세다.
+
+### 0.1 작업 목표
+
+1. 14건의 react-hooks 위반을 코드 수정으로 해소.
+2. `eslint.config.mjs`의 두 줄 disable 제거:
+   - `"react-hooks/set-state-in-effect": "off"`
+   - `"react-hooks/refs": "off"`
+3. `npm run lint` 통과 확인 후 PR.
+
+### 0.2 작업 진행 방식
+
+- **별도 브랜치/PR**: `fix/react-hooks-violations` (master 기반).
+- **disable 잠정 유지**: 수정 진행 중 일부 파일 lint 실패 가능 → 모든
+  위반 정리가 끝난 마지막 커밋에서 disable 두 줄을 제거하는 게 깔끔.
+- **WSL ↔ Windows 빌드 분기 준수**: `npm run lint` / `npm test`는 WSL
+  bash, `npm run build:check`는 pwsh로 (§2.1).
+- **lock 변경 금지**: 본 작업은 코드 수정만. `package.json` /
+  `package-lock.json` 건드리지 말 것. 만약 변동되면 WSL↔Windows npm i
+  사고일 가능성 (§1.2 패턴) — `git checkout master -- package*.json`.
+
+### 0.3 위반 14건 상세
+
+신규 룰 두 종류:
+
+| 룰                                | 카운트 | 의미                                                           |
+| --------------------------------- | ------ | -------------------------------------------------------------- |
+| `react-hooks/refs`                | 8건    | 렌더 중 ref 값 읽기/쓰기 금지                                  |
+| `react-hooks/set-state-in-effect` | 6건    | useEffect 본문에서 동기 setState 호출 금지 (cascading renders) |
+
+파일별 위반 위치 (master `ab49cdc` 기준 라인 번호 — 작업 시 drift 가능,
+파일에서 grep으로 위치 재확인할 것):
+
+#### A. `react-hooks/refs` (8건)
+
+1. [src/renderer/components/DebugConsole.tsx:125](../src/renderer/components/DebugConsole.tsx#L125)
+   - `bottomRef: bottomRef as React.RefObject<HTMLDivElement>` — props 객체에
+     ref 담아 함수에 전달.
+2. [src/renderer/components/DebugConsole.tsx:134](../src/renderer/components/DebugConsole.tsx#L134)
+   - `editorRef: editorRef as React.RefObject<HTMLTextAreaElement>` — 동일 패턴.
+3. [src/renderer/components/DebugConsole.tsx:395](../src/renderer/components/DebugConsole.tsx#L395)
+   - `getLogViewerProps(filter)` 호출 시 내부에서 ref 접근 발생.
+4. [src/renderer/components/DebugConsole.tsx:400](../src/renderer/components/DebugConsole.tsx#L400)
+   - `getConfigViewerProps()` 호출 시 동일.
+5. [src/renderer/components/modals/FontCatalogModal.tsx:254](../src/renderer/components/modals/FontCatalogModal.tsx#L254)
+   - `container={modalRef.current}` — 렌더 중 `.current` 직접 접근 (Toast portal target).
+6. [src/renderer/components/modals/FontManagerModal.tsx:306](../src/renderer/components/modals/FontManagerModal.tsx#L306)
+   - 동일 (`container={modalRef.current}`).
+7. [src/renderer/components/settings/SettingsContent.tsx:118](../src/renderer/components/settings/SettingsContent.tsx#L118)
+   - `buttonTextRef.current = buttonText` — 렌더 중 ref 할당.
+8. [src/renderer/components/settings/SettingsContent.tsx:120](../src/renderer/components/settings/SettingsContent.tsx#L120)
+   - `variantRef.current = variant` — 동일 패턴.
+
+#### B. `react-hooks/set-state-in-effect` (6건)
+
+1. [src/renderer/components/modals/FontCatalogModal.tsx:141](../src/renderer/components/modals/FontCatalogModal.tsx#L141)
+   - `useEffect`에서 `loadCatalog()` 호출 → 내부 setState.
+2. [src/renderer/components/modals/FontManagerModal.tsx:156](../src/renderer/components/modals/FontManagerModal.tsx#L156)
+   - `useEffect`에서 `fetchFonts()` 호출 → 내부 setState.
+3. [src/renderer/components/modals/NoticeModal.tsx:68](../src/renderer/components/modals/NoticeModal.tsx#L68)
+   - `useEffect`에서 `loadContent()` 호출 → 내부 setState.
+4. [src/renderer/components/settings/SettingsContent.tsx:92](../src/renderer/components/settings/SettingsContent.tsx#L92)
+   - `setDescriptionBlocks([{ text: item.description, variant: "default" }])`.
+5. [src/renderer/components/settings/SettingsContent.tsx:170](../src/renderer/components/settings/SettingsContent.tsx#L170)
+   - `useEffect`에서 `resetDescription()` 호출 → 내부 setState.
+6. [src/renderer/components/ui/ConfirmModal.tsx:34](../src/renderer/components/ui/ConfirmModal.tsx#L34)
+   - `setTimeLeft(timeoutSeconds)` — effect 진입 시 1회. 룰 의도와는
+     약간 결이 다른 케이스로, **`useState`의 초기값으로 빼면 해소** 가능성.
+
+### 0.4 수정 방향 가이드
+
+룰 문서 참고: https://react.dev/learn/you-might-not-need-an-effect
+
+#### `set-state-in-effect` 패턴 처리
+
+- **모달 진입 시 데이터 로드 (1, 2, 3, 5번)**: 함수 호출 자체가 문제가
+  아니라 effect body에서 동기 setter를 부르는 게 문제. 두 가지 옵션:
+  - (a) 로드 함수를 비동기로 감싸기: `Promise.resolve().then(loadCatalog)`
+    또는 `queueMicrotask(loadCatalog)`. 가장 적은 변경.
+  - (b) 데이터 로드를 비동기 콜백 안에서만 setState 하도록 구조 변경:
+    `useEffect(() => { fetchCatalog().then(setCatalog); }, [...])`.
+    이미 그렇게 되어 있을 가능성 높으니 함수 내부 확인 필요.
+- **`SettingsContent.tsx:92` (`setDescriptionBlocks`)**: useEffect 시작 시
+  description 동기화. → derived state로 만들거나 (`useMemo`), 입력값
+  변화 시점에 set으로 처리.
+- **`ConfirmModal.tsx:34` (`setTimeLeft`)**: effect 진입 시 1회 초기화.
+  → `useState`의 lazy initializer로 옮기거나, `isOpen` 변화시점에 setter
+  를 effect 밖에서 처리하는 패턴 검토.
+
+#### `refs` 패턴 처리
+
+- **`SettingsContent.tsx:118/120` (`ref.current = value` 렌더 중 할당)**:
+  안티패턴. `useLayoutEffect`로 옮기는 게 React 정석 (값 동기화).
+- **`container={modalRef.current}` (5, 6번)**: portal target에 ref
+  직접 전달. callback ref + state로 잡거나 `useLayoutEffect`에서 state
+  로 캐시해서 전달. 또는 ref를 일급으로 받는 portal API 사용.
+- **`DebugConsole.tsx` 1~4번 (props 객체에 ref 담아 함수에 전달)**:
+  함수가 ref를 props로 받는 구조. `React.forwardRef` 패턴이나 ref 자체
+  대신 callback ref(`onMount` 같은 콜백)를 props로 넘기는 방식 검토.
+  네 군데가 같은 구조라 한 군데 패턴 잡으면 나머지 동일하게 적용 가능.
+
+### 0.5 검증
+
+```bash
+# WSL bash
+npm run lint                                  # exit 0 기대
+node node_modules/eslint/bin/eslint.js src    # RTK 우회 직접 확인 (§2.5)
+```
+
+빌드 검증은 §2.1에 따라 pwsh:
+
+```powershell
+cd D:\project_poe2\POE2-unofficial-launcher
+npm run build:check
+```
+
+### 0.6 disable 제거 (마지막 단계)
+
+`eslint.config.mjs` L30~L35의 TODO 주석 4줄 + disable 2줄을 삭제. 직전
+master 시점에 추가된 [eslint.config.mjs#L30-L35](../eslint.config.mjs#L30):
+
+```js
+// TODO(fix/react-hooks-violations): eslint-plugin-react-hooks 7.1에서
+// 새로 추가된 두 룰이 기존 코드의 hook 패턴 14건을 잡아낸다.
+// eslint v10 업그레이드와 코드 수정 PR을 분리하기 위해 임시 off.
+// 별도 PR에서 위반 정리 후 이 두 줄 삭제할 것.
+"react-hooks/set-state-in-effect": "off",
+"react-hooks/refs": "off",
+```
+
+위 블록 통째로 제거 후 lint 한 번 더 돌려 확인.
+
+### 0.7 컨텍스트 (왜 이런 PR 시퀀스가 됐는지)
+
+`master` 로그 기준 작업 흐름 (Renovate가 막혔던 메이저 업그레이드를 풀어낸 시퀀스):
+
+- `cf94708` #120 @vitejs/plugin-react v6 (merge)
+- `7352870` #122 vite v8 (merge)
+- `3bcbd8b` #161 esbuild devDep 추가 (squash) — vite v8가 esbuild를
+  자체 deps에서 빼면서 발생한 빌드 차단 해소.
+- `417deec` #131 typescript v6 (merge) — `tsconfig.json`의 baseUrl
+  deprecation 격상 차단을 #160에서 선제 해결.
+- `65a2568` #160 tsconfig baseUrl/paths 제거 (merge).
+- `14b75b7` #162 eslint-plugin-import → eslint-plugin-import-x 교체
+  (squash) — 본가가 eslint v10 peer 미지원 (`^2 || ... || ^9`)이라
+  fork로 교체. 자세한 유지보수 정체 근거는 본 문서 작성 시점 세션 기록.
+- `5d621de` #163 RTK lint 출력 이슈 메모 (squash) — §2.5.
+- `ab49cdc` #164 eslint v10 + react-hooks 7.1 (squash) — Renovate
+  PR #111이 lock 재생성 실패로 막혀 우리가 직접 진행. lock의 핀
+  (`react-hooks@7.0.1`)이 v10 호환 불가라 명시적으로 `^7.1.1`로
+  올려야 했음. **본 §0이 이 PR의 잔여작업.**
+- Renovate PR #111은 `chore(deps): Update lint & format to v10`이었고,
+  본 PR #164가 동일 목적을 직접 처리했기에 close 처리 (master에 의존성
+  변경 흡수됨).
+
+### 0.8 함정 박제
+
+- **lock에 핀된 버전이 `package.json` range를 깨고 업그레이드를 막을 수
+  있다.** master `^7.0.1`이라도 lock이 `7.0.1`이면 npm은 7.1을 안
+  고른다. ERESOLVE처럼 보이지만 진짜 원인은 *lock에 박힌 transitive*가
+  range 밖의 의존성을 강제하는 것. 같은 함정 만나면 `npm ls <pkg>` +
+  `npm view <pkg>@<locked-version> peerDependencies` 조합으로 판별.
+- **`renovate/artifacts: FAILURE`는 Renovate의 lock 재생성 실패 신호.**
+  CI보다 먼저 보면 시간 절약. 이게 떠 있으면 PR을 그대로 두지 말고
+  근본 원인 파악(보통 peer 충돌).
+
+---
+
 ## 1. 폰트 릴리즈 이후 작업
 
 ### 1.1 config-integrity 테스트 1건 fail


### PR DESCRIPTION
## Summary
- `docs/residual-work.md`에 §0 [최우선] 섹션 추가.
- #164에서 머지한 eslint v10 + react-hooks 7.1 업그레이드의 잔여작업: 임시 off 처리한 두 룰(`set-state-in-effect`, `refs`)이 잡아낸 기존 코드 14건을 정리하기 위한 작업 명세.

## 동기
#164(`ab49cdc`)에서 의존성 업그레이드와 코드 수정을 분리하기로 했고, 분리한 후속 작업은 별도 세션에서 진행한다. 다음 세션 진입 시 컨텍스트 재구성 없이 그대로 작업을 시작할 수 있도록 다음을 §0에 박제했다:

- 작업 목표·진행 방식
- 위반 14건의 룰별/파일별 위치 (master `ab49cdc` 기준 라인 번호 + clickable 링크)
- 룰별 수정 방향 가이드 (refs, set-state-in-effect 각각)
- 검증 절차 (lint·build:check 분기)
- 마지막에 `eslint.config.mjs`의 disable 두 줄을 어디서 어떻게 걷어내는지
- 이번 PR 시퀀스가 왜 이렇게 됐는지 (#120/#122/#161/#131/#160/#162/#163/#164 흐름)
- 함정 박제 (lock 핀이 range 업을 막는 패턴, `renovate/artifacts` 의미)