### PR TITLE
fix(main): 화면 잠금 해제 후 정상 해상도인데도 타이틀바에 저해상도 모드가 오표시되는 오류 수정

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -2622,9 +2622,16 @@ eventBus.register({
         source: "ConfigChange",
       });
     }
+  },
+});
 
-    // [Trigger Point 3] Broadcast Title Update when Active Game changes
-    if (key === "activeGame") {
+// Register Handler to update Window Title when configuration changes
+eventBus.register({
+  id: "WindowTitleSyncManager",
+  targetEvent: EventType.CONFIG_CHANGE,
+  handle: async (event: ConfigChangeEvent) => {
+    const { key } = event.payload;
+    if (key === "activeGame" || key === "resolutionMode") {
       broadcastTitleUpdate();
     }
   },


### PR DESCRIPTION
## Summary
- `src/main/main.ts`: 화면 잠금 해제 시 해상도가 원래대로 복구될 때 타이틀바 갱신 트리거가 누락되는 결함을 해결했습니다.
- 기존 `DevToolsSyncManager`에서 타이틀 업데이트 로직을 완전히 떼어내고 전용 `WindowTitleSyncManager`로 깔끔하게 분리 독립시켰으며, `resolutionMode` 설정값 변경 시 자동으로 `broadcastTitleUpdate()`를 호출하도록 아키텍처를 개선했습니다.

## Motivation
- 화면 잠금 상태에서 모니터 연결 해제 혹은 가상 저해상도(0x0) 좌표 수집으로 인해 `[저해상도 모드]` 캐시가 강제로 주입된 상황에서, 잠금 해제 후 물리 창 크기 자체가 변하지 않아 생기던 타이틀 오표시 및 고착 문제를 원천 방지하기 위함입니다.