### PR TITLE
feat: fix custom font applications and refine WSL developer setup

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,25 @@
+# 모든 텍스트 파일은 저장소/체크아웃 모두 LF 고정.
+# WSL/Windows 혼용 환경에서 IDE/에디터가 임의로 CRLF 로 바꾸는 회귀 방지.
+* text=auto eol=lf
+
+# 명시적으로 LF 강제 — 빌드/실행에 직접 영향이 큰 스크립트류
+*.sh        text eol=lf
+*.bash      text eol=lf
+.husky/*    text eol=lf
+
+# Windows 전용 스크립트는 CRLF 유지
+*.bat       text eol=crlf
+*.cmd       text eol=crlf
+*.ps1       text eol=crlf
+
+# 바이너리 (Git 자동 감지 보조)
+*.png       binary
+*.jpg       binary
+*.gif       binary
+*.ico       binary
+*.icns      binary
+*.ttf       binary
+*.otf       binary
+*.woff      binary
+*.woff2     binary
+*.pdf       binary

--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ Thumbs.db
 # Claude Code per-user (absolute paths, machine-specific)
 .claude/settings.json
 .claude/settings.local.json
+
+# Antigravity (Gemini) per-user config — symlinks to ~/.gemini
+.antigravitycli/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,9 @@
 # CLAUDE.md — POE2 Unofficial Launcher
 
-Electron + React 19 + Vite 7 + TypeScript launcher for Path of Exile / PoE 2.
+Electron + React 19 + Vite 8 + TypeScript launcher for Path of Exile / PoE 2.
 Layout: `src/main/` (Electron main), `src/renderer/` (React UI), `src/shared/` (shared types).
+
+This file is the single source of project rules for **all coding agents** (Claude, Gemini, etc.). Other agent entry points (`GEMINI.md`, `.cursorrules`, …) should just point here, not fork the rules.
 
 ## ⚠️ Documentation status
 
@@ -26,27 +28,22 @@ To work with the wiki visible as read context: `claude --add-dir ~/project_llm_w
 
 ### WSL execution rules (detect at session start)
 
-If `uname -r` contains `microsoft`/`WSL`, this is WSL — apply the following split:
+If `uname -r` contains `microsoft`/`WSL`, this is WSL — WSL is the development primary (edit/git/lint/rtk) and Windows is the build/run primary (Electron + actual POE / POE2 game test, which Linux cannot run). Both OSes share the same `node_modules` under `D:\project_poe2\POE2-unofficial-launcher\`.
 
-- `npm run lint` / `npm test`: run directly in WSL bash (pure Node, same result).
-- `npm run build:check`: invoke via Windows PowerShell, not WSL bash.
+Split commands by where they belong:
+
+- WSL bash, direct: `npm run lint`, `npm test` (pure Node, same result).
+- Windows PowerShell, never WSL: `npm install`, `npm ci`, `npm run build`, `npm run build:check`, `npm run dev`.
   - Prefer `pwsh.exe` (PowerShell 7); fall back to `powershell.exe` (5.1) if absent.
   - Detect: `command -v pwsh.exe >/dev/null && PS=pwsh.exe || PS=powershell.exe`
-  - Invoke: `"$PS" -NoProfile -Command "cd 'D:\project_poe2\POE2-unofficial-launcher'; npm run build:check"`
+  - Invoke: `"$PS" -NoProfile -Command "cd 'D:\project_poe2\POE2-unofficial-launcher'; npm run <script>"`
   - On failure (e.g. native module mismatch), fall back to asking the user to run it on Windows.
-- Tasks requiring in-game verification (e.g. font work): a passing build is not sufficient — always request the user's live check.
 
-### WSL execution rules (detect at session start)
+Why `npm install`/`npm ci` must not run in WSL: WSL's npm writes only POSIX symlinks under `node_modules/.bin/` and does not create the Windows wrappers (`.cmd`, `.ps1`). The next `npm run build` / `npm run dev` from Windows then fails with `'tsc' is not recognized` / `'vite' is not recognized`. If dependencies need reinstalling (lock conflict, native binding error, pre-commit hook failing on unrs-resolver, etc.), ask the user to run `npm ci` from Windows pwsh — do not auto-repair from WSL.
 
-If `uname -r` contains `microsoft`/`WSL`, this is WSL — apply the following split:
+If a pre-commit hook fails in WSL due to native-binding mismatch, do not try to fix the environment. Either ask the user to commit from Windows, or get explicit approval for `--no-verify` for that single commit.
 
-- `npm run lint` / `npm test`: run directly in WSL bash (pure Node, same result).
-- `npm run build:check`: invoke via Windows PowerShell, not WSL bash.
-  - Prefer `pwsh.exe` (PowerShell 7); fall back to `powershell.exe` (5.1) if absent.
-  - Detect: `command -v pwsh.exe >/dev/null && PS=pwsh.exe || PS=powershell.exe`
-  - Invoke: `"$PS" -NoProfile -Command "cd 'D:\project_poe2\POE2-unofficial-launcher'; npm run build:check"`
-  - On failure (e.g. native module mismatch), fall back to asking the user to run it on Windows.
-- Tasks requiring in-game verification (e.g. font work): a passing build is not sufficient — always request the user's live check.
+Tasks requiring in-game verification (e.g. font work, launcher boot): a passing build is not sufficient — always request the user's live check on Windows.
 
 ## Code style
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,8 +32,8 @@ If `uname -r` contains `microsoft`/`WSL`, this is WSL — WSL is the development
 
 Split commands by where they belong:
 
-- WSL bash, direct: `npm run lint`, `npm test` (pure Node, same result).
-- Windows PowerShell, never WSL: `npm install`, `npm ci`, `npm run build`, `npm run build:check`, `npm run dev`.
+- WSL bash, direct: 순수 Node 스크립트만 (예: `node -e ...`로 가설 검증). 같은 `node_modules`를 공유하지만 **eslint/vitest 모두 Linux 네이티브 바이너리(`unrs-resolver`, `@rolldown/binding-linux-x64-gnu`)를 요구해서 WSL에선 실패**한다 — 시도하지 말 것.
+- Windows PowerShell, never WSL: `npm install`, `npm ci`, `npm run build`, `npm run build:check`, `npm run dev`, `npm run lint`, `npm run lint:fix`, `npm test`.
   - Prefer `pwsh.exe` (PowerShell 7); fall back to `powershell.exe` (5.1) if absent.
   - Detect: `command -v pwsh.exe >/dev/null && PS=pwsh.exe || PS=powershell.exe`
   - Invoke: `"$PS" -NoProfile -Command "cd 'D:\project_poe2\POE2-unofficial-launcher'; npm run <script>"`

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,1 @@
+See [CLAUDE.md](./CLAUDE.md) — the same project rules apply to any coding agent (Gemini included).

--- a/docs/residual-work.md
+++ b/docs/residual-work.md
@@ -88,7 +88,35 @@
 - UI 노출 시 추가로 `settings-management` 스킬.
 - 누락 시 ORPHANED config 발생.
 
-### 2.5 RTK가 `npm run lint` 출력에 lint 대상 외 파일을 섞어 보여줌
+### 2.5 husky pre-commit이 WSL에서 native binding으로 실패 — pwsh 위임 필요
+
+- **현상**: WSL에서 `git commit` 하면 lint-staged → eslint 단계에서
+  `unrs-resolver` "Cannot find native binding" 으로 hook 실패. ESLint 10 +
+  `eslint-plugin-import-x`가 끌고 들어온 `unrs-resolver`는 Linux 네이티브
+  바이너리(`@unrs/resolver-binding-linux-x64-gnu`)를 요구하는데, 같은
+  `node_modules`를 Windows pwsh에서 `npm ci`로 채워 둔 상태라 Linux용
+  바인딩이 없음.
+- **현재 회피**: 커밋만 Windows pwsh에서 수행. WSL에서는 작성/스테이지
+  까지만 하고 `pwsh.exe -NoProfile -Command "cd 'D:\\project_poe2\\POE2-unofficial-launcher'; git commit -m '...'"`.
+- **근본 해결안 (제안)**: `.husky/pre-commit` 가 WSL을 감지하면
+  (`grep -qi 'microsoft\\|WSL' /proc/version`) lint-staged 실행을
+  Windows pwsh에 위임. 의사코드:
+  ```sh
+  if grep -qi 'microsoft\|WSL' /proc/version 2>/dev/null; then
+    PS=$(command -v pwsh.exe || command -v powershell.exe)
+    "$PS" -NoProfile -Command "cd 'D:\\project_poe2\\POE2-unofficial-launcher'; npx lint-staged"
+  else
+    npx lint-staged
+  fi
+  ```
+- **선결 검증**: pwsh가 WSL 인터랙티브 stdin을 가로채는 husky 케이스에서
+  prettier/eslint의 in-place 수정이 WSL git index에 정상 반영되는지
+  (CRLF/LF 문제 포함 — `.gitattributes`는 이미 LF 강제). 안 되면 `git add`
+  재호출이 hook 안에서 한 번 더 필요할 수 있음.
+- **WSL 전용 Linux 바인딩 분리 설치 우회(§2.2 패턴)**: `npm install --no-save @unrs/resolver-binding-linux-x64-gnu` 추가도 후보. 단 lint-staged가
+  eslint를 spawn할 때 같은 node_modules tree를 보므로 효과 확인 필요.
+
+### 2.6 RTK가 `npm run lint` 출력에 lint 대상 외 파일을 섞어 보여줌
 
 - `package.json`의 lint 스크립트는 `eslint src`라 **`src/` 만 검사 대상**.
 - 그러나 `npm run lint`(RTK 후킹 경유)의 요약 출력에는 `scripts/` 등

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "scripts": {
     "setup": "node -e \"if(!require('fs').existsSync('node_modules')) { require('child_process').execSync('npm install', {stdio: 'inherit'}) }\"",
     "dev": "chcp 65001 && vite",
+    "dev:wsl": "command -v pwsh.exe >/dev/null && PS=pwsh.exe || PS=powershell.exe; \"$PS\" -NoProfile -Command \"chcp 65001; npm run dev\"",
     "dev:crash:immediate": "chcp 65001 && cross-env VITE_TEST_CRASH_MODE=IMMEDIATE vite",
     "dev:crash:delayed": "chcp 65001 && cross-env VITE_TEST_CRASH_MODE=DELAYED vite",
     "dev:crash:null": "chcp 65001 && cross-env VITE_TEST_CRASH_MODE=NULL_REF vite",

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -526,9 +526,12 @@ ipcMain.handle("debug:get-history", () => {
   return getLogHistory();
 });
 
-ipcMain.handle("game:get-status", (_event, gameId: string, serviceId: string) => {
-  return getGlobalGameStatus(gameId, serviceId);
-});
+ipcMain.handle(
+  "game:get-status",
+  (_event, gameId: string, serviceId: string) => {
+    return getGlobalGameStatus(gameId, serviceId);
+  },
+);
 
 // [Removed] Old session:logout handler (duplicates new partitioned one)
 

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -206,8 +206,6 @@ process.on("unhandledRejection", (reason) => {
 
 process.env["ELECTRON_DISABLE_SECURITY_WARNINGS"] = "true";
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-
 process.env.DIST = path.join(__dirname, "../dist");
 process.env.VITE_PUBLIC = app.isPackaged
   ? process.env.DIST

--- a/src/main/services/FontManager.ts
+++ b/src/main/services/FontManager.ts
@@ -628,6 +628,7 @@ if (Get-ItemProperty -Path $p1 -Name "${name}" -ErrorAction SilentlyContinue) {
       if (!fontData) continue;
 
       const sourcePath = path.join(this.customFontsDir, fontData.fileName);
+
       for (const targetName of targetNames) {
         const rule = FONT_MUTATION_DEFINITIONS[targetName];
         if (!rule) {
@@ -635,15 +636,16 @@ if (Get-ItemProperty -Path $p1 -Name "${name}" -ErrorAction SilentlyContinue) {
           continue;
         }
 
+        const tempPath = path.join(
+          app.getPath("temp"),
+          `poe2_${targetName.replace(/\s+/g, "_")}_${randomUUID().slice(0, 8)}.ttf`,
+        );
+
         const scale = this.resolveFontScale(targetName);
         const mutatedBuffer = await this.mutateFontName(
           sourcePath,
           rule,
           scale,
-        );
-        const tempPath = path.join(
-          app.getPath("temp"),
-          `poe2_${targetName.replace(/\s+/g, "_")}_${randomUUID().slice(0, 8)}.ttf`,
         );
         await fs.writeFile(tempPath, Buffer.from(mutatedBuffer));
 
@@ -1036,11 +1038,25 @@ if (Get-ItemProperty -Path $p1 -Name "${name}" -ErrorAction SilentlyContinue) {
     return Math.min(FONT_SCALE_MAX, Math.max(FONT_SCALE_MIN, Math.round(raw)));
   }
 
-  private mutateFontName(
+  private async mutateFontName(
     filePath: string,
     rule: FontMutationRule,
     scale: number,
   ): Promise<ArrayBuffer> {
+    // sfnt scaler가 OTTO이면 CFF 컨테이너 → OtfMutatorWorker(SFNT 바이트 패치).
+    // 그 외(0x00010000 등)는 TrueType → FontMutatorWorker(fonteditor-core).
+    // fonteditor-core는 CFF→glyf 변환에서 한글 글리프를 손실시키므로 OTF는 따로 다룬다.
+    const headHandle = await fs.open(filePath, "r");
+    let isOTF: boolean;
+    try {
+      const head = Buffer.alloc(4);
+      await headHandle.read(head, 0, 4, 0);
+      isOTF = head.toString("ascii") === "OTTO";
+    } finally {
+      await headHandle.close();
+    }
+    const workerName = isOTF ? "OtfMutatorWorker.js" : "FontMutatorWorker.js";
+
     return new Promise((resolve, reject) => {
       // [Production] Base path for unpacked workers (Standard Case)
       let workerPath = path.join(
@@ -1049,12 +1065,12 @@ if (Get-ItemProperty -Path $p1 -Name "${name}" -ErrorAction SilentlyContinue) {
         "app.asar.unpacked",
         "dist-electron",
         "workers",
-        "FontMutatorWorker.js",
+        workerName,
       );
 
       if (!app.isPackaged) {
         // [Development] Adjacent to main bundle in dist-electron
-        workerPath = path.join(__dirname, "workers", "FontMutatorWorker.js");
+        workerPath = path.join(__dirname, "workers", workerName);
       }
 
       const worker = new Worker(workerPath);

--- a/src/main/tests/FontMutatorWorker.integration.test.ts
+++ b/src/main/tests/FontMutatorWorker.integration.test.ts
@@ -1,0 +1,138 @@
+// src/main/tests/FontMutatorWorker.integration.test.ts
+import fs from "node:fs";
+import path from "node:path";
+
+import { Font } from "fonteditor-core";
+import { describe, it, expect } from "vitest";
+
+/**
+ * 회귀 가설: FontMutatorWorker는 Font.create(buf, { type: "ttf" })로 고정 파싱한다.
+ * 사용자가 IPC pick-file 다이얼로그에서 .otf를 골랐을 경우(현재 허용됨),
+ * 이 경로에서 "ttf file damaged" 또는 유사 에러가 발생해야 한다 (=현재 버그 재현).
+ *
+ * 샘플 폰트 경로: D:\project_poe2\POE2-unofficial-launcher-gh-pages\fonts
+ * (gh-pages 리포 체크아웃 필요. 없으면 테스트는 skip 처리.)
+ */
+
+const SAMPLE_DIR = path.resolve(
+  __dirname,
+  "../../../../POE2-unofficial-launcher-gh-pages/fonts",
+);
+
+const hasSamples = fs.existsSync(SAMPLE_DIR);
+
+function readFontType(filePath: string): "ttf" | "otf" {
+  // sfnt scaler type:
+  //   0x00010000 → TrueType outlines (ttf)
+  //   'OTTO'     → CFF outlines (otf)
+  //   'true'/'typ1' → 구형 Mac TrueType
+  const fd = fs.openSync(filePath, "r");
+  const head = Buffer.alloc(4);
+  fs.readSync(fd, head, 0, 4, 0);
+  fs.closeSync(fd);
+  if (head.toString("ascii") === "OTTO") return "otf";
+  return "ttf";
+}
+
+describe.skipIf(!hasSamples)(
+  "FontMutatorWorker — fonteditor-core 파싱 가설",
+  () => {
+    const sampleFiles = hasSamples
+      ? fs
+          .readdirSync(SAMPLE_DIR)
+          .filter((f) => /\.(ttf|otf)$/i.test(f))
+          .map((f) => path.join(SAMPLE_DIR, f))
+      : [];
+
+    it(".otf 파일을 type:'ttf'로 파싱하면 실패한다 (현재 워커 동작)", () => {
+      const otfFile = sampleFiles.find((p) => p.toLowerCase().endsWith(".otf"));
+      expect(otfFile, "otf 샘플 폰트가 폴더에 있어야 함").toBeTruthy();
+      if (!otfFile) return;
+
+      const buf = fs.readFileSync(otfFile);
+      expect(readFontType(otfFile)).toBe("otf");
+
+      // 현재 FontMutatorWorker.ts:52 와 동일한 호출
+      expect(() => Font.create(buf, { type: "ttf" })).toThrow();
+    });
+
+    it(".otf 파일을 type:'otf'로 파싱하면 성공한다", () => {
+      const otfFile = sampleFiles.find((p) => p.toLowerCase().endsWith(".otf"));
+      if (!otfFile) return;
+
+      const buf = fs.readFileSync(otfFile);
+      const font = Font.create(buf, { type: "otf" });
+      const data = font.get();
+      expect(data.name).toBeTruthy();
+      expect(typeof data.name.fontFamily).toBe("string");
+    });
+
+    it(
+      "모든 .ttf 샘플은 type:'ttf'로 파싱 가능해야 한다 (변조 파이프라인 입력 적합성)",
+      { timeout: 30000 },
+      () => {
+        const ttfFiles = sampleFiles.filter((p) =>
+          p.toLowerCase().endsWith(".ttf"),
+        );
+        expect(ttfFiles.length).toBeGreaterThan(0);
+
+        const failures: { file: string; error: string }[] = [];
+        for (const file of ttfFiles) {
+          try {
+            const buf = fs.readFileSync(file);
+            Font.create(buf, { type: "ttf" });
+          } catch (e) {
+            failures.push({
+              file: path.basename(file),
+              error: (e as Error).message,
+            });
+          }
+        }
+
+        expect(
+          failures,
+          `다음 .ttf 파일이 fonteditor-core ttf 파서를 통과하지 못함:\n${failures
+            .map((f) => `  - ${f.file}: ${f.error}`)
+            .join("\n")}`,
+        ).toEqual([]);
+      },
+    );
+
+    it("fonteditor-core write({type:'ttf'})는 OTF→TTF 글리프 변환을 깨뜨린다 (회귀 가드)", () => {
+      // 배경: in-game 검증에서 Pretendard 한글이 거의 모두 빈 글리프로 표시됨.
+      // 원인: fonteditor-core가 OTF 입력의 cmap/name은 보존하지만,
+      //       write({type:'ttf'})의 CFF→glyf 변환이 한글 음절 대부분의 outline을 잃는다.
+      // 이 테스트가 통과하는 한 OTF 입력은 OtfMutatorWorker(SFNT 바이트 패치) 경로를 써야 한다.
+      // 미래에 fonteditor-core 업그레이드로 글리프가 보존되면 이 테스트가 실패하며,
+      // 그 시점에 OTF/TTF 경로를 하나로 통합할지 재검토할 신호가 된다.
+      const otfFile = sampleFiles.find((p) =>
+        p.toLowerCase().endsWith("Pretendard-Regular.otf".toLowerCase()),
+      );
+      if (!otfFile) return;
+
+      const buf = fs.readFileSync(otfFile);
+      const font = Font.create(buf, { type: "otf" });
+
+      // write({type:'ttf'}) 결과를 다시 파싱
+      const ttfOut = font.write({ type: "ttf" });
+      const reparsed = Font.create(Buffer.from(ttfOut as Uint8Array), {
+        type: "ttf",
+      }).get();
+
+      // U+AC00(가): cmap에는 남아있지만 outline이 비어있는 케이스가 핵심 증거.
+      type GlyfEntry = { contours?: { length: number }[] };
+      const cmap = (reparsed.cmap || {}) as Record<string, number>;
+      const glyf = (reparsed.glyf || []) as GlyfEntry[];
+      const gidGa = cmap[0xac00];
+      expect(gidGa, "U+AC00(가)가 cmap에서 사라지면 안 됨").toBeTypeOf(
+        "number",
+      );
+
+      const gaContours = glyf[gidGa]?.contours?.length ?? 0;
+      expect(
+        gaContours,
+        "회귀 가드: 만약 0보다 크게 나오면 fonteditor-core가 OTF→TTF 변환을 제대로 지원하기 시작한 것 — OTF 우회 경로 재검토 필요",
+      ).toBe(0);
+    });
+  },
+);

