### PR TITLE
chore: 로드맵 공지와 캡처 스킬 정리

### DIFF
--- a/.agents/skills/roadmap-capture/SKILL.md
+++ b/.agents/skills/roadmap-capture/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: roadmap-capture
+description: Use when a user says a feature, bug fix, experiment, or follow-up can wait, should be done later, belongs on the roadmap/backlog, or asks to add/update Roadmap items. Ask for priority when missing, update docs/Roadmap.md as the source of truth, add docs/roadmap refs when useful, and validate issue/notice generation.
+---
+
+# Skill: Roadmap Capture
+
+## Instructions
+
+Use this skill when a development discussion produces deferred work such as
+"나중에 하자", "추후", "로드맵에 넣자", "backlog", or "TODO로 남기자".
+
+1. Capture the deferred item in plain user-facing wording.
+2. If the user did not specify priority, ask for one priority before editing:
+   `P0` stability/operation, `P1` execution/notification/update, `P2` user-facing expansion, or `P3` long-term review.
+3. Update `docs/Roadmap.md`; this is the single source of truth.
+4. Add the item under the selected priority as a checklist entry.
+5. If the item needs more than one sentence of detail, create or update
+   `docs/roadmap/<kebab-case-topic>.md` and append
+   `([ref](roadmap/<kebab-case-topic>.md))` to the checklist item.
+6. Do not manually edit GitHub Issue #7. The sync workflow strips `ref` links
+   and pushes the checklist-only body.
+7. Do not manually edit the `gh-pages` notice files. The notice workflow builds
+   `notice/[notice]roadmap.md` from `docs/Roadmap.md`.
+8. For completed roadmap work, move the checked item to the `완료됨` section
+   instead of leaving it in its old priority bucket.
+
+## Validation
+
+After editing Roadmap content, validate the generated outputs:
+
+```bash
+npm run roadmap:issue-body
+npm run roadmap:notice
+```
+
+In this Windows-first repo, run npm scripts from Windows PowerShell as described
+in `AGENTS.md`.
+
+## Examples
+
+- User: "자동화 실패 판정은 나중에 하자"
+  - Ask for priority if missing.
+  - Add a checklist item under the selected priority.
+  - Create a detail ref only if the discussion includes enough policy or design
+    detail to preserve.
+- User: "이건 P1로 로드맵에 넣어"
+  - Add it directly under `## P1 - 실행, 알림, 업데이트`.

--- a/.github/workflows/sync-roadmap-notice.yml
+++ b/.github/workflows/sync-roadmap-notice.yml
@@ -34,13 +34,14 @@ jobs:
           node-version: "24"
 
       - name: Build roadmap notice
-        run: node scripts/build-roadmap-notice.cjs --output gh-pages/notice/roadmap.md
+        run: node scripts/build-roadmap-notice.cjs --output 'gh-pages/notice/[notice]roadmap.md'
 
       - name: Commit and push roadmap notice
         working-directory: gh-pages
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add notice/roadmap.md
-          git commit -m "docs: update roadmap notice [skip ci]" || echo "No changes to commit"
+          git add 'notice/[notice]roadmap.md'
+          git rm -f --ignore-unmatch 'notice/[notice]PoE & PoE 2 Unofficial Launcher 로드맵 공지.md' 'notice/roadmap.md'
+          git commit -m "docs: update roadmap notice" || echo "No changes to commit"
           git push origin gh-pages

--- a/docs/roadmap/developer-roadmap-notice.md
+++ b/docs/roadmap/developer-roadmap-notice.md
@@ -22,9 +22,11 @@ Roadmap 공지를 별도로 직접 편집하면 `docs/Roadmap.md`, GitHub Issue 
   - `--output`으로 출력 경로를 지정할 수 있다.
 - `.github/workflows/sync-roadmap-notice.yml`
   - `master` 브랜치에서 Roadmap 공지 생성에 필요한 파일이 변경되면 실행된다.
-  - 생성된 md를 `gh-pages` 브랜치의 `notice/roadmap.md`로 교체한다.
+  - 생성된 md를 `gh-pages` 브랜치의 `notice/[notice]roadmap.md`로 교체한다.
+  - 기존 `notice/[notice]PoE & PoE 2 Unofficial Launcher 로드맵 공지.md`와 `notice/roadmap.md`는 제거한다.
+  - 이 커밋은 `gh-pages`의 공지 목록 생성 workflow를 실행해야 하므로 `[skip ci]`를 붙이지 않는다.
 - `.github/workflows/automate-notice-list.yml`
-  - `gh-pages` 브랜치에서 `notice/roadmap.md` 변경을 감지해 `notice/list.json`을 재생성한다.
+  - `gh-pages` 브랜치에서 `notice/*.md` 변경을 감지해 `notice/list.json`을 재생성한다.
 - `npm run roadmap:notice`
   - 로컬에서 개발자 공지용 Roadmap md를 확인할 때 사용한다.
 
@@ -33,4 +35,4 @@ Roadmap 공지를 별도로 직접 편집하면 `docs/Roadmap.md`, GitHub Issue 
 - [x] 개발자 공지 Roadmap 템플릿 추가
 - [x] Roadmap 체크리스트 주입 지점 주석 추가
 - [x] Roadmap 공지 생성 스크립트 추가
-- [x] gh-pages `notice/roadmap.md` 갱신 workflow 추가
+- [x] gh-pages `notice/[notice]roadmap.md` 갱신 workflow 추가

--- a/docs/roadmap/developer-roadmap-notice.template.md
+++ b/docs/roadmap/developer-roadmap-notice.template.md
@@ -1,4 +1,4 @@
-# PoE & PoE 2 Unofficial Launcher 로드맵
+# PoE & PoE 2 Unofficial Launcher 로드맵 공지
 
 런처 개발 로드맵은 버전 단위 약속 대신 우선순위 기준으로 관리합니다.
 완료된 항목은 하단으로 이동하며, 진행 순서는 서비스 안정성과 사용자 영향도를 기준으로 조정될 수 있습니다.


### PR DESCRIPTION
## Summary
- Sync the generated Roadmap developer notice to `notice/[notice]roadmap.md` and remove stale Roadmap notice filenames from `gh-pages` during sync.
- Keep the notice sync commit eligible for the `gh-pages` notice list workflow so `notice/list.json` can be regenerated.
- Add a repo skill that captures deferred development items into `docs/Roadmap.md` after confirming priority.

## Motivation
Roadmap management belongs in the master source tree. The launcher notice and GitHub Issue sync should be generated from the same `docs/Roadmap.md` source, and future deferred work should be recorded through the same priority-based roadmap process.
