### PR TITLE
feat/ 버전 확인 관련 로직 통합 및 고도화

### DIFF
--- a/src/main/events/handlers/AutoPatchHandler.ts
+++ b/src/main/events/handlers/AutoPatchHandler.ts
@@ -177,7 +177,7 @@ export async function triggerPendingManualPatches(context: AppContext) {
 
       // Start safely
       manager
-        .startSelfDiagnosis(installPath, serviceId, {
+        .startSelfDiagnosis(installPath, serviceId, gameId, {
           webRoot,
           backupWebRoot,
         })
@@ -414,6 +414,7 @@ export const AutoPatchProcessStopHandler: EventHandler<ProcessEvent> = {
             const success = await manager.startSelfDiagnosis(
               installPath,
               serviceId,
+              gameId,
               {
                 webRoot,
                 backupWebRoot,

--- a/src/main/events/types.ts
+++ b/src/main/events/types.ts
@@ -45,6 +45,9 @@ export enum EventType {
   PATCH_RESERVATION_FAILED = "PATCH:RESERVATION_FAILED",
   PATCH_RESERVATION_SUCCESS = "PATCH:RESERVATION_SUCCESS",
   PATCH_UI_TITLE_TICK = "PATCH:UI_TITLE_TICK",
+
+  // Remote version (master socket / gh-pages)
+  REMOTE_VERSION_UPDATED = "REMOTE:VERSION_UPDATED",
 }
 
 export interface ToolForceRepairEvent {
@@ -292,7 +295,20 @@ export type AppEvent =
   | PatchRetryRequestedEvent
   | PatchReservationFailedEvent
   | PatchReservationSuccessEvent
-  | PatchUiTitleTickEvent;
+  | PatchUiTitleTickEvent
+  | RemoteVersionUpdatedEvent;
+
+export interface RemoteVersionUpdatedEvent {
+  type: EventType.REMOTE_VERSION_UPDATED;
+  payload: {
+    gameId: AppConfig["activeGame"];
+    webRoot: string;
+    version: string;
+    source: "master-socket" | "gh-pages";
+    fetchedAt: number;
+  };
+  timestamp?: number;
+}
 
 export interface PatchUiTitleTickEvent {
   type: EventType.PATCH_UI_TITLE_TICK;

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -2213,7 +2213,7 @@ ipcMain.on(
       });
 
       activeManualPatchManager
-        .startSelfDiagnosis(installPath, serviceId)
+        .startSelfDiagnosis(installPath, serviceId, activeGame)
         .finally(() => {
           // Cleanup reference if it finished (optional, but good for GC)
           // But we have to check if IT is the same instance

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -120,6 +120,7 @@ import { LogParser } from "./utils/LogParser";
 import { PowerShellManager } from "./utils/powershell";
 import { getGameInstallPath, isGameInstalled } from "./utils/registry";
 import { syncInstallLocation } from "./utils/registry";
+import { RemoteVersionResolver } from "./utils/RemoteVersionResolver";
 import { LegacyUacManager, SimpleUacBypass } from "./utils/uac/uac-migration";
 import {
   applyResolutionRules,
@@ -839,6 +840,23 @@ ipcMain.handle("session:logout", async () => {
     return false;
   }
 });
+
+// --- Remote Version IPC ---
+ipcMain.handle(
+  "version:resolveRemote",
+  async (_event, gameId: AppConfig["activeGame"]) => {
+    if (gameId !== "POE1" && gameId !== "POE2") return null;
+    return RemoteVersionResolver.resolve(gameId);
+  },
+);
+
+ipcMain.handle(
+  "version:peekRemote",
+  async (_event, gameId: AppConfig["activeGame"]) => {
+    if (gameId !== "POE1" && gameId !== "POE2") return null;
+    return RemoteVersionResolver.peekCache(gameId) ?? null;
+  },
+);
 
 // --- Support Tools IPC ---
 ipcMain.handle(
@@ -2770,5 +2788,28 @@ app.whenReady().then(async () => {
         });
       }
     });
+
+    // Refresh remote version cache (10-min TTL) so renderer can compare with local log.
+    for (const gameId of ["POE1", "POE2"] as const) {
+      if (RemoteVersionResolver.isFresh(gameId)) continue;
+      RemoteVersionResolver.resolve(gameId).then((entry) => {
+        if (!entry) return;
+        const payload = {
+          gameId: entry.gameId,
+          webRoot: entry.webRoot,
+          version: entry.version,
+          source: entry.source,
+          fetchedAt: entry.fetchedAt,
+        };
+        if (appContext) {
+          eventBus.emit(EventType.REMOTE_VERSION_UPDATED, appContext, payload);
+        }
+        BrowserWindow.getAllWindows().forEach((win) => {
+          if (!win.isDestroyed()) {
+            win.webContents.send("remote-version:updated", payload);
+          }
+        });
+      });
+    }
   });
 });

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -336,4 +336,32 @@ contextBridge.exposeInMainWorld("electronAPI", {
       return () => ipcRenderer.off("font:download-progress", handler);
     },
   },
+  remoteVersion: {
+    resolve: (gameId: AppConfig["activeGame"]) =>
+      ipcRenderer.invoke("version:resolveRemote", gameId),
+    peek: (gameId: AppConfig["activeGame"]) =>
+      ipcRenderer.invoke("version:peekRemote", gameId),
+    onUpdated: (
+      callback: (payload: {
+        gameId: AppConfig["activeGame"];
+        webRoot: string;
+        version: string;
+        source: "master-socket" | "gh-pages";
+        fetchedAt: number;
+      }) => void,
+    ) => {
+      const handler = (
+        _event: IpcRendererEvent,
+        payload: {
+          gameId: AppConfig["activeGame"];
+          webRoot: string;
+          version: string;
+          source: "master-socket" | "gh-pages";
+          fetchedAt: number;
+        },
+      ) => callback(payload);
+      ipcRenderer.on("remote-version:updated", handler);
+      return () => ipcRenderer.off("remote-version:updated", handler);
+    },
+  },
 });

--- a/src/main/services/PatchManager.ts
+++ b/src/main/services/PatchManager.ts
@@ -9,6 +9,7 @@ import { eventBus } from "../events/EventBus";
 import { AppContext, EventType, PatchProgressEvent } from "../events/types";
 import { Logger } from "../utils/logger";
 import { LogParser } from "../utils/LogParser";
+import { RemoteVersionResolver } from "../utils/RemoteVersionResolver";
 
 interface ParsedLogInfo {
   webRoot: string | null;
@@ -48,6 +49,7 @@ export class PatchManager {
   public async startSelfDiagnosis(
     installPath: string,
     serviceId: AppConfig["serviceChannel"],
+    gameId: AppConfig["activeGame"],
     overrides?: { webRoot?: string; backupWebRoot?: string },
   ): Promise<boolean> {
     // Prevent re-entrancy / double-execution
@@ -98,7 +100,21 @@ export class PatchManager {
       }
 
       if (!logInfo.webRoot) {
-        throw new Error("최근 로그에서 Web Root 정보를 찾을 수 없습니다.");
+        // Fallback: 로그에 Web Root가 없으면 master 소켓(또는 gh-pages)에서 가져온다.
+        // 게임을 한 번도 켜본 적 없는 사용자도 강제 복구를 시도할 수 있게 함.
+        const remote = await RemoteVersionResolver.resolve(gameId);
+        if (remote) {
+          this.logger.log(
+            `[Diagnosis] Web Root 폴백 적용 (source=${remote.source}, version=${remote.version})`,
+          );
+          logInfo = {
+            webRoot: remote.webRoot,
+            backupWebRoot: logInfo.backupWebRoot,
+            filesToDownload: logInfo.filesToDownload,
+          };
+        } else {
+          throw new Error("최근 로그에서 Web Root 정보를 찾을 수 없습니다.");
+        }
       }
 
       let targetFiles = logInfo.filesToDownload;
@@ -125,7 +141,7 @@ export class PatchManager {
 
       await this.processDownloads(
         installPath,
-        logInfo.webRoot,
+        logInfo.webRoot!,
         targetFiles,
         logInfo.backupWebRoot,
       );

--- a/src/main/tests/RemoteVersionResolver.test.ts
+++ b/src/main/tests/RemoteVersionResolver.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { RemoteVersionResolver } from "../utils/RemoteVersionResolver";
+import { GhPagesError } from "../utils/version-sources/ghPagesLatest";
+import { MasterSocketError } from "../utils/version-sources/masterSocket";
+
+const POE2_KAKAO =
+  "https://patch.poe2.kakaogames.com/production/patch/4.4.0.13/";
+const POE2_KAKAO_OLD =
+  "https://patch.poe2.kakaogames.com/production/patch/4.4.0.10/";
+
+describe("RemoteVersionResolver", () => {
+  beforeEach(() => {
+    RemoteVersionResolver.__reset();
+  });
+
+  afterEach(() => {
+    RemoteVersionResolver.__reset();
+  });
+
+  it("returns master result and tags source", async () => {
+    const master = vi.fn().mockResolvedValue({ webRoot: POE2_KAKAO });
+    const ghPages = vi.fn();
+    RemoteVersionResolver.__setAdapters({ master, ghPages });
+
+    const result = await RemoteVersionResolver.resolve("POE2");
+    expect(result).toMatchObject({
+      gameId: "POE2",
+      webRoot: POE2_KAKAO,
+      version: "4.4.0.13",
+      source: "master-socket",
+    });
+    expect(master).toHaveBeenCalledTimes(1);
+    expect(ghPages).not.toHaveBeenCalled();
+  });
+
+  it("falls back to gh-pages when master throws", async () => {
+    const master = vi
+      .fn()
+      .mockRejectedValue(new MasterSocketError("timeout", "timeout"));
+    const ghPages = vi.fn().mockResolvedValue({ webRoot: POE2_KAKAO_OLD });
+    RemoteVersionResolver.__setAdapters({ master, ghPages });
+
+    const result = await RemoteVersionResolver.resolve("POE2");
+    expect(result).toMatchObject({
+      source: "gh-pages",
+      webRoot: POE2_KAKAO_OLD,
+    });
+    expect(master).toHaveBeenCalledTimes(1);
+    expect(ghPages).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns null when both sources fail", async () => {
+    const master = vi
+      .fn()
+      .mockRejectedValue(new MasterSocketError("boom", "unknown"));
+    const ghPages = vi
+      .fn()
+      .mockRejectedValue(new GhPagesError("boom", "network"));
+    RemoteVersionResolver.__setAdapters({ master, ghPages });
+
+    const result = await RemoteVersionResolver.resolve("POE1");
+    expect(result).toBeNull();
+  });
+
+  it("dedups concurrent calls for the same game", async () => {
+    let resolveMaster!: (v: { webRoot: string }) => void;
+    const master = vi.fn(
+      () =>
+        new Promise<{ webRoot: string }>((res) => {
+          resolveMaster = res;
+        }),
+    );
+    const ghPages = vi.fn();
+    RemoteVersionResolver.__setAdapters({ master, ghPages });
+
+    const p1 = RemoteVersionResolver.resolve("POE2");
+    const p2 = RemoteVersionResolver.resolve("POE2");
+    resolveMaster({ webRoot: POE2_KAKAO });
+    const [r1, r2] = await Promise.all([p1, p2]);
+
+    expect(master).toHaveBeenCalledTimes(1);
+    expect(r1).toBe(r2);
+  });
+
+  it("returns cached value while fresh, refreshes after TTL", async () => {
+    const master = vi
+      .fn()
+      .mockResolvedValueOnce({ webRoot: POE2_KAKAO_OLD })
+      .mockResolvedValueOnce({ webRoot: POE2_KAKAO });
+    RemoteVersionResolver.__setAdapters({
+      master,
+      ghPages: vi.fn(),
+    });
+
+    const first = await RemoteVersionResolver.resolve("POE2");
+    expect(first?.version).toBe("4.4.0.10");
+
+    // Within TTL: same value, no extra call
+    const second = await RemoteVersionResolver.resolve("POE2");
+    expect(second).toBe(first);
+    expect(master).toHaveBeenCalledTimes(1);
+
+    // Force cache expiry by rewinding fetchedAt
+    const cached = RemoteVersionResolver.peekCache("POE2")!;
+    cached.fetchedAt = Date.now() - 11 * 60 * 1000;
+
+    const third = await RemoteVersionResolver.resolve("POE2");
+    expect(third?.version).toBe("4.4.0.13");
+    expect(master).toHaveBeenCalledTimes(2);
+  });
+
+  it("isFresh respects TTL", () => {
+    const master = vi.fn().mockResolvedValue({ webRoot: POE2_KAKAO });
+    RemoteVersionResolver.__setAdapters({ master, ghPages: vi.fn() });
+
+    expect(RemoteVersionResolver.isFresh("POE2")).toBe(false);
+    return RemoteVersionResolver.resolve("POE2").then(() => {
+      expect(RemoteVersionResolver.isFresh("POE2")).toBe(true);
+      const cached = RemoteVersionResolver.peekCache("POE2")!;
+      cached.fetchedAt = Date.now() - 11 * 60 * 1000;
+      expect(RemoteVersionResolver.isFresh("POE2")).toBe(false);
+    });
+  });
+});

--- a/src/main/tests/ghPagesLatest.test.ts
+++ b/src/main/tests/ghPagesLatest.test.ts
@@ -1,0 +1,61 @@
+import axios from "axios";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import { fetchGhPagesWebRoot } from "../utils/version-sources/ghPagesLatest";
+
+vi.mock("axios");
+
+const mockedAxios = axios as unknown as { get: ReturnType<typeof vi.fn> };
+
+describe("fetchGhPagesWebRoot", () => {
+  beforeEach(() => {
+    mockedAxios.get = vi.fn();
+  });
+
+  it("returns webRoot for known game", async () => {
+    mockedAxios.get.mockResolvedValueOnce({
+      status: 200,
+      data: {
+        POE1: {
+          version: "3.28.0.6.2",
+          webRoot: "https://poe.gdn.gamecdn.net/live/patch/3.28.0.6.2/",
+          timestamp: 1,
+        },
+        POE2: {
+          version: "4.4.0.10",
+          webRoot:
+            "https://patch.poe2.kakaogames.com/production/patch/4.4.0.10/",
+          timestamp: 2,
+        },
+      },
+    });
+    await expect(fetchGhPagesWebRoot("POE2")).resolves.toEqual({
+      webRoot: "https://patch.poe2.kakaogames.com/production/patch/4.4.0.10/",
+    });
+  });
+
+  it("throws missing-game when entry absent", async () => {
+    mockedAxios.get.mockResolvedValueOnce({ status: 200, data: {} });
+    await expect(fetchGhPagesWebRoot("POE1")).rejects.toMatchObject({
+      name: "GhPagesError",
+      code: "missing-game",
+    });
+  });
+
+  it("throws missing-webroot when entry has no webRoot field", async () => {
+    mockedAxios.get.mockResolvedValueOnce({
+      status: 200,
+      data: { POE1: { version: "x", timestamp: 0 } },
+    });
+    await expect(fetchGhPagesWebRoot("POE1")).rejects.toMatchObject({
+      code: "missing-webroot",
+    });
+  });
+
+  it("wraps network errors as network", async () => {
+    mockedAxios.get.mockRejectedValueOnce(new Error("ECONNRESET"));
+    await expect(fetchGhPagesWebRoot("POE1")).rejects.toMatchObject({
+      code: "network",
+    });
+  });
+});

--- a/src/main/tests/masterSocket.integration.test.ts
+++ b/src/main/tests/masterSocket.integration.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+
+import { fetchMasterWebRoot } from "../utils/version-sources/masterSocket";
+
+/**
+ * Integration: 실제 PoE master patch server에 TCP 연결해서 응답을 검증한다.
+ * 네트워크가 막혀있거나 GGG 측 master 호스트/포트/프로토콜이 바뀌면 fail한다.
+ *
+ * 도메인 화이트리스트는 일부러 안 건다 — 호출 위치(국가)에 따라 GGG global CDN
+ * (patch.poecdn.com / patch-poe2.poecdn.com)이나 카카오 CDN
+ * (poe.gdn.gamecdn.net / patch.poe2.kakaogames.com)으로 라우팅이 갈리고,
+ * 미래에 GGG가 CDN 도메인을 바꿔도 회귀로 잡고 싶지 않다.
+ *
+ * 검증 포인트:
+ *   1. 응답을 받는다 (timeout 안 남)
+ *   2. webRoot가 http(s) URL 형태
+ *   3. URL 마지막 path segment가 `\d+(\.\d+)+` 패턴 (= 버전)
+ *   4. 응답 시간 5초 이내
+ */
+
+const VERSION_PATTERN = /^\d+(\.\d+)+$/;
+
+function assertWebRoot(webRoot: string): void {
+  expect(webRoot).toMatch(/^https?:\/\//);
+  const url = new URL(webRoot);
+  const segments = url.pathname.split("/").filter(Boolean);
+  expect(segments.length).toBeGreaterThan(0);
+  const lastSegment = segments[segments.length - 1];
+  expect(lastSegment).toMatch(VERSION_PATTERN);
+}
+
+describe("fetchMasterWebRoot (live)", () => {
+  it("fetches a valid webRoot for POE1", async () => {
+    const started = Date.now();
+    const result = await fetchMasterWebRoot("POE1", { timeoutMs: 5000 });
+    const elapsed = Date.now() - started;
+    console.log(`POE1 master response (${elapsed}ms):`, result.webRoot);
+    assertWebRoot(result.webRoot);
+    expect(elapsed).toBeLessThan(5000);
+  }, 10_000);
+
+  it("fetches a valid webRoot for POE2", async () => {
+    const started = Date.now();
+    const result = await fetchMasterWebRoot("POE2", { timeoutMs: 5000 });
+    const elapsed = Date.now() - started;
+    console.log(`POE2 master response (${elapsed}ms):`, result.webRoot);
+    assertWebRoot(result.webRoot);
+    expect(elapsed).toBeLessThan(5000);
+  }, 10_000);
+});

--- a/src/main/tests/masterSocket.test.ts
+++ b/src/main/tests/masterSocket.test.ts
@@ -1,0 +1,147 @@
+import { EventEmitter } from "node:events";
+
+import { describe, it, expect, vi } from "vitest";
+
+import {
+  fetchMasterWebRoot,
+  MasterSocketError,
+} from "../utils/version-sources/masterSocket";
+
+// Fake socket replaces net.Socket. Tests drive its data/close/error events manually.
+class FakeSocket extends EventEmitter {
+  public destroyed = false;
+  public written: Buffer[] = [];
+  write(chunk: Buffer): boolean {
+    this.written.push(chunk);
+    return true;
+  }
+  destroy(): void {
+    this.destroyed = true;
+    this.emit("close");
+  }
+}
+
+function buildResponse(webRoot: string): Buffer {
+  // 1 byte unknown + 33 bytes blank + 1 byte url length + url(utf16le) + trailing backup bytes (ignored)
+  const urlBytes = Buffer.from(webRoot, "utf16le");
+  if (urlBytes.length % 2 !== 0)
+    throw new Error("utf16le bytes must be even length");
+  const urlLen = urlBytes.length / 2;
+  const head = Buffer.concat([
+    Buffer.from([0x02]),
+    Buffer.alloc(33),
+    Buffer.from([urlLen]),
+  ]);
+  // Add a trailing 1-byte blank + 1-byte length + same url as "backup" so structure resembles real response
+  const tail = Buffer.concat([Buffer.from([0x00, urlLen]), urlBytes]);
+  return Buffer.concat([head, urlBytes, tail]);
+}
+
+function driveConnect(socket: FakeSocket): void {
+  // emit connect on next tick to mimic real socket
+  setImmediate(() => socket.emit("connect"));
+}
+
+describe("fetchMasterWebRoot", () => {
+  it("parses a normal response (single chunk)", async () => {
+    const expected =
+      "https://patch.poe2.kakaogames.com/production/patch/4.4.0.13/";
+    const fake = new FakeSocket();
+    const promise = fetchMasterWebRoot("POE2", {
+      connect: () => fake as unknown as never,
+    });
+    driveConnect(fake);
+    await vi.waitFor(() => expect(fake.written.length).toBeGreaterThan(0));
+    expect(Array.from(fake.written[0])).toEqual([0x01, 0x07]);
+    fake.emit("data", buildResponse(expected));
+    await expect(promise).resolves.toEqual({ webRoot: expected });
+  });
+
+  it("reassembles a response that arrives byte-by-byte", async () => {
+    const expected = "https://poe.gdn.gamecdn.net/live/patch/3.28.0.10/";
+    const fake = new FakeSocket();
+    const promise = fetchMasterWebRoot("POE1", {
+      connect: () => fake as unknown as never,
+    });
+    driveConnect(fake);
+    const buf = buildResponse(expected);
+    for (const byte of buf) fake.emit("data", Buffer.from([byte]));
+    await expect(promise).resolves.toEqual({ webRoot: expected });
+  });
+
+  it("rejects with short-response when connection closes early", async () => {
+    const fake = new FakeSocket();
+    const promise = fetchMasterWebRoot("POE1", {
+      connect: () => fake as unknown as never,
+    });
+    driveConnect(fake);
+    fake.emit("data", Buffer.from([0x02, 0x00, 0x00, 0x00])); // too short
+    fake.emit("close");
+    await expect(promise).rejects.toMatchObject({
+      name: "MasterSocketError",
+      code: "short-response",
+    });
+  });
+
+  it("rejects with empty-url when url length byte is 0", async () => {
+    const fake = new FakeSocket();
+    const promise = fetchMasterWebRoot("POE1", {
+      connect: () => fake as unknown as never,
+    });
+    driveConnect(fake);
+    const buf = Buffer.concat([
+      Buffer.from([0x02]),
+      Buffer.alloc(33),
+      Buffer.from([0x00]), // url_length = 0
+      Buffer.alloc(4),
+    ]);
+    fake.emit("data", buf);
+    await expect(promise).rejects.toMatchObject({
+      name: "MasterSocketError",
+      code: "empty-url",
+    });
+  });
+
+  it("rejects with timeout if server never responds", async () => {
+    const fake = new FakeSocket();
+    const promise = fetchMasterWebRoot("POE1", {
+      timeoutMs: 30,
+      connect: () => fake as unknown as never,
+    });
+    driveConnect(fake);
+    await expect(promise).rejects.toBeInstanceOf(MasterSocketError);
+    await expect(promise).rejects.toMatchObject({ code: "timeout" });
+  });
+
+  it("maps ECONNREFUSED to connection-refused", async () => {
+    const fake = new FakeSocket();
+    const promise = fetchMasterWebRoot("POE1", {
+      connect: () => fake as unknown as never,
+    });
+    setImmediate(() => {
+      const err = new Error("connect ECONNREFUSED") as NodeJS.ErrnoException;
+      err.code = "ECONNREFUSED";
+      fake.emit("error", err);
+    });
+    await expect(promise).rejects.toMatchObject({
+      name: "MasterSocketError",
+      code: "connection-refused",
+    });
+  });
+
+  it("maps ENOTFOUND to dns", async () => {
+    const fake = new FakeSocket();
+    const promise = fetchMasterWebRoot("POE1", {
+      connect: () => fake as unknown as never,
+    });
+    setImmediate(() => {
+      const err = new Error("getaddrinfo ENOTFOUND") as NodeJS.ErrnoException;
+      err.code = "ENOTFOUND";
+      fake.emit("error", err);
+    });
+    await expect(promise).rejects.toMatchObject({
+      name: "MasterSocketError",
+      code: "dns",
+    });
+  });
+});

--- a/src/main/utils/RemoteVersionResolver.ts
+++ b/src/main/utils/RemoteVersionResolver.ts
@@ -1,0 +1,145 @@
+import { Logger } from "./logger";
+import { LogParser } from "./LogParser";
+import {
+  fetchGhPagesWebRoot,
+  GhPagesError,
+} from "./version-sources/ghPagesLatest";
+import {
+  fetchMasterWebRoot,
+  MasterSocketError,
+} from "./version-sources/masterSocket";
+import { AppConfig } from "../../shared/types";
+
+export type RemoteVersionSource = "master-socket" | "gh-pages";
+
+export interface RemoteWebRoot {
+  gameId: AppConfig["activeGame"];
+  webRoot: string;
+  version: string;
+  source: RemoteVersionSource;
+  fetchedAt: number;
+}
+
+const CACHE_TTL_MS = 10 * 60 * 1000; // 10 minutes
+const logger = new Logger({
+  type: "REMOTE_VERSION",
+  typeColor: "#FFB86C",
+  priority: 5,
+});
+
+interface AdapterDeps {
+  master: typeof fetchMasterWebRoot;
+  ghPages: typeof fetchGhPagesWebRoot;
+}
+
+const defaultAdapters: AdapterDeps = {
+  master: fetchMasterWebRoot,
+  ghPages: fetchGhPagesWebRoot,
+};
+
+export class RemoteVersionResolver {
+  private static cache = new Map<AppConfig["activeGame"], RemoteWebRoot>();
+  private static inflight = new Map<
+    AppConfig["activeGame"],
+    Promise<RemoteWebRoot | null>
+  >();
+  private static adapters: AdapterDeps = defaultAdapters;
+
+  // Test seam: inject mock adapters
+  public static __setAdapters(adapters: Partial<AdapterDeps>): void {
+    RemoteVersionResolver.adapters = { ...defaultAdapters, ...adapters };
+  }
+
+  public static __reset(): void {
+    RemoteVersionResolver.adapters = defaultAdapters;
+    RemoteVersionResolver.cache.clear();
+    RemoteVersionResolver.inflight.clear();
+  }
+
+  /** Returns the last cached value regardless of TTL. */
+  public static peekCache(
+    gameId: AppConfig["activeGame"],
+  ): RemoteWebRoot | undefined {
+    return RemoteVersionResolver.cache.get(gameId);
+  }
+
+  /** Returns true if cached value is still fresh (within TTL). */
+  public static isFresh(
+    gameId: AppConfig["activeGame"],
+    now = Date.now(),
+  ): boolean {
+    const cached = RemoteVersionResolver.cache.get(gameId);
+    return !!cached && now - cached.fetchedAt < CACHE_TTL_MS;
+  }
+
+  /**
+   * Resolves the remote webRoot for a game.
+   * Uses cache if fresh. Otherwise tries master socket, then gh-pages.
+   * Returns null only if all sources fail.
+   */
+  public static async resolve(
+    gameId: AppConfig["activeGame"],
+  ): Promise<RemoteWebRoot | null> {
+    if (RemoteVersionResolver.isFresh(gameId)) {
+      return RemoteVersionResolver.cache.get(gameId)!;
+    }
+    const existing = RemoteVersionResolver.inflight.get(gameId);
+    if (existing) return existing;
+
+    const task = RemoteVersionResolver.resolveUncached(gameId).finally(() => {
+      RemoteVersionResolver.inflight.delete(gameId);
+    });
+    RemoteVersionResolver.inflight.set(gameId, task);
+    return task;
+  }
+
+  private static async resolveUncached(
+    gameId: AppConfig["activeGame"],
+  ): Promise<RemoteWebRoot | null> {
+    const { master, ghPages } = RemoteVersionResolver.adapters;
+
+    try {
+      const { webRoot } = await master(gameId);
+      const entry = RemoteVersionResolver.build(
+        gameId,
+        webRoot,
+        "master-socket",
+      );
+      RemoteVersionResolver.cache.set(gameId, entry);
+      return entry;
+    } catch (err) {
+      const code = err instanceof MasterSocketError ? err.code : "unknown";
+      logger.warn(
+        `[${gameId}] master socket failed (${code}): ${(err as Error).message}`,
+      );
+    }
+
+    try {
+      const { webRoot } = await ghPages(gameId);
+      const entry = RemoteVersionResolver.build(gameId, webRoot, "gh-pages");
+      RemoteVersionResolver.cache.set(gameId, entry);
+      return entry;
+    } catch (err) {
+      const code = err instanceof GhPagesError ? err.code : "unknown";
+      logger.warn(
+        `[${gameId}] gh-pages fallback failed (${code}): ${(err as Error).message}`,
+      );
+    }
+
+    return null;
+  }
+
+  private static build(
+    gameId: AppConfig["activeGame"],
+    webRoot: string,
+    source: RemoteVersionSource,
+  ): RemoteWebRoot {
+    return {
+      gameId,
+      webRoot,
+      version: LogParser.extractVersion(webRoot),
+      source,
+      fetchedAt: Date.now(),
+    };
+  }
+}

--- a/src/main/utils/version-sources/ghPagesLatest.ts
+++ b/src/main/utils/version-sources/ghPagesLatest.ts
@@ -1,0 +1,75 @@
+import axios from "axios";
+
+import { AppConfig } from "../../../shared/types";
+import { SUPPORT_URLS } from "../../../shared/urls";
+
+interface GhPagesEntry {
+  version: string;
+  webRoot: string;
+  timestamp: number;
+}
+
+type GhPagesPayload = Partial<Record<AppConfig["activeGame"], GhPagesEntry>>;
+
+const DEFAULT_TIMEOUT_MS = 3000;
+
+export interface GhPagesResult {
+  webRoot: string;
+}
+
+export class GhPagesError extends Error {
+  constructor(
+    message: string,
+    public readonly code:
+      | "http"
+      | "missing-game"
+      | "missing-webroot"
+      | "network",
+  ) {
+    super(message);
+    this.name = "GhPagesError";
+  }
+}
+
+export interface FetchGhPagesOptions {
+  timeoutMs?: number;
+}
+
+export async function fetchGhPagesWebRoot(
+  gameId: AppConfig["activeGame"],
+  opts: FetchGhPagesOptions = {},
+): Promise<GhPagesResult> {
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const url = `${SUPPORT_URLS.LATEST_VERSIONS_JSON}?t=${Date.now()}`;
+
+  let response;
+  try {
+    response = await axios.get<GhPagesPayload>(url, {
+      timeout: timeoutMs,
+      responseType: "json",
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new GhPagesError(`gh-pages fetch failed: ${msg}`, "network");
+  }
+
+  if (response.status < 200 || response.status >= 300) {
+    throw new GhPagesError(`gh-pages returned ${response.status}`, "http");
+  }
+
+  const entry = response.data?.[gameId];
+  if (!entry) {
+    throw new GhPagesError(
+      `gh-pages missing entry for ${gameId}`,
+      "missing-game",
+    );
+  }
+  if (!entry.webRoot) {
+    throw new GhPagesError(
+      `gh-pages entry for ${gameId} has no webRoot`,
+      "missing-webroot",
+    );
+  }
+
+  return { webRoot: entry.webRoot };
+}

--- a/src/main/utils/version-sources/masterSocket.ts
+++ b/src/main/utils/version-sources/masterSocket.ts
@@ -1,0 +1,157 @@
+import net from "node:net";
+
+import { AppConfig } from "../../../shared/types";
+
+interface MasterEndpoint {
+  host: string;
+  port: number;
+}
+
+const ENDPOINTS: Record<AppConfig["activeGame"], MasterEndpoint> = {
+  POE1: { host: "patch.pathofexile.com", port: 12995 },
+  POE2: { host: "patch.pathofexile2.com", port: 13060 },
+};
+
+// Protocol byte sequence sent by official client and ggpker.
+// 0x01 = magic, 0x07 = patch protocol version 7.
+const REQUEST_BYTES = Buffer.from([0x01, 0x07]);
+
+// Response layout: offset 34 = url length (utf-16 code points),
+// offset 35 onwards = url bytes (length * 2 bytes), UTF-16LE.
+const URL_LENGTH_OFFSET = 34;
+const URL_BYTES_OFFSET = 35;
+
+const DEFAULT_TIMEOUT_MS = 3000;
+const MIN_RESPONSE_LENGTH = URL_BYTES_OFFSET + 2; // at least 1 utf-16 code point
+
+export interface MasterSocketResult {
+  webRoot: string;
+}
+
+export class MasterSocketError extends Error {
+  constructor(
+    message: string,
+    public readonly code:
+      | "timeout"
+      | "connection-refused"
+      | "dns"
+      | "short-response"
+      | "empty-url"
+      | "unknown",
+  ) {
+    super(message);
+    this.name = "MasterSocketError";
+  }
+}
+
+export interface FetchMasterOptions {
+  timeoutMs?: number;
+  // Injection seam for tests
+  connect?: (host: string, port: number) => net.Socket;
+}
+
+export function fetchMasterWebRoot(
+  gameId: AppConfig["activeGame"],
+  opts: FetchMasterOptions = {},
+): Promise<MasterSocketResult> {
+  const { host, port } = ENDPOINTS[gameId];
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const connectFn = opts.connect ?? ((h, p) => net.createConnection(p, h));
+
+  return new Promise<MasterSocketResult>((resolve, reject) => {
+    const socket = connectFn(host, port);
+    const chunks: Buffer[] = [];
+    let settled = false;
+    const finish = (
+      err: MasterSocketError | null,
+      result?: MasterSocketResult,
+    ) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      try {
+        socket.destroy();
+      } catch {
+        // ignore
+      }
+      if (err) reject(err);
+      else if (result) resolve(result);
+    };
+
+    const timer = setTimeout(() => {
+      finish(
+        new MasterSocketError(
+          `master socket timeout (${timeoutMs}ms)`,
+          "timeout",
+        ),
+      );
+    }, timeoutMs);
+
+    socket.once("connect", () => {
+      socket.write(REQUEST_BYTES);
+    });
+
+    socket.on("data", (chunk: Buffer) => {
+      chunks.push(chunk);
+      const merged = Buffer.concat(chunks);
+      if (merged.length < MIN_RESPONSE_LENGTH) return;
+      const urlLen = merged[URL_LENGTH_OFFSET];
+      if (urlLen === 0) {
+        finish(
+          new MasterSocketError(
+            "master returned empty url length",
+            "empty-url",
+          ),
+        );
+        return;
+      }
+      const needed = URL_BYTES_OFFSET + urlLen * 2;
+      if (merged.length < needed) return;
+      const webRoot = merged
+        .subarray(URL_BYTES_OFFSET, needed)
+        .toString("utf16le");
+      if (!webRoot) {
+        finish(
+          new MasterSocketError(
+            "master returned empty url string",
+            "empty-url",
+          ),
+        );
+        return;
+      }
+      finish(null, { webRoot });
+    });
+
+    socket.on("error", (err: NodeJS.ErrnoException) => {
+      const code =
+        err.code === "ECONNREFUSED"
+          ? "connection-refused"
+          : err.code === "ENOTFOUND" || err.code === "EAI_AGAIN"
+            ? "dns"
+            : "unknown";
+      finish(new MasterSocketError(err.message, code));
+    });
+
+    socket.on("close", () => {
+      if (settled) return;
+      const merged = Buffer.concat(chunks);
+      if (merged.length < MIN_RESPONSE_LENGTH) {
+        finish(
+          new MasterSocketError(
+            `master closed connection with short response (${merged.length} bytes)`,
+            "short-response",
+          ),
+        );
+        return;
+      }
+      // If we reach here, length seemed sufficient but data handler did not finish:
+      // treat as short response (length byte advertised more than we received).
+      finish(
+        new MasterSocketError(
+          "master closed before complete response",
+          "short-response",
+        ),
+      );
+    });
+  });
+}

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -243,17 +243,50 @@ function App() {
   } | null>(null);
 
   // === Remote Version State ===
+  // Sources: main process RemoteVersionResolver (master socket -> gh-pages fallback),
+  // refreshed on window focus (10-min TTL). Renderer just listens.
   const [remoteVersions, setRemoteVersions] = useState<RemoteVersions | null>(
     null,
   );
 
   useEffect(() => {
-    VersionService.fetchRemoteVersions().then((versions) => {
-      if (versions) {
-        setRemoteVersions(versions);
-        logger.log("[App] Remote versions loaded:", Object.keys(versions));
-      }
+    const games: AppConfig["activeGame"][] = ["POE1", "POE2"];
+    const applyEntry = (entry: {
+      gameId: AppConfig["activeGame"];
+      webRoot: string;
+      version: string;
+      fetchedAt: number;
+    }) => {
+      setRemoteVersions((prev) => ({
+        ...(prev ?? {}),
+        [entry.gameId]: {
+          version: entry.version,
+          webRoot: entry.webRoot,
+          timestamp: entry.fetchedAt,
+        },
+      }));
+    };
+
+    // Initial resolve (uses cache if fresh, otherwise triggers fetch).
+    Promise.all(
+      games.map((gameId) => window.electronAPI.remoteVersion.resolve(gameId)),
+    ).then((results) => {
+      results.forEach((entry) => {
+        if (entry) applyEntry(entry);
+      });
+      logger.log("[App] Remote versions loaded:", results.filter(Boolean));
     });
+
+    // Push updates when main refreshes the cache (e.g. window regains focus).
+    const unsubscribe = window.electronAPI.remoteVersion.onUpdated(
+      (payload) => {
+        applyEntry(payload);
+      },
+    );
+
+    return () => {
+      unsubscribe?.();
+    };
   }, []);
 
   // Handle Manual Force Repair Request (from SupportLinks)
@@ -626,6 +659,24 @@ function App() {
     // Idle / Error -> Enabled
     return false;
   }, [activeGameStatus, config.activeGame, config.serviceChannel]);
+
+  // Whether the install needs patching: local last-seen version differs from remote latest.
+  // Only meaningful when game is installed and we have both versions.
+  const isUpdateNeeded = useMemo(() => {
+    if (activeGameStatus.status === "uninstalled") return false;
+    const key = `${config.activeGame}_${config.serviceChannel}`;
+    const localVersion = config.knownGameVersions?.[key]?.version;
+    const remoteVersion = remoteVersions?.[config.activeGame]?.version;
+    if (!localVersion || !remoteVersion) return false;
+    if (localVersion === "unknown" || remoteVersion === "unknown") return false;
+    return VersionService.compareVersions(remoteVersion, localVersion) > 0;
+  }, [
+    activeGameStatus.status,
+    config.activeGame,
+    config.serviceChannel,
+    config.knownGameVersions,
+    remoteVersions,
+  ]);
 
   useEffect(() => {
     if (window.electronAPI) {
@@ -1181,7 +1232,9 @@ function App() {
                   label={
                     activeGameStatus.status === "uninstalled"
                       ? "설치하기"
-                      : "게임 시작"
+                      : isUpdateNeeded
+                        ? "업데이트"
+                        : "게임 시작"
                   }
                   className={isButtonDisabled ? "disabled" : ""}
                   style={

--- a/src/renderer/settings/settings-config.ts
+++ b/src/renderer/settings/settings-config.ts
@@ -409,6 +409,10 @@ export const SETTINGS_CONFIG: SettingsCategory[] = [
           {
             id: "theme_mode_poe1",
             type: "select",
+            // Value is stored in remoteThemeSettings.selectedThemes, not in a
+            // top-level config key. defaultValue marks this as not store-backed
+            // for the integrity test.
+            defaultValue: "auto",
             label: "Path of Exile 1 테마",
             description:
               "런처에서 Path of Exile 1 선택 시 적용될 테마를 설정합니다.",
@@ -423,6 +427,7 @@ export const SETTINGS_CONFIG: SettingsCategory[] = [
           {
             id: "theme_mode_poe2",
             type: "select",
+            defaultValue: "auto",
             label: "Path of Exile 2 테마",
             description:
               "런처에서 Path of Exile 2 선택 시 적용될 테마를 설정합니다.",
@@ -786,8 +791,8 @@ export const SETTINGS_CONFIG: SettingsCategory[] = [
             icon: "font_download",
             onClickListener: () => {
               window.dispatchEvent(new CustomEvent("open-font-manager-modal"));
-            }
-          }
+            },
+          },
         ],
       },
       {

--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -161,18 +161,6 @@ export const CONFIG_METADATA: Record<string, ConfigDefinition> = {
     description:
       "원격 테마 관리 시스템의 설정(자동 적용 여부, 선택된 테마 등)을 저장합니다. (자동 관리)",
   },
-  THEME_MODE_POE1: {
-    key: "theme_mode_poe1",
-    name: "POE1 Theme Mode",
-    category: "Appearance",
-    description: "Path of Exile 1에서 사용할 테마를 결정합니다.",
-  },
-  THEME_MODE_POE2: {
-    key: "theme_mode_poe2",
-    name: "POE2 Theme Mode",
-    category: "Appearance",
-    description: "Path of Exile 2에서 사용할 테마를 결정합니다.",
-  },
   PATCH_RESERVATIONS: {
     key: "patchReservations",
     name: "Patch Reservations",
@@ -247,8 +235,6 @@ export const CONFIG_KEYS = {
   GGG_ACCOUNT_ID: CONFIG_METADATA.GGG_ACCOUNT_ID.key,
   KNOWN_GAME_VERSIONS: CONFIG_METADATA.KNOWN_GAME_VERSIONS.key,
   REMOTE_THEME_SETTINGS: CONFIG_METADATA.REMOTE_THEME_SETTINGS.key,
-  THEME_MODE_POE1: CONFIG_METADATA.THEME_MODE_POE1.key,
-  THEME_MODE_POE2: CONFIG_METADATA.THEME_MODE_POE2.key,
   PATCH_RESERVATIONS: CONFIG_METADATA.PATCH_RESERVATIONS.key,
   SILENT_PATCH_NOTIFICATION: CONFIG_METADATA.SILENT_PATCH_NOTIFICATION.key,
   TERMINATE_AFTER_PATCH: CONFIG_METADATA.TERMINATE_AFTER_PATCH.key,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -436,6 +436,27 @@ export interface ElectronAPI {
 
   // [Font Management]
   font: FontAPI;
+
+  // [Remote Version] master socket / gh-pages fallback, refreshed on window focus
+  remoteVersion: {
+    resolve: (
+      gameId: AppConfig["activeGame"],
+    ) => Promise<RemoteWebRootPayload | null>;
+    peek: (
+      gameId: AppConfig["activeGame"],
+    ) => Promise<RemoteWebRootPayload | null>;
+    onUpdated: (
+      callback: (payload: RemoteWebRootPayload) => void,
+    ) => () => void;
+  };
+}
+
+export interface RemoteWebRootPayload {
+  gameId: AppConfig["activeGame"];
+  webRoot: string;
+  version: string;
+  source: "master-socket" | "gh-pages";
+  fetchedAt: number;
 }
 
 export type UpdateStatus =

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,5 +7,9 @@ export default defineConfig({
   },
   define: {
     __APP_VERSION__: JSON.stringify("0.0.0-test"),
+    __APP_AUTHOR_EMAIL__: JSON.stringify("test@example.com"),
+    __APP_HASH__: JSON.stringify("test-hash"),
+    __APP_GUID__: JSON.stringify("test-guid"),
+    __PRODUCT_NAME__: JSON.stringify("Test Product"),
   },
 });


### PR DESCRIPTION
## Summary

게임 실행 없이 PoE 서버에서 직접 최신 버전과 webRoot를 조회할 수 있게 만들고, 이를 강제 복구·자동 수정·게임 시작 버튼 상태 표시에 연결.

기존엔 강제 복구가 사용자 수동 갱신 의존인 gh-pages JSON (실측 4 patch 지연)에 의존했고, 자동 수정도 로컬 로그에 `Web root` 라인이 남아있어야만 동작했음. ggpker 오픈소스 분석으로 PoE master patch server에 TCP `[0x01, 0x07]` 한 방으로 webRoot/version을 50ms 안에 받을 수 있음을 확인 → 외부 의존 없이 자체 처리.

## 변경 내역

### `feat(main): 버전 확인 관련 로직 통합 및 고도화 - 1`

- PoE master patch server에 TCP 소켓으로 proto 7 요청을 보내 webRoot와 버전을 직접 조회하는 어댑터 추가 (`patch.pathofexile.com:12995` / `patch.pathofexile2.com:13060`)
- gh-pages `latest-versions.json` 폴백 어댑터 추가 (master 소켓 실패 시 사용)
- `RemoteVersionResolver`: 두 소스를 순차 시도하고 10분 TTL 캐시 + 동시 호출 dedup
- IPC `version:resolveRemote` / `version:peekRemote` 추가, preload `electronAPI.remoteVersion` 노출
- 윈도우 포커스 시 만료된 캐시만 자동 갱신 (백그라운드 폴링 없음, `REMOTE_VERSION_UPDATED` 이벤트 + `remote-version:updated` webContents.send)
- 단위 테스트 17개 (mock 소켓, axios 응답, 폴백·캐시·dedup) + vitest.config 빌드타임 상수 보강 (부수효과로 NewsService 테스트도 복구됨)

### `feat(main): 버전 확인 관련 로직 통합 및 고도화 - 2`

- 강제 복구 모달의 원격 버전 소스를 신규 IPC로 교체. 기존 gh-pages 단독 fetch에서 master 소켓 우선 + gh-pages 폴백으로 자동 격상
- renderer가 `onUpdated` 이벤트를 구독해 윈도우 포커스 시 main이 갱신한 결과를 자동 반영
- 게임 시작 버튼 라벨이 상황별로 분기 — 미설치 시 "설치하기", 로컬 로그 버전과 원격 master 소켓 버전이 다르면 "업데이트", 그 외 "게임 시작"
- `shared/types.ts`에 `ElectronAPI.remoteVersion` 필드 + `RemoteWebRootPayload` 인터페이스 추가

### `feat(main): 버전 확인 관련 로직 통합 및 고도화 - 3`

- `PatchManager.startSelfDiagnosis`(자동 수정 진단)가 로그에서 Web Root를 못 찾았을 때 `RemoteVersionResolver`로 webRoot를 보강하도록 변경. 게임을 한 번도 켜본 적 없는 사용자도 강제 복구 경로에 진입할 수 있게 됨
- `startSelfDiagnosis` 시그니처에 `gameId` 추가. 호출자 3곳(AutoPatchHandler 2건, main.ts 수동 패치 1건) 전부 업데이트
- 폴백 적용 시 source/version을 로그에 남겨 어떤 소스로 복구했는지 추적 가능

### `feat(main): 버전 확인 관련 로직 통합 및 고도화 - 4`

- `masterSocket.integration.test.ts` 추가: 실제 PoE master에 TCP 연결해서 응답 검증
- 도메인 화이트리스트 없이 (1) 응답 수신 (2) http(s) URL 형태 (3) 마지막 path segment가 버전 패턴 (4) 5초 이내 응답만 확인 — 미래에 GGG가 CDN 도메인을 바꿔도 회귀로 잡지 않도록

### `fix(config): 사용하지 않게 된 일부 설정값 정리`

- `settings-config.ts`의 `theme_mode_poe1/poe2` UI 항목은 실제로는 `remoteThemeSettings.selectedThemes`를 우회로 읽고 쓰며, 자기 id를 store key로는 사용하지 않는 dead key였음 (시즌 테마 기능 도입부터 존재)
- `defaultValue: "auto"`를 UI 항목에 명시 — config-integrity 테스트가 store-backed로 오인하던 것을 정상화
- `CONFIG_METADATA` / `CONFIG_KEYS` / `DEFAULT_CONFIG` / `AppConfig`에서 dead key 흔적 제거. 실제로 어떤 코드도 이 키를 직접 읽고 쓰지 않아 회귀 없음

## 외부 자료

- ggpker `check-version.ts` (분석 시점 영구 링크): https://github.com/ggpk-exposed/ggpker/blob/aadc15ad584fa512bfb8c6fb6511f43f243c0f71/src/check-version.ts
  - 본 PR 작업 직후(2026-05-24) ggpker 측 리팩토링으로 이 파일은 삭제되고 소켓 호출 로직이 index-server(별도 Rust 서비스)로 이동했음. 우리 구현에 영향 없음 (프로토콜/호스트/포트는 동일).
- 게임 클라이언트 로그에도 `Send patching protocol version 7` 라인이 찍혀 proto 7이 표준임을 확인