--- a/src/main/tests/OtfMutator.integration.test.ts
+++ b/src/main/tests/OtfMutator.integration.test.ts
@@ -1,0 +1,120 @@
+// src/main/tests/OtfMutator.integration.test.ts
+import fs from "node:fs";
+import path from "node:path";
+
+import { Font } from "fonteditor-core";
+import { describe, it, expect } from "vitest";
+
+import { FONT_MUTATION_DEFINITIONS } from "../../shared/font-targets";
+import { mutateOtfSfnt } from "../workers/otfMutator";
+
+/**
+ * OtfMutator: SFNT 레벨 변조기.
+ * 검증 포인트:
+ *  - CFF 컨테이너(OTTO scaler) 유지 → 한글 글리프 보존
+ *  - name table 6필드가 본체 정답 이름으로 교체
+ *  - OS/2/hhea/head 메트릭이 unitsPerEm 비율로 정확히 스케일
+ *
+ * 샘플 폰트 경로 없으면 skip (CI는 launcher 리포만 체크아웃하므로).
+ */
+
+const SAMPLE_DIR = path.resolve(
+  __dirname,
+  "../../../../POE2-unofficial-launcher-gh-pages/fonts",
+);
+const hasSamples = fs.existsSync(SAMPLE_DIR);
+
+describe.skipIf(!hasSamples)("OtfMutator — SFNT 변조기", () => {
+  const samplePath = (name: string) => path.join(SAMPLE_DIR, name);
+
+  it("Pretendard.otf(upm=2048)를 Noto Sans CJK TC Book으로 변조: 이름/메트릭/한글 글리프 보존", () => {
+    const src = samplePath("Pretendard-Regular.otf");
+    if (!fs.existsSync(src)) return;
+
+    const rule = FONT_MUTATION_DEFINITIONS["Noto Sans CJK TC Book"];
+    const out = mutateOtfSfnt(fs.readFileSync(src), rule, 100);
+
+    // 1. scaler가 OTTO 유지 (CFF 컨테이너)
+    expect(out.slice(0, 4).toString("ascii")).toBe("OTTO");
+
+    // 2. fonteditor-core로 다시 파싱해 필드 검증
+    const re = Font.create(out, { type: "otf" }).get();
+    expect(re.name.fontFamily).toBe(rule.family);
+    expect(re.name.fontSubFamily).toBe(rule.subfamily);
+    expect(re.name.fullName).toBe(rule.fullName);
+    expect(re.name.postScriptName).toBe(rule.postScript);
+    expect(re.name.uniqueSubFamily).toBe(rule.metrics!.uniqueSubFamily);
+    expect(re.name.version).toBe(rule.metrics!.version);
+
+    // 3. 한글 cmap 전체 보존
+    const cmap = (re.cmap || {}) as Record<string, number>;
+    const hangulCount = Object.keys(cmap).filter((cp) => {
+      const c = parseInt(cp, 10);
+      return c >= 0xac00 && c <= 0xd7a3;
+    }).length;
+    expect(hangulCount).toBe(11172);
+
+    // 4. unitsPerEm 비율 보정 — Pretendard 2048 / 본체 1000 = 2.048
+    const ratio = re.head.unitsPerEm / rule.metrics!.unitsPerEm;
+    expect(re.hhea.ascent).toBe(
+      Math.round(rule.metrics!.baseHheaAscent * ratio),
+    );
+    expect(re.hhea.descent).toBe(
+      Math.round(rule.metrics!.baseHheaDescent * ratio),
+    );
+    expect(re["OS/2"].usWinAscent).toBe(
+      Math.round(rule.metrics!.baseWinAscent * ratio),
+    );
+    expect(re["OS/2"].usWinDescent).toBe(
+      Math.round(rule.metrics!.baseWinDescent * ratio),
+    );
+    expect(re["OS/2"].usWeightClass).toBe(rule.metrics!.usWeightClass);
+    expect(re["OS/2"].fsSelection).toBe(rule.metrics!.fsSelection);
+  });
+
+  it("동일 입력을 Spoqa Han Sans Neo로 변조: 이름·메트릭 분리 검증", () => {
+    const src = samplePath("Pretendard-Regular.otf");
+    if (!fs.existsSync(src)) return;
+
+    const rule = FONT_MUTATION_DEFINITIONS["Spoqa Han Sans Neo Regular"];
+    const out = mutateOtfSfnt(fs.readFileSync(src), rule, 100);
+    const re = Font.create(out, { type: "otf" }).get();
+
+    expect(re.name.fontFamily).toBe("Spoqa Han Sans Neo");
+    expect(re.name.postScriptName).toBe("SpoqaHanSansNeo-Regular");
+    // fsSelection이 Noto(64)와 다른 Spoqa(192)로 박혔는지 — 룰 분리 검증
+    expect(re["OS/2"].fsSelection).toBe(192);
+  });
+
+  it("TTF(non-OTTO) 입력은 거부한다", () => {
+    const ttfPath = fs
+      .readdirSync(SAMPLE_DIR)
+      .find((f) => f.toLowerCase().endsWith(".ttf"));
+    if (!ttfPath) return;
+
+    const rule = FONT_MUTATION_DEFINITIONS["Noto Sans CJK TC Book"];
+    expect(() =>
+      mutateOtfSfnt(fs.readFileSync(samplePath(ttfPath)), rule, 100),
+    ).toThrow(/OTTO/);
+  });
+
+  it("scale=150 적용 시 hhea/winAscent가 (100/150) 비율로 줄어든다", () => {
+    const src = samplePath("Pretendard-Regular.otf");
+    if (!fs.existsSync(src)) return;
+
+    const rule = FONT_MUTATION_DEFINITIONS["Noto Sans CJK TC Book"];
+    const out100 = mutateOtfSfnt(fs.readFileSync(src), rule, 100);
+    const out150 = mutateOtfSfnt(fs.readFileSync(src), rule, 150);
+
+    const a100 = Font.create(out100, { type: "otf" }).get();
+    const a150 = Font.create(out150, { type: "otf" }).get();
+
+    // scale% ↑ = 글자 크게 보임 = 라인높이가 100/scale배로 줄어듦.
+    // hhea.lineHeight (ascent - descent) 비율 검증.
+    const line100 = a100.hhea.ascent - a100.hhea.descent;
+    const line150 = a150.hhea.ascent - a150.hhea.descent;
+    // 150%면 라인높이가 100/150 ≈ 0.667배. ±2 단위 라운딩 허용.
+    const expected150 = Math.round(line100 * (100 / 150));
+    expect(Math.abs(line150 - expected150)).toBeLessThanOrEqual(2);
+  });
+});

