### PR TITLE
fix(react-hooks): eslint-plugin-react-hooks 7.1 위반 14건 정리

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -29,12 +29,6 @@ export default [
     },
     rules: {
       ...reactHooks.configs.recommended.rules,
-      // TODO(fix/react-hooks-violations): eslint-plugin-react-hooks 7.1에서
-      // 새로 추가된 두 룰이 기존 코드의 hook 패턴 14건을 잡아낸다.
-      // eslint v10 업그레이드와 코드 수정 PR을 분리하기 위해 임시 off.
-      // 별도 PR에서 위반 정리 후 이 두 줄 삭제할 것.
-      "react-hooks/set-state-in-effect": "off",
-      "react-hooks/refs": "off",
       "react-refresh/only-export-components": [
         "warn",
         { allowConstantExport: true },

--- a/src/renderer/components/DebugConsole.tsx
+++ b/src/renderer/components/DebugConsole.tsx
@@ -1,9 +1,9 @@
 import React, { useEffect, useState, useRef } from "react";
 
-import { ConfigViewerProps } from "./debug/ConfigViewer";
+import ConfigViewer, { ConfigViewerProps } from "./debug/ConfigViewer";
 import ExportModal from "./debug/ExportModal";
 import { mergeLog } from "./debug/helpers";
-import { LogViewerProps } from "./debug/LogViewer";
+import LogViewer, { LogViewerProps } from "./debug/LogViewer";
 import { LogModule, ConfigModule } from "./debug/modules";
 import { LogEntry, DebugModule } from "./debug/types";
 import { AppConfig } from "../../shared/types";
@@ -117,28 +117,6 @@ const DebugConsole: React.FC = () => {
       await window.electronAPI.deleteConfig(key);
     }
   };
-
-  // Specific helpers to get typed props
-  const getLogViewerProps = (tabId: string): LogViewerProps => ({
-    logState,
-    filter: tabId,
-    bottomRef: bottomRef as React.RefObject<HTMLDivElement>,
-  });
-
-  const getConfigViewerProps = (/* tabId unused */): ConfigViewerProps => ({
-    currentConfig,
-    editingKey,
-    initialValue,
-    editValue,
-    saveError,
-    editorRef: editorRef as React.RefObject<HTMLTextAreaElement>,
-    startEditing,
-    cancelEditing,
-    saveConfig,
-    deleteConfig,
-    setEditValue,
-    setSaveError,
-  });
 
   const handleExport = async (selectedIds: string[]) => {
     const allSources = modules.flatMap((m) => {
@@ -389,16 +367,25 @@ const DebugConsole: React.FC = () => {
       >
         {activeModule && (
           <>
-            {activeModule.id === "log-module" &&
-              (activeModule as typeof LogModule).renderPanel(
-                filter,
-                getLogViewerProps(filter),
-              )}
-            {activeModule.id === "config-module" &&
-              (activeModule as typeof ConfigModule).renderPanel(
-                filter,
-                getConfigViewerProps(),
-              )}
+            {activeModule.id === "log-module" && (
+              <LogViewer logState={logState} filter={filter} ref={bottomRef} />
+            )}
+            {activeModule.id === "config-module" && (
+              <ConfigViewer
+                currentConfig={currentConfig}
+                editingKey={editingKey}
+                initialValue={initialValue}
+                editValue={editValue}
+                saveError={saveError}
+                ref={editorRef}
+                startEditing={startEditing}
+                cancelEditing={cancelEditing}
+                saveConfig={saveConfig}
+                deleteConfig={deleteConfig}
+                setEditValue={setEditValue}
+                setSaveError={setSaveError}
+              />
+            )}
           </>
         )}
 

--- a/src/renderer/components/debug/ConfigViewer.tsx
+++ b/src/renderer/components/debug/ConfigViewer.tsx
@@ -14,7 +14,7 @@ export interface ConfigViewerProps {
   initialValue: unknown;
   editValue: string;
   saveError: string | null;
-  editorRef: React.RefObject<HTMLTextAreaElement>;
+  ref?: React.Ref<HTMLTextAreaElement>;
   startEditing: (key: string, value: unknown) => void;
   cancelEditing: () => void;
   saveConfig: (key: string) => Promise<void>;
@@ -29,7 +29,7 @@ const ConfigViewer: React.FC<ConfigViewerProps> = ({
   initialValue,
   editValue,
   saveError,
-  editorRef,
+  ref,
   startEditing,
   cancelEditing,
   saveConfig,
@@ -188,7 +188,7 @@ const ConfigViewer: React.FC<ConfigViewerProps> = ({
         {isEditing ? (
           <div>
             <textarea
-              ref={editorRef}
+              ref={ref}
               value={editValue}
               onChange={(e) => {
                 setEditValue(e.target.value);

--- a/src/renderer/components/debug/LogViewer.tsx
+++ b/src/renderer/components/debug/LogViewer.tsx
@@ -8,14 +8,10 @@ export interface LogViewerProps {
     byType: { [key: string]: LogEntry[] };
   };
   filter: string;
-  bottomRef: React.RefObject<HTMLDivElement>;
+  ref?: React.Ref<HTMLDivElement>;
 }
 
-const LogViewer: React.FC<LogViewerProps> = ({
-  logState,
-  filter,
-  bottomRef,
-}) => {
+const LogViewer: React.FC<LogViewerProps> = ({ logState, filter, ref }) => {
   const groupedLogs = useMemo(() => {
     const logs =
       filter === "ALL" ? logState.all : logState.byType[filter] || [];
@@ -143,7 +139,7 @@ const LogViewer: React.FC<LogViewerProps> = ({
           </React.Fragment>
         );
       })}
-      <div ref={bottomRef} />
+      <div ref={ref} />
     </div>
   );
 };

--- a/src/renderer/components/modals/FontCatalogModal.tsx
+++ b/src/renderer/components/modals/FontCatalogModal.tsx
@@ -45,7 +45,7 @@ const FontCatalogModal: React.FC<FontCatalogModalProps> = ({
   const [toastVisible, setToastVisible] = useState(false);
   const toastTimerRef = React.useRef<NodeJS.Timeout | null>(null);
 
-  const modalRef = useRef<HTMLDivElement>(null);
+  const [modalEl, setModalEl] = useState<HTMLDivElement | null>(null);
 
   const [pendingLocalPath, setPendingLocalPath] = useState<string | null>(null);
   const [analyzedLocalName, setAnalyzedLocalName] = useState("");
@@ -138,7 +138,9 @@ const FontCatalogModal: React.FC<FontCatalogModalProps> = ({
 
   useEffect(() => {
     if (isVisible) {
-      loadCatalog();
+      // Deferred via microtask so the synchronous setIsLoading inside loadCatalog
+      // doesn't trigger a cascading render from this effect.
+      void Promise.resolve().then(() => loadCatalog());
     }
   }, [isVisible, loadCatalog]);
 
@@ -246,12 +248,12 @@ const FontCatalogModal: React.FC<FontCatalogModalProps> = ({
       <div
         className="font-catalog-modal"
         onClick={(e) => e.stopPropagation()}
-        ref={modalRef}
+        ref={setModalEl}
       >
         <Toast
           message={toastMsg}
           visible={toastVisible}
-          container={modalRef.current}
+          container={modalEl}
           variant={toastVariant}
         />
         <header className="catalog-header">

--- a/src/renderer/components/modals/FontManagerModal.tsx
+++ b/src/renderer/components/modals/FontManagerModal.tsx
@@ -54,7 +54,7 @@ const FontManagerModal: React.FC<FontManagerModalProps> = ({
   const [showDetailSettings, setShowDetailSettings] = useState(false);
   const flashTimerRef = React.useRef<NodeJS.Timeout | null>(null);
 
-  const modalRef = React.useRef<HTMLDivElement>(null);
+  const [modalEl, setModalEl] = useState<HTMLDivElement | null>(null);
   const { getActiveGameState, syncGameState } = useGameState();
 
   const isKakaoRunning =
@@ -153,7 +153,9 @@ const FontManagerModal: React.FC<FontManagerModalProps> = ({
 
   useEffect(() => {
     if (isVisible) {
-      fetchFonts();
+      // Deferred via microtask so the synchronous setFonts/setAssignments inside
+      // fetchFonts doesn't trigger a cascading render from this effect.
+      void Promise.resolve().then(() => fetchFonts());
       syncGameState(gameId, "Kakao Games");
       syncGameState(gameId, "GGG");
     }
@@ -297,13 +299,13 @@ const FontManagerModal: React.FC<FontManagerModalProps> = ({
     >
       <div
         className={`font-modal ${isVisible ? "visible" : ""}`}
-        ref={modalRef}
+        ref={setModalEl}
         onClick={(e) => e.stopPropagation()}
       >
         <Toast
           message={toastMsg}
           visible={toastVisible}
-          container={modalRef.current}
+          container={modalEl}
           variant={toastVariant}
         />
 

--- a/src/renderer/components/modals/NoticeModal.tsx
+++ b/src/renderer/components/modals/NoticeModal.tsx
@@ -16,6 +16,17 @@ const NoticeModal: React.FC<NoticeModalProps> = ({ item, onClose }) => {
   const [content, setContent] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
 
+  // Reset visibility/content when the item prop disappears.
+  // Done in render phase so the effect body avoids a cascading setState.
+  const [prevItemId, setPrevItemId] = useState<string | null>(item?.id ?? null);
+  if (!item && prevItemId !== null) {
+    setPrevItemId(null);
+    setIsVisible(false);
+    setContent(null);
+  } else if (item && item.id !== prevItemId) {
+    setPrevItemId(item.id);
+  }
+
   const loadContent = useCallback(async () => {
     if (!item) return;
     setIsLoading(true);
@@ -64,13 +75,11 @@ const NoticeModal: React.FC<NoticeModalProps> = ({ item, onClose }) => {
       // Fade-in animation
       const timer = setTimeout(() => setIsVisible(true), 10);
 
-      // Load content
-      loadContent();
+      // Load content (deferred via microtask so the synchronous setIsLoading inside
+      // loadContent doesn't trigger a cascading render from this effect).
+      void Promise.resolve().then(loadContent);
 
       return () => clearTimeout(timer);
-    } else {
-      setIsVisible(false);
-      setContent(null);
     }
   }, [item, loadContent]);
 

--- a/src/renderer/components/settings/SettingsContent.tsx
+++ b/src/renderer/components/settings/SettingsContent.tsx
@@ -1,4 +1,10 @@
-import React, { useState, useEffect, useCallback, useRef } from "react";
+import React, {
+  useState,
+  useEffect,
+  useLayoutEffect,
+  useCallback,
+  useRef,
+} from "react";
 
 import ConfirmModal, { ConfirmModalProps } from "../ui/ConfirmModal";
 import { ButtonItem } from "./items/SettingButton";
@@ -78,22 +84,18 @@ const SettingItemRenderer: React.FC<{
   });
 
   const itemRef = useRef<HTMLDivElement>(null);
-  const isFirstRender = useRef(true);
 
-  // Initialize description blocks from item.description (string)
-  useEffect(() => {
-    // Skip the first run as lazy init handled it
-    if (isFirstRender.current) {
-      isFirstRender.current = false;
-      return;
-    }
-
-    if (item.description) {
-      setDescriptionBlocks([{ text: item.description, variant: "default" }]);
-    } else {
-      setDescriptionBlocks([]);
-    }
-  }, [item.description]); // Reset when prop changes
+  // Reset description blocks when item.description prop changes.
+  // Inline render-phase update avoids an effect that would trigger a cascading render.
+  const [prevDescription, setPrevDescription] = useState<string | undefined>(
+    item.description,
+  );
+  if (item.description !== prevDescription) {
+    setPrevDescription(item.description);
+    setDescriptionBlocks(
+      item.description ? [{ text: item.description, variant: "default" }] : [],
+    );
+  }
 
   const [disabled, setDisabled] = useState<boolean>(!!item.disabled);
   const [isVisible, setIsVisible] = useState<boolean>(true);
@@ -115,9 +117,11 @@ const SettingItemRenderer: React.FC<{
   );
 
   const buttonTextRef = useRef(buttonText);
-  buttonTextRef.current = buttonText;
   const variantRef = useRef(variant);
-  variantRef.current = variant;
+  useLayoutEffect(() => {
+    buttonTextRef.current = buttonText;
+    variantRef.current = variant;
+  });
 
   // Track if onInit has taken control to avoid store-override race conditions
   const [authorityClaimed, setAuthorityClaimed] = useState(false);
@@ -140,6 +144,18 @@ const SettingItemRenderer: React.FC<{
   const refreshOnValues = JSON.stringify(
     item.refreshOn?.map((id) => config[id]) || [],
   );
+
+  // Reset dynamic description blocks before onInit re-runs, so addDescription calls
+  // start from the static baseline rather than accumulating across re-inits.
+  // Done in render phase (not in effect) to avoid cascading renders.
+  const [prevOnInitKey, setPrevOnInitKey] = useState<string | null>(null);
+  const onInitKey = item.onInit ? refreshOnValues : null;
+  if (item.onInit && onInitKey !== prevOnInitKey) {
+    setPrevOnInitKey(onInitKey);
+    setDescriptionBlocks(
+      item.description ? [{ text: item.description, variant: "default" }] : [],
+    );
+  }
 
   // Helper to add description
   const addDescription = useCallback(
@@ -165,9 +181,9 @@ const SettingItemRenderer: React.FC<{
     if (item.onInit) {
       logger.log(`[Settings] Running onInit for ${item.id}`);
 
-      // Auto-clear dynamic descriptions before re-running onInit
-      // This ensures we start with the base static description
-      resetDescription();
+      // NOTE: description blocks are pre-reset in render phase via prevOnInitKey
+      // comparison above. Calling resetDescription() here would trigger a cascading
+      // render (react-hooks/set-state-in-effect).
 
       const initResult = item.onInit({
         setValue: (newValue) => {

--- a/src/renderer/components/ui/ConfirmModal.tsx
+++ b/src/renderer/components/ui/ConfirmModal.tsx
@@ -28,10 +28,20 @@ const ConfirmModal: React.FC<ConfirmModalProps> = ({
     timeoutSeconds,
   );
 
+  // Reset countdown when the modal (re)opens or the timeout prop changes.
+  // Render-phase comparison avoids a cascading render from inside an effect.
+  const [prevSessionKey, setPrevSessionKey] = React.useState<string>(
+    `${isOpen}|${timeoutSeconds ?? ""}`,
+  );
+  const sessionKey = `${isOpen}|${timeoutSeconds ?? ""}`;
+  if (sessionKey !== prevSessionKey) {
+    setPrevSessionKey(sessionKey);
+    setTimeLeft(timeoutSeconds);
+  }
+
   React.useEffect(() => {
     if (!isOpen || timeoutSeconds === undefined) return;
 
-    setTimeLeft(timeoutSeconds);
     const timer = setInterval(() => {
       setTimeLeft((prev) => {
         if (prev !== undefined && prev <= 1) {


### PR DESCRIPTION
## Summary

#164에서 임시 off 했던 두 룰 (`react-hooks/set-state-in-effect`, `react-hooks/refs`)을 코드 수정으로 해소하고 disable을 제거합니다. [docs/residual-work.md §0](https://github.com/NERDHEAD-lab/POE2-unofficial-launcher/blob/master/docs/residual-work.md) 잔여 작업 명세에 따른 후속 PR.

## 변경 내역

### `react-hooks/refs` 8건

- **LogViewer / ConfigViewer**: `bottomRef` / `editorRef`를 React 19 ref prop으로 받도록 시그니처 변경. DebugConsole에서 `getLogViewerProps` / `getConfigViewerProps` 헬퍼(props 객체에 ref를 담아 함수 인자로 넘기던 패턴)를 제거하고, JSX에서 viewer를 직접 렌더하면서 `ref={...}`를 별도 prop으로 attach.
- **SettingsContent**: 렌더 중 `buttonTextRef.current = buttonText` / `variantRef.current = variant` 직접 할당을 `useLayoutEffect`로 이동.
- **FontCatalogModal / FontManagerModal**: Toast portal target을 callback ref + state 패턴으로 변경 (`modalRef.current` → `modalEl`). 렌더 중 `.current` 직접 접근을 제거.

### `react-hooks/set-state-in-effect` 6건

- **SettingsContent**: `item.description` 변화에 따른 description 동기화 및 onInit 직전 리셋을 render-phase prev 비교(`setPrevDescription`, `setPrevOnInitKey`) 패턴으로 이동 — [React 가이드의 "use during rendering"](https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes).
- **FontCatalogModal / FontManagerModal**: `useEffect` 진입 시 `loadCatalog()` / `fetchFonts()` 직접 호출을 `Promise.resolve().then(...)`로 한 단계 마이크로태스크 지연 (loader 내부 동기 `setIsLoading(true)` 등이 cascade를 일으키지 않도록).
- **NoticeModal**: loader 호출에 동일 패턴 + `item` prop이 null로 바뀌는 분기의 `setIsVisible(false); setContent(null);`을 render-phase prev 비교로 이동.
- **ConfirmModal**: effect 진입 시 `setTimeLeft(timeoutSeconds)` 초기화를 render-phase prev 비교(`prevSessionKey`)로 이동.

### `eslint.config.mjs`

`react-hooks/set-state-in-effect: "off"` / `react-hooks/refs: "off"` 두 줄 + 동반 TODO 주석 4줄 제거.

## 검증

- `node node_modules/eslint/bin/eslint.js src` → **exit 0** (RTK 우회 직접 실행, `src/`만 검사).
- `tsc` (build:check 첫 단계) **통과** — vite 단계는 WSL 환경의 native binding 부재(`@rolldown/binding-win32-x64-msvc`)로 미실행. [docs/residual-work.md §2.2](https://github.com/NERDHEAD-lab/POE2-unofficial-launcher/blob/master/docs/residual-work.md) 박제 함정에 해당하며 코드 변경과 무관. CI 빌드에서 최종 검증 예정.
- `package.json` / `package-lock.json` 무변경 (코드 수정만).

## Motivation

eslint v10 + react-hooks 7.1 메이저 업그레이드(#164)에서 신규 룰 두 종이 기존 코드의 hook 패턴 14건을 잡았고, 의존성 업그레이드 PR을 머지 가능한 단위로 유지하기 위해 룰을 임시 disable하고 별도 PR로 코드 수정을 분리하기로 결정. 본 PR이 그 후속.