### PR TITLE
fix: 게임 실행 중 업데이트 표시가 남지 않게 수정

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -49,6 +49,7 @@ import TitleBar from "./components/TitleBar";
 import UpdateModal from "./components/UpdateModal";
 import { useGameState } from "./contexts/GameStateContext";
 import { VersionService, RemoteVersions } from "./services/VersionService";
+import { getGameStartButtonLabel } from "./utils/game-start-label";
 import { logger } from "./utils/logger";
 import { applyThemeColors, DEFAULT_THEME_COLORS } from "./utils/theme";
 
@@ -726,6 +727,11 @@ function App() {
     remoteVersions,
   ]);
 
+  const gameStartButtonLabel = useMemo(
+    () => getGameStartButtonLabel(activeGameStatus.status, isUpdateNeeded),
+    [activeGameStatus.status, isUpdateNeeded],
+  );
+
   useEffect(() => {
     if (window.electronAPI) {
       // 1. Initial Load
@@ -1368,13 +1374,7 @@ function App() {
 
                 <GameStartButton
                   onClick={handleGameStart}
-                  label={
-                    activeGameStatus.status === "uninstalled"
-                      ? "설치하기"
-                      : isUpdateNeeded
-                        ? "업데이트"
-                        : "게임 시작"
-                  }
+                  label={gameStartButtonLabel}
                   className={isButtonDisabled ? "disabled" : ""}
                   style={
                     isButtonDisabled

--- a/src/renderer/utils/game-start-label.test.ts
+++ b/src/renderer/utils/game-start-label.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getGameStartButtonLabel,
+  shouldShowUpdateLabel,
+} from "./game-start-label";
+import { RunStatus } from "../../shared/types";
+
+const launchActiveStatuses: RunStatus[] = [
+  "preparing",
+  "processing",
+  "authenticating",
+  "ready",
+  "running",
+];
+
+describe("game start button label", () => {
+  it("shows install label when the selected game is not installed", () => {
+    expect(getGameStartButtonLabel("uninstalled", true)).toBe("설치하기");
+    expect(shouldShowUpdateLabel("uninstalled", true)).toBe(false);
+  });
+
+  it("shows update label only while the launcher can present a version action", () => {
+    expect(getGameStartButtonLabel("idle", true)).toBe("업데이트");
+    expect(getGameStartButtonLabel("error", true)).toBe("업데이트");
+    expect(getGameStartButtonLabel("stopping", true)).toBe("업데이트");
+  });
+
+  it("does not show update label while game launch or play is already active", () => {
+    for (const status of launchActiveStatuses) {
+      expect(getGameStartButtonLabel(status, true)).toBe("게임 시작");
+      expect(shouldShowUpdateLabel(status, true)).toBe(false);
+    }
+  });
+
+  it("returns game start label when no update is needed", () => {
+    expect(getGameStartButtonLabel("idle", false)).toBe("게임 시작");
+    expect(getGameStartButtonLabel("running", false)).toBe("게임 시작");
+  });
+});

--- a/src/renderer/utils/game-start-label.ts
+++ b/src/renderer/utils/game-start-label.ts
@@ -1,0 +1,29 @@
+import { RunStatus } from "../../shared/types";
+
+const UPDATE_LABEL_SUPPRESSED_STATUSES: RunStatus[] = [
+  "preparing",
+  "processing",
+  "authenticating",
+  "ready",
+  "running",
+];
+
+export const shouldShowUpdateLabel = (
+  status: RunStatus,
+  isUpdateNeeded: boolean,
+) => {
+  return (
+    isUpdateNeeded &&
+    status !== "uninstalled" &&
+    !UPDATE_LABEL_SUPPRESSED_STATUSES.includes(status)
+  );
+};
+
+export const getGameStartButtonLabel = (
+  status: RunStatus,
+  isUpdateNeeded: boolean,
+) => {
+  if (status === "uninstalled") return "설치하기";
+  if (shouldShowUpdateLabel(status, isUpdateNeeded)) return "업데이트";
+  return "게임 시작";
+};


### PR DESCRIPTION
## Summary
- 게임 실행 준비, 인증, 실행 중 상태에서는 업데이트 필요 여부가 감지되어도 게임 시작 버튼 문구를 `게임 시작`으로 유지합니다.
- 버튼 문구 판단을 renderer helper로 분리하고 상태별 단위 테스트를 추가했습니다.

## Motivation
업데이트 감지는 버전 비교 기준으로 유지하되, 사용자가 이미 게임을 실행 중인 disabled 버튼에서 `업데이트` 문구를 보는 혼선을 줄이기 위한 변경입니다.