--- a/src/main/workers/FontMutatorWorker.ts
+++ b/src/main/workers/FontMutatorWorker.ts
@@ -79,9 +79,15 @@ if (parentPort) {
         const hhea = fontData.hhea;
         const os2 = fontData["OS/2"];
 
+        // 본체 정답값은 unitsPerEm=1000 기준. 입력 폰트가 다른 upm이면 비율로 보정한다
+        // (예: Pretendard 2048, 일부 maplestory/binggrae 900). 안 그러면 게임이 본체와
+        // 다른 단위로 ascent/descent를 해석해 글자가 작게 또는 잘리게 나온다.
+        const upmRatio = head.unitsPerEm / m.unitsPerEm;
+        const u = (v: number) => Math.round(v * upmRatio);
+
         // hhea.descent는 음수, baseWinDescent는 양수 표기 → 음수로 변환해 전달
-        const h = scaledLine(m.baseHheaAscent, m.baseHheaDescent, scale);
-        const w = scaledLine(m.baseWinAscent, -m.baseWinDescent, scale);
+        const h = scaledLine(u(m.baseHheaAscent), u(m.baseHheaDescent), scale);
+        const w = scaledLine(u(m.baseWinAscent), u(-m.baseWinDescent), scale);
 
         hhea.ascent = h.ascent;
         hhea.descent = h.descent;
@@ -90,10 +96,10 @@ if (parentPort) {
         os2.usWinAscent = w.ascent;
         os2.usWinDescent = -w.descent; // scaledLine descent(음수) → 양수 표기
 
-        // scale 무관 고정 (본체 상수)
-        os2.sTypoAscender = m.typoAscender;
-        os2.sTypoDescender = m.typoDescender;
-        os2.sTypoLineGap = m.typoLineGap;
+        // scale 무관, upm만 보정
+        os2.sTypoAscender = u(m.typoAscender);
+        os2.sTypoDescender = u(m.typoDescender);
+        os2.sTypoLineGap = u(m.typoLineGap);
         os2.fsSelection = m.fsSelection;
         os2.usWeightClass = m.usWeightClass;
         head.macStyle = m.macStyle;

--- a/src/main/workers/OtfMutatorWorker.ts
+++ b/src/main/workers/OtfMutatorWorker.ts
@@ -1,0 +1,50 @@
+import fs from "node:fs";
+import { parentPort } from "node:worker_threads";
+
+import { mutateOtfSfnt } from "./otfMutator";
+
+import type { FontMutationRule } from "../../shared/font-targets";
+
+/**
+ * OTF(CFF) 전용 변조 워커. 변조 로직은 ./otfMutator.ts에 분리되어 있다.
+ * 이 파일은 worker_threads 메시지 어댑터일 뿐이다.
+ *
+ * 인터페이스는 FontMutatorWorker(TTF)와 동일: 같은 MutatorMessage를 받고
+ * 같은 { success, buffer } 또는 { error }를 반환한다.
+ */
+
+interface MutatorMessage {
+  filePath: string;
+  rule: FontMutationRule;
+  /** 사용자 크기 보정 % (50~150). 미지정 시 100. */
+  scale?: number;
+}
+
+if (parentPort) {
+  parentPort.on("message", (data: MutatorMessage) => {
+    const { filePath, rule } = data;
+    const scale =
+      typeof data.scale === "number" && data.scale > 0 ? data.scale : 100;
+
+    try {
+      if (!rule) {
+        throw new Error("변조 규칙(rule) 객체가 전달되지 않았습니다.");
+      }
+
+      const buffer = fs.readFileSync(filePath);
+      const finalBuffer = mutateOtfSfnt(buffer, rule, scale);
+      const arrayBuffer = finalBuffer.buffer.slice(
+        finalBuffer.byteOffset,
+        finalBuffer.byteOffset + finalBuffer.byteLength,
+      );
+
+      parentPort?.postMessage({ success: true, buffer: arrayBuffer }, [
+        arrayBuffer as ArrayBuffer,
+      ]);
+    } catch (e: unknown) {
+      parentPort?.postMessage({
+        error: (e as Error).message || "OTF 변조 과정 중 알 수 없는 오류 발생",
+      });
+    }
+  });
+}

--- a/src/main/workers/otfMutator.ts
+++ b/src/main/workers/otfMutator.ts
@@ -1,0 +1,255 @@
+import type { FontMutationRule } from "../../shared/font-targets";
+
+/**
+ * OTF(CFF) 전용 SFNT 레벨 변조 로직.
+ *
+ * fonteditor-core는 OTF write를 지원하지 않고, type:'ttf'로 write하면
+ * CFF→glyf 변환 단계에서 한글 음절 대부분의 outline이 손실된다.
+ * → CFF 컨테이너는 절대 손대지 않고 SFNT 레벨에서 name/OS-2/hhea/head 4개
+ *   테이블만 교체·패치한다. 결과 파일은 OTTO scaler를 유지한 OpenType.
+ *
+ * 워커 IPC와 분리되어 있어 vitest 등에서 직접 import해 단위 검증 가능.
+ */
+
+/** SFNT 스펙: head.checkSumAdjustment 계산용 매직 상수. */
+const HEAD_CSA_MAGIC = 0xb1b0afba;
+
+function readTableDirectory(buf: Buffer): {
+  scaler: Buffer;
+  tables: Record<string, Buffer>;
+} {
+  const numTables = buf.readUInt16BE(4);
+  const tables: Record<string, Buffer> = {};
+  for (let i = 0; i < numTables; i++) {
+    const off = 12 + i * 16;
+    const tag = buf.toString("ascii", off, off + 4);
+    const tof = buf.readUInt32BE(off + 8);
+    const tlen = buf.readUInt32BE(off + 12);
+    tables[tag] = buf.slice(tof, tof + tlen);
+  }
+  return { scaler: buf.slice(0, 4), tables };
+}
+
+function buildNameTable(names: Record<number, string>): Buffer {
+  const order = [1, 2, 3, 4, 5, 6];
+  const records: { nameID: number; length: number; offset: number }[] = [];
+  const storage: Buffer[] = [];
+  let storageOffset = 0;
+  for (const nameID of order) {
+    const str = names[nameID];
+    const utf16 = Buffer.from(str, "utf16le");
+    const be = Buffer.alloc(utf16.length);
+    for (let i = 0; i < utf16.length; i += 2) {
+      be[i] = utf16[i + 1];
+      be[i + 1] = utf16[i];
+    }
+    records.push({ nameID, length: be.length, offset: storageOffset });
+    storage.push(be);
+    storageOffset += be.length;
+  }
+  const stringOffset = 6 + records.length * 12;
+  const out = Buffer.alloc(stringOffset + storageOffset);
+  out.writeUInt16BE(0, 0); // format 0
+  out.writeUInt16BE(records.length, 2);
+  out.writeUInt16BE(stringOffset, 4);
+  let p = 6;
+  for (const r of records) {
+    out.writeUInt16BE(3, p); // platformID Windows
+    p += 2;
+    out.writeUInt16BE(1, p); // encodingID Unicode BMP
+    p += 2;
+    out.writeUInt16BE(0x0409, p); // languageID en-US
+    p += 2;
+    out.writeUInt16BE(r.nameID, p);
+    p += 2;
+    out.writeUInt16BE(r.length, p);
+    p += 2;
+    out.writeUInt16BE(r.offset, p);
+    p += 2;
+  }
+  let sp = stringOffset;
+  for (const s of storage) {
+    s.copy(out, sp);
+    sp += s.length;
+  }
+  return out;
+}
+
+function pad4(n: number): number {
+  return (n + 3) & ~3;
+}
+
+function tableChecksum(data: Buffer): number {
+  let sum = 0;
+  const padded = Buffer.alloc(pad4(data.length));
+  data.copy(padded, 0);
+  for (let i = 0; i < padded.length; i += 4) {
+    sum = (sum + padded.readUInt32BE(i)) >>> 0;
+  }
+  return sum;
+}
+
+function reassembleSfnt(
+  scaler: Buffer,
+  tables: Record<string, Buffer>,
+): Buffer {
+  // SFNT spec: 테이블 디렉토리는 tag 알파벳 순.
+  const tagList = Object.keys(tables).sort();
+  const numTables = tagList.length;
+
+  let curOffset = pad4(12 + numTables * 16);
+  type Entry = {
+    tag: string;
+    data: Buffer;
+    offset: number;
+    length: number;
+    checksum: number;
+  };
+  const layout: Entry[] = [];
+  for (const tag of tagList) {
+    const d = tables[tag];
+    layout.push({
+      tag,
+      data: d,
+      offset: curOffset,
+      length: d.length,
+      checksum: tableChecksum(d),
+    });
+    curOffset += pad4(d.length);
+  }
+
+  const out = Buffer.alloc(curOffset);
+  scaler.copy(out, 0);
+  out.writeUInt16BE(numTables, 4);
+
+  let entrySelector = 0;
+  let r = 1;
+  while (r * 2 <= numTables) {
+    r *= 2;
+    entrySelector++;
+  }
+  out.writeUInt16BE(r * 16, 6); // searchRange
+  out.writeUInt16BE(entrySelector, 8);
+  out.writeUInt16BE(numTables * 16 - r * 16, 10); // rangeShift
+
+  let p = 12;
+  for (const e of layout) {
+    out.write(e.tag.padEnd(4, " "), p, "ascii");
+    p += 4;
+    out.writeUInt32BE(e.checksum, p);
+    p += 4;
+    out.writeUInt32BE(e.offset, p);
+    p += 4;
+    out.writeUInt32BE(e.length, p);
+    p += 4;
+  }
+  for (const e of layout) e.data.copy(out, e.offset);
+
+  // head.checkSumAdjustment = MAGIC - sum(file with csa=0). head는 호출자가 미리 csa=0으로 둠.
+  let fileSum = 0;
+  for (let i = 0; i < out.length; i += 4) {
+    fileSum = (fileSum + out.readUInt32BE(i)) >>> 0;
+  }
+  const csa = (HEAD_CSA_MAGIC - fileSum) >>> 0;
+  const headEntry = layout.find((e) => e.tag === "head");
+  if (headEntry) {
+    out.writeUInt32BE(csa, headEntry.offset + 8);
+  }
+  return out;
+}
+
+/**
+ * scale% 적용 라인높이 산출 (FontMutatorWorker와 동일 공식).
+ * unitsPerEm 비율은 호출 측에서 별도로 곱한다.
+ */
+function applyScale(
+  baseAscent: number,
+  baseDescent: number,
+  scale: number,
+): { ascent: number; descent: number } {
+  const baseLine = baseAscent - baseDescent;
+  const ascRatio = baseAscent / baseLine;
+  const newLine = Math.round((baseLine * 100) / scale);
+  const ascent = Math.round(newLine * ascRatio);
+  const descent = ascent - newLine;
+  return { ascent, descent };
+}
+
+function readUnitsPerEm(headTable: Buffer): number {
+  // head: 0:version(4), 4:fontRevision(4), 8:csa(4), 12:magic(4),
+  // 16:flags(2), 18:unitsPerEm(2)
+  return headTable.readUInt16BE(18);
+}
+
+export function mutateOtfSfnt(
+  buffer: Buffer,
+  rule: FontMutationRule,
+  scale: number,
+): Buffer {
+  if (buffer.slice(0, 4).toString("ascii") !== "OTTO") {
+    throw new Error("OtfMutator: 입력이 OTTO scaler가 아님");
+  }
+
+  const { scaler, tables } = readTableDirectory(buffer);
+  const m = rule.metrics;
+  const newTables: Record<string, Buffer> = { ...tables };
+
+  // === name table 교체 ===
+  // ID 3(uniqueSubFamily)/5(version)는 metrics가 있을 때만 본체 원문, 없으면 합성
+  // (FontMutatorWorker의 분기와 동일).
+  const uniqueSubFamily = m ? m.uniqueSubFamily : `${rule.postScript};1.000`;
+  const version = m ? m.version : "Version 1.000";
+  newTables["name"] = buildNameTable({
+    1: rule.family,
+    2: rule.subfamily,
+    3: uniqueSubFamily,
+    4: rule.fullName,
+    5: version,
+    6: rule.postScript,
+  });
+
+  // === OS/2 / hhea / head 메트릭 패치 (metrics가 있을 때만) ===
+  if (m) {
+    const fontUPM = readUnitsPerEm(tables["head"]);
+    const upmRatio = fontUPM / m.unitsPerEm;
+    const u = (v: number) => Math.round(v * upmRatio);
+
+    // hhea.descent와 baseHheaDescent는 음수, baseWinDescent는 양수 표기.
+    const h = applyScale(u(m.baseHheaAscent), u(m.baseHheaDescent), scale);
+    const w = applyScale(u(m.baseWinAscent), u(-m.baseWinDescent), scale);
+
+    // hhea (in-place)
+    const hhea = Buffer.from(tables["hhea"]);
+    hhea.writeInt16BE(h.ascent, 4);
+    hhea.writeInt16BE(h.descent, 6);
+    hhea.writeInt16BE(0, 8); // lineGap
+    newTables["hhea"] = hhea;
+
+    // OS/2 (in-place)
+    // v0+ offsets: 4:usWeightClass, 62:fsSelection,
+    //   68:sTypoAscender, 70:sTypoDescender, 72:sTypoLineGap,
+    //   74:usWinAscent, 76:usWinDescent
+    const os2 = Buffer.from(tables["OS/2"]);
+    os2.writeUInt16BE(m.usWeightClass, 4);
+    os2.writeUInt16BE(m.fsSelection, 62);
+    os2.writeInt16BE(u(m.typoAscender), 68);
+    os2.writeInt16BE(u(m.typoDescender), 70);
+    os2.writeInt16BE(u(m.typoLineGap), 72);
+    os2.writeUInt16BE(w.ascent, 74);
+    os2.writeUInt16BE(-w.descent, 76);
+    newTables["OS/2"] = os2;
+
+    // head.macStyle + csa=0 (재조립 단계에서 채움)
+    const head = Buffer.from(tables["head"]);
+    head.writeUInt16BE(m.macStyle, 44);
+    head.writeUInt32BE(0, 8);
+    newTables["head"] = head;
+  } else {
+    // metrics 미정의여도 head csa는 재계산해야 무결성 유지.
+    const head = Buffer.from(tables["head"]);
+    head.writeUInt32BE(0, 8);
+    newTables["head"] = head;
+  }
+
+  return reassembleSfnt(scaler, newTables);
+}

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -74,6 +74,21 @@ export default defineConfig({
         },
       },
       {
+        entry: "src/main/workers/OtfMutatorWorker.ts",
+        vite: {
+          define: defines,
+          build: {
+            outDir: "dist-electron/workers",
+            emptyOutDir: false,
+            lib: {
+              entry: "src/main/workers/OtfMutatorWorker.ts",
+              formats: ["cjs"],
+              fileName: () => "[name].js",
+            },
+          },
+        },
+      },
+      {
         entry: "src/main/preload.ts",
         onstart(options) {
           options.reload();


### PR DESCRIPTION
## Summary
- **Custom Font Fixes**: Resolved the issue where OTF font application failed due to a "ttf file damaged" error, and implemented `unitsPerEm` correction to normalize font scaling/cropping across custom fonts.
- **WSL & Windows Integration**: Integrated WSL execution rules, enforced LF endings on checkout using `.gitattributes`, and registered the `npm run dev:wsl` script to facilitate starting Windows dev servers within WSL environments.
- **Build & Style Fixes**: Resolved build failures associated with Vite 8 (Rolldown) CJS module transformation regarding `import.meta.url` in electron main, and cleaned up styling matching prettier constraints.

## Motivation
These changes improve the stability of custom font features by ensuring consistent scaling and resolving OTF rendering failures. In addition, the WSL developer ecosystem is now streamlined so developers working on mixed Windows/WSL setups can run and build the application without local execution conflicts or script discrepancies.
