### PR TITLE
fix: 일부 상황에서 게시글이 표시되지 않는 현상 개선 (내 탓 아님)

### DIFF
--- a/src/main/services/NewsService.ts
+++ b/src/main/services/NewsService.ts
@@ -346,25 +346,58 @@ export class NewsService {
         root.querySelector(".newsPost .content") ||
         root.querySelector(".content-container .content");
 
-      if (!content)
-        return "내용을 불러올 수 없습니다. (게시글이 삭제되었거나 형식이 다를 수 있습니다.)";
+      let cleanHtml = "";
 
-      // Remove unnecessary elements (author info, buttons, etc.)
-      const unwantedSelectors = [
-        ".post_author_info",
-        ".report_button",
-        ".content-footer",
-        ".social-buttons",
-        "script",
-        "style",
-      ];
-      unwantedSelectors.forEach((sel) => {
-        content.querySelectorAll(sel).forEach((el) => el.remove());
-      });
+      if (!content) {
+        // 대체제 (.lbox-container 조각들) 확인 및 병합 시도
+        const lboxContainers = root.querySelectorAll(".lbox-container");
+        if (lboxContainers.length > 0) {
+          this.logger.log(
+            `[NewsService] Basic content selector missed for post ${id}. ` +
+            `Falling back to merging ${lboxContainers.length} .lbox-container elements.`
+          );
 
-      const cleanHtml = content.innerHTML.trim();
+          const unwantedSelectors = [
+            ".post_author_info",
+            ".report_button",
+            ".content-footer",
+            ".social-buttons",
+            "script",
+            "style",
+          ];
+
+          lboxContainers.forEach((container) => {
+            unwantedSelectors.forEach((sel) => {
+              container.querySelectorAll(sel).forEach((el) => el.remove());
+            });
+          });
+
+          cleanHtml = lboxContainers.map((container) => container.innerHTML.trim()).join("\n");
+        } else {
+          // 대체제도 없는 최종적인 구조 붕괴 상황에만 예외 발생
+          throw new Error(
+            `게시글 본문(content) 및 대체 컨테이너(lbox-container)를 모두 찾을 수 없습니다. (HTML 구조 붕괴 또는 글 삭제)\n` +
+            `Target URL: ${link}\n` +
+            `Tested Selectors: .forumPost .content, .newsPost .content, .content-container .content, .lbox-container`
+          );
+        }
+      } else {
+        // Remove unnecessary elements (author info, buttons, etc.)
+        const unwantedSelectors = [
+          ".post_author_info",
+          ".report_button",
+          ".content-footer",
+          ".social-buttons",
+          "script",
+          "style",
+        ];
+        unwantedSelectors.forEach((sel) => {
+          content.querySelectorAll(sel).forEach((el) => el.remove());
+        });
+        cleanHtml = content.innerHTML.trim();
+      }
+
       this.updateCache(id, cleanHtml);
-
       this.logger.log(`Successfully fetched content for post ${id}.`);
 
       return cleanHtml;


### PR DESCRIPTION
## Summary
- **대체 파싱 로직 추가**: 특정 공지사항(3932541 등)에서 표준 본문 클래스(`.content`)가 누락되고 `.lbox-container` 조각들로 채워지는 Daum 측 마크업 이슈에 대응하여, 대체 요소를 수집하고 조인하여 온전한 게시글을 렌더링하는 fallback 메커니즘을 적용했습니다.
- **오류 Trace 예외처리 강화**: 최종적으로 모든 요소가 감지되지 않는 구조 붕괴 상황에 대비해, 대상 게시글의 원본 URL과 매칭을 시도했던 셀렉터 정보들을 에러 객체에 소상히 담아 로거 및 에러 보고 파이프라인에 포착되도록 강하게 예외처리를 하였습니다.

## Motivation
외부 사이트(다음게임)의 퍼블리싱 상태 불일치(혹은 마크업 깨짐)로 인해 런처 뉴스 탭에서 글이 완전히 렌더링되지 못하고 누락되는 오류 현상을 완전 방지하기 위함입니다. 본 패치로 인해 외부 구조에 구애받지 않는 강인한 파싱 환경과 더불어, 만일의 사태 시 빠른 대처를 위한 에러 디버깅 정보를 확보할 수 있게 됩니다.
