### PR TITLE
fix: 설치 경로 확인 차단 및 새로고침 시간 표시 개선

### DIFF
--- a/src/main/events/handlers/GameInstallCheckHandler.ts
+++ b/src/main/events/handlers/GameInstallCheckHandler.ts
@@ -1,6 +1,6 @@
 import { AppConfig } from "../../../shared/types";
 import { logger } from "../../utils/logger";
-import { isGameInstalled } from "../../utils/registry";
+import { getGameInstallationStatus } from "../../utils/registry";
 import { eventBus } from "../EventBus";
 import {
   AppContext,
@@ -32,7 +32,10 @@ export const GameInstallCheckHandler: EventHandler<ConfigChangeEvent> = {
       `[GameInstallCheckHandler] Checking installation for ${activeGame} (${serviceChannel})...`,
     );
 
-    const installed = await isGameInstalled(serviceChannel, activeGame);
+    const installationStatus = await getGameInstallationStatus(
+      serviceChannel,
+      activeGame,
+    );
 
     // [Fix] Check if the game is already RUNNING before resetting to 'idle'
     // This prevents status flickering or resetting when switching tabs while game is open.
@@ -92,7 +95,15 @@ export const GameInstallCheckHandler: EventHandler<ConfigChangeEvent> = {
       {
         gameId: activeGame,
         serviceId: serviceChannel,
-        status: installed ? "idle" : "uninstalled",
+        status:
+          installationStatus === "uninstalled"
+            ? "uninstalled"
+            : installationStatus === "unknown"
+              ? "install_check_blocked"
+              : "idle",
+        ...(installationStatus === "unknown"
+          ? { errorCode: "INSTALL_CHECK_UNKNOWN" }
+          : {}),
       },
     );
   },

--- a/src/main/game/GameSessionTracker.ts
+++ b/src/main/game/GameSessionTracker.ts
@@ -50,7 +50,10 @@ export class GameSessionTracker {
 
     if (
       isCurrentContext &&
-      (status === "idle" || status === "error" || status === "uninstalled")
+      (status === "idle" ||
+        status === "error" ||
+        status === "uninstalled" ||
+        status === "install_check_blocked")
     ) {
       this.clear();
     }

--- a/src/main/kakao/automation-page-dump.ts
+++ b/src/main/kakao/automation-page-dump.ts
@@ -113,7 +113,11 @@ export async function handleAutomationDumpGameStatus(status: GameStatusState) {
     return;
   }
 
-  if (status.status === "idle" || status.status === "uninstalled") {
+  if (
+    status.status === "idle" ||
+    status.status === "uninstalled" ||
+    status.status === "install_check_blocked"
+  ) {
     await discardAutomationDumpSession(`status-${status.status}`);
   }
 }

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -102,8 +102,11 @@ import {
 } from "./utils/logger";
 import { LogParser } from "./utils/LogParser";
 import { PowerShellManager } from "./utils/powershell";
-import { getGameInstallPath, isGameInstalled } from "./utils/registry";
-import { syncInstallLocation } from "./utils/registry";
+import {
+  getGameInstallPath,
+  getGameInstallationStatus,
+  syncInstallLocation,
+} from "./utils/registry";
 import { RemoteVersionResolver } from "./utils/RemoteVersionResolver";
 import { LegacyUacManager, SimpleUacBypass } from "./utils/uac/uac-migration";
 import {
@@ -2063,7 +2066,7 @@ async function createWindow() {
     logger.log("[Main] Checking initial status for all game contexts...");
 
     for (const combo of combinations) {
-      const installed = await isGameInstalled(
+      const installationStatus = await getGameInstallationStatus(
         combo.service as AppConfig["serviceChannel"],
         combo.game as AppConfig["activeGame"],
       );
@@ -2074,7 +2077,15 @@ async function createWindow() {
         {
           gameId: combo.game as AppConfig["activeGame"],
           serviceId: combo.service as AppConfig["serviceChannel"],
-          status: installed ? "idle" : "uninstalled",
+          status:
+            installationStatus === "uninstalled"
+              ? "uninstalled"
+              : installationStatus === "unknown"
+                ? "install_check_blocked"
+                : "idle",
+          ...(installationStatus === "unknown"
+            ? { errorCode: "INSTALL_CHECK_UNKNOWN" }
+            : {}),
         },
       );
     }

--- a/src/main/services/NewsService.ts
+++ b/src/main/services/NewsService.ts
@@ -44,6 +44,7 @@ type NewsRefreshSource =
 type FetchResult = {
   items: NewsItem[];
   changed: boolean;
+  refreshed: boolean;
 };
 
 const DEV_NOTICE_KEY = "dev-notice";
@@ -149,9 +150,10 @@ export class NewsService {
       dueSources.map((source) => this.refreshSource(source)),
     );
     const changed = results.some((result) => result.changed);
+    const refreshed = results.some((result) => result.refreshed);
 
     this.hasPendingRefresh = false;
-    if (changed) {
+    if (refreshed) {
       this.emitUpdated();
     }
 
@@ -347,11 +349,15 @@ export class NewsService {
     const key = this.getForumKey(game, service, category);
     const url = NEWS_URL_MAP[key];
 
-    if (!url) return { items: [], changed: false };
+    if (!url) return { items: [], changed: false, refreshed: false };
 
     if (this.fetchLock.has(key)) {
       this.logger.log(`Fetch already in progress for ${key}. Skipping.`);
-      return { items: this.getCacheItems(key), changed: false };
+      return {
+        items: this.getCacheItems(key),
+        changed: false,
+        refreshed: false,
+      };
     }
 
     this.fetchLock.add(key);
@@ -435,10 +441,14 @@ export class NewsService {
         `Successfully fetched ${category} for ${service}-${game}.`,
       );
       this.markRefreshed(key);
-      return { items, changed: isChanged };
+      return { items, changed: isChanged, refreshed: true };
     } catch (error) {
       this.logger.error(`Failed to fetch news list for ${key}:`, error);
-      return { items: this.getCacheItems(key), changed: false };
+      return {
+        items: this.getCacheItems(key),
+        changed: false,
+        refreshed: false,
+      };
     } finally {
       this.fetchLock.delete(key);
     }
@@ -454,11 +464,15 @@ export class NewsService {
   ): Promise<FetchResult> {
     const notify = options.notify ?? true;
     const url = NEWS_URL_MAP["dev-notice"];
-    if (!url) return { items: [], changed: false };
+    if (!url) return { items: [], changed: false, refreshed: false };
 
     if (this.fetchLock.has(DEV_NOTICE_KEY)) {
       this.logger.log("Fetch already in progress for dev-notice. Skipping.");
-      return { items: this.getCacheItems(DEV_NOTICE_KEY), changed: false };
+      return {
+        items: this.getCacheItems(DEV_NOTICE_KEY),
+        changed: false,
+        refreshed: false,
+      };
     }
 
     this.fetchLock.add(DEV_NOTICE_KEY);
@@ -472,7 +486,11 @@ export class NewsService {
 
       if (!Array.isArray(data)) {
         this.logger.warn("Dev notices data is not an array.");
-        return { items: this.getCacheItems(DEV_NOTICE_KEY), changed: false };
+        return {
+          items: this.getCacheItems(DEV_NOTICE_KEY),
+          changed: false,
+          refreshed: false,
+        };
       }
 
       const items: NewsItem[] = data.map(
@@ -523,10 +541,14 @@ export class NewsService {
         if (notify) this.emitUpdated();
       }
 
-      return { items: sortedItems, changed: isChanged };
+      return { items: sortedItems, changed: isChanged, refreshed: true };
     } catch (error) {
       this.logger.error("Failed to fetch dev notices:", error);
-      return { items: this.getCacheItems(DEV_NOTICE_KEY), changed: false };
+      return {
+        items: this.getCacheItems(DEV_NOTICE_KEY),
+        changed: false,
+        refreshed: false,
+      };
     } finally {
       this.fetchLock.delete(DEV_NOTICE_KEY);
     }

--- a/src/main/tests/GameInstallCheckHandler.test.ts
+++ b/src/main/tests/GameInstallCheckHandler.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { eventBus } from "../events/EventBus";
+import { GameInstallCheckHandler } from "../events/handlers/GameInstallCheckHandler";
+import {
+  EventType,
+  type AppContext,
+  type ConfigChangeEvent,
+} from "../events/types";
+import { getGameInstallationStatus } from "../utils/registry";
+
+const mocks = vi.hoisted(() => ({
+  getGameInstallationStatus: vi.fn(),
+}));
+
+vi.mock("../events/EventBus", () => ({
+  eventBus: {
+    emit: vi.fn(),
+  },
+}));
+
+vi.mock("../utils/registry", () => ({
+  getGameInstallationStatus: mocks.getGameInstallationStatus,
+}));
+
+const configChangeEvent: ConfigChangeEvent = {
+  type: EventType.CONFIG_CHANGE,
+  payload: {
+    key: "activeGame",
+    oldValue: "POE1",
+    newValue: "POE2",
+  },
+};
+
+describe("GameInstallCheckHandler", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("emits a blocked install-check status when installation status is unknown", async () => {
+    vi.mocked(getGameInstallationStatus).mockResolvedValue("unknown");
+
+    const context = {
+      getConfig: vi.fn(() => ({
+        activeGame: "POE2",
+        serviceChannel: "Kakao Games",
+      })),
+      processWatcher: {
+        isProcessRunning: vi.fn(() => false),
+      },
+    } as unknown as AppContext;
+
+    await GameInstallCheckHandler.handle(configChangeEvent, context);
+
+    expect(eventBus.emit).toHaveBeenCalledWith(
+      EventType.GAME_STATUS_CHANGE,
+      context,
+      {
+        gameId: "POE2",
+        serviceId: "Kakao Games",
+        status: "install_check_blocked",
+        errorCode: "INSTALL_CHECK_UNKNOWN",
+      },
+    );
+  });
+});

--- a/src/main/tests/GameStatusStore.test.ts
+++ b/src/main/tests/GameStatusStore.test.ts
@@ -38,10 +38,11 @@ describe("GameStatusStore", () => {
     expect(getGameStatus("POE2", "Kakao Games")).toEqual(status);
   });
 
-  it("identifies launch states that keep the start button blocked", () => {
+  it("identifies statuses that keep a launch session active", () => {
     expect(isLaunchBlockingStatus("ready")).toBe(true);
     expect(isLaunchBlockingStatus("running")).toBe(true);
     expect(isLaunchBlockingStatus("stopping")).toBe(false);
+    expect(isLaunchBlockingStatus("install_check_blocked")).toBe(false);
     expect(isLaunchBlockingStatus("idle")).toBe(false);
   });
 

--- a/src/main/tests/NewsService.test.ts
+++ b/src/main/tests/NewsService.test.ts
@@ -162,13 +162,15 @@ describe("NewsService", () => {
     expect(onUpdated).not.toHaveBeenCalled();
 
     vi.setSystemTime(new Date(Date.now() + NEWS_REFRESH_INTERVAL));
-    await service.refreshDue({
+    const unchangedDueRefresh = await service.refreshDue({
       game: "POE2",
       service: "GGG",
       reason: "due-again",
     });
 
+    expect(unchangedDueRefresh).toBe(false);
     expect(globalThis.fetch).toHaveBeenCalledTimes(3);
+    expect(onUpdated).toHaveBeenCalledTimes(1);
     expect(service.getLastUpdatedAt("GGG-POE2-notice")).toBe(Date.now());
   });
 

--- a/src/main/tests/powershell-blocked.test.ts
+++ b/src/main/tests/powershell-blocked.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  isPowerShellBlockedReason,
+  PowerShellBlockedException,
+  PowerShellManager,
+} from "../utils/powershell";
+
+type PendingResponse = {
+  stdout: string;
+  stderr: string;
+  code: number | null;
+};
+
+type PendingCallback = (res: PendingResponse) => void;
+type PowerShellSession = Parameters<PowerShellManager["executeCommand"]>[1];
+
+describe("PowerShell blocked diagnostics", () => {
+  it("detects OS-level spawn permission failures", () => {
+    const error = Object.assign(new Error("spawn EPERM"), { code: "EPERM" });
+
+    expect(isPowerShellBlockedReason(error)).toBe(true);
+  });
+
+  it("detects common Windows policy block messages", () => {
+    expect(
+      isPowerShellBlockedReason(
+        "This program is blocked by group policy. For more information, contact your system administrator.",
+      ),
+    ).toBe(true);
+    expect(
+      isPowerShellBlockedReason(
+        "File cannot be loaded because running scripts is disabled on this system.",
+      ),
+    ).toBe(true);
+    expect(isPowerShellBlockedReason("액세스가 거부되었습니다.")).toBe(true);
+    expect(
+      isPowerShellBlockedReason(
+        "이 시스템에서 스크립트를 실행할 수 없으므로 파일을 로드할 수 없습니다.",
+      ),
+    ).toBe(true);
+  });
+
+  it("includes likely security causes in the thrown error", () => {
+    const error = new PowerShellBlockedException("spawn EPERM");
+
+    expect(error.name).toBe("PowerShellBlockedException");
+    expect(error.message).toContain("백신/EDR");
+    expect(error.message).toContain("Windows 보안 정책");
+    expect(error.message).toContain("spawn EPERM");
+  });
+
+  it("throws when a PowerShell command result indicates a policy block", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    const session = {
+      server: {},
+      socket: {
+        destroyed: false,
+        write: vi.fn((_payload: string, callback?: (error?: Error) => void) => {
+          callback?.();
+        }),
+      },
+      process: null,
+      pendingRequests: new Map<string, PendingCallback>(),
+      pipePath: null,
+      initializing: null,
+      rejectInit: undefined,
+    } as unknown as PowerShellSession & {
+      pendingRequests: Map<string, PendingCallback>;
+    };
+
+    const result = PowerShellManager.getInstance().executeCommand(
+      "Get-Item HKCU:\\Software",
+      session,
+      false,
+      true,
+    );
+    await Promise.resolve();
+    const callback = [...session.pendingRequests.values()][0];
+    if (!callback) throw new Error("PowerShell request was not queued.");
+
+    callback({
+      stdout: "",
+      stderr: "This program is blocked by group policy.",
+      code: 1,
+    });
+
+    await expect(result).rejects.toThrow(PowerShellBlockedException);
+    expect(consoleError).toHaveBeenCalledWith(
+      expect.stringContaining("[process_normal]"),
+      expect.stringContaining("백신/EDR"),
+    );
+
+    consoleError.mockRestore();
+  });
+});

--- a/src/main/tests/registry-install-status.test.ts
+++ b/src/main/tests/registry-install-status.test.ts
@@ -1,0 +1,146 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getGameInstallationStatus, isGameInstalled } from "../utils/registry";
+
+import type { ChildProcess } from "node:child_process";
+
+const mocks = vi.hoisted(() => ({
+  execFile: vi.fn(),
+  stat: vi.fn(),
+  powershellExecute: vi.fn(),
+  loggerWarn: vi.fn(),
+}));
+
+vi.mock("node:child_process", () => ({
+  default: {
+    execFile: mocks.execFile,
+  },
+  execFile: mocks.execFile,
+}));
+
+vi.mock("node:fs/promises", () => ({
+  default: {
+    stat: mocks.stat,
+  },
+}));
+
+vi.mock("electron", () => ({
+  app: {
+    getPath: vi.fn(() => "C:\\test\\app.exe"),
+    isPackaged: false,
+  },
+}));
+
+vi.mock("../utils/logger", () => ({
+  logger: {
+    warn: mocks.loggerWarn,
+    error: vi.fn(),
+    log: vi.fn(),
+  },
+}));
+
+vi.mock("../utils/powershell", () => ({
+  PowerShellManager: {
+    getInstance: () => ({
+      execute: mocks.powershellExecute,
+    }),
+  },
+}));
+
+type RegQueryCallback = (
+  error: (Error & { code?: number | string }) | null,
+  stdout: string,
+  stderr: string,
+) => void;
+
+type RegQueryImplementation = (
+  command: string,
+  args: string[],
+  options: { windowsHide?: boolean; timeout?: number },
+  callback: RegQueryCallback,
+) => ChildProcess;
+
+const mockRegQuery = (implementation: RegQueryImplementation) => {
+  mocks.execFile.mockImplementation(implementation);
+};
+
+describe("registry install status", () => {
+  beforeEach(() => {
+    mocks.execFile.mockReset();
+    mocks.stat.mockReset();
+    mocks.powershellExecute.mockReset();
+    mocks.loggerWarn.mockClear();
+    mocks.powershellExecute.mockResolvedValue({
+      stdout: "",
+      stderr: "",
+      code: 0,
+    });
+  });
+
+  it("falls back to reg.exe when the PowerShell session cannot start", async () => {
+    const installPath = String.raw`C:\Games\Path of Exile 2`;
+    mocks.powershellExecute.mockRejectedValue(new Error("spawn EPERM"));
+    mockRegQuery((_command, args, _options, callback) => {
+      expect(args).toEqual([
+        "query",
+        "HKCU\\Software\\DaumGames\\POE2",
+        "/v",
+        "InstallPath",
+      ]);
+      callback(
+        null,
+        `
+HKEY_CURRENT_USER\\Software\\DaumGames\\POE2
+    InstallPath    REG_SZ    ${installPath}
+`,
+        "",
+      );
+      return {} as ChildProcess;
+    });
+    mocks.stat.mockResolvedValue({ isDirectory: () => true });
+
+    await expect(
+      getGameInstallationStatus("Kakao Games", "POE2"),
+    ).resolves.toBe("installed");
+    await expect(isGameInstalled("Kakao Games", "POE2")).resolves.toBe(true);
+
+    expect(mocks.stat).toHaveBeenCalledWith(installPath);
+  });
+
+  it("returns unknown instead of uninstalled when registry access fails", async () => {
+    mocks.powershellExecute.mockRejectedValue(new Error("spawn EPERM"));
+    mockRegQuery((_command, _args, _options, callback) => {
+      callback(
+        Object.assign(new Error("spawn EPERM"), { code: "EPERM" }),
+        "",
+        "spawn EPERM",
+      );
+      return {} as ChildProcess;
+    });
+
+    await expect(
+      getGameInstallationStatus("Kakao Games", "POE2"),
+    ).resolves.toBe("unknown");
+    await expect(isGameInstalled("Kakao Games", "POE2")).resolves.toBe(false);
+
+    expect(mocks.stat).not.toHaveBeenCalled();
+    expect(mocks.loggerWarn).toHaveBeenCalledWith(
+      expect.stringContaining("Could not determine installation status"),
+    );
+  });
+
+  it("returns uninstalled when the registry value is absent", async () => {
+    mocks.powershellExecute.mockResolvedValue({
+      stdout: "",
+      stderr: "",
+      code: 0,
+    });
+
+    await expect(
+      getGameInstallationStatus("Kakao Games", "POE2"),
+    ).resolves.toBe("uninstalled");
+
+    expect(mocks.execFile).not.toHaveBeenCalled();
+    expect(mocks.stat).not.toHaveBeenCalled();
+  });
+});

--- a/src/main/utils/powershell.ts
+++ b/src/main/utils/powershell.ts
@@ -12,6 +12,62 @@ export class UACDeniedException extends Error {
   }
 }
 
+const POWERSHELL_BLOCKED_GUIDANCE =
+  "PowerShell 실행이 Windows에 의해 거부되었거나 명령이 보안 정책으로 차단되었습니다. 백신/EDR 또는 Windows 보안 정책(AppLocker, WDAC, 그룹 정책, Defender ASR 등)이 원인일 수 있습니다.";
+
+type ProcessError = Error & {
+  code?: string | number;
+};
+
+export class PowerShellBlockedException extends Error {
+  constructor(reason: string, cause?: unknown) {
+    super(`${POWERSHELL_BLOCKED_GUIDANCE} 원본 오류: ${reason}`);
+    this.name = "PowerShellBlockedException";
+    if (cause !== undefined) {
+      (this as Error & { cause?: unknown }).cause = cause;
+    }
+  }
+}
+
+const formatUnknownError = (error: unknown): string => {
+  if (error instanceof Error) return error.message;
+  return String(error);
+};
+
+export const isPowerShellBlockedReason = (reason: unknown): boolean => {
+  const code =
+    typeof reason === "object" && reason !== null && "code" in reason
+      ? String((reason as ProcessError).code).toUpperCase()
+      : "";
+  if (code === "EPERM" || code === "EACCES") return true;
+
+  const text = formatUnknownError(reason).toLowerCase();
+  return (
+    text.includes("eperm") ||
+    text.includes("eacces") ||
+    text.includes("access is denied") ||
+    text.includes("access denied") ||
+    text.includes("permission denied") ||
+    text.includes("operation not permitted") ||
+    text.includes("blocked by group policy") ||
+    text.includes("blocked by your system administrator") ||
+    text.includes("disabled on this system") ||
+    text.includes("running scripts is disabled") ||
+    text.includes("unauthorizedaccessexception") ||
+    text.includes("액세스가 거부") ||
+    text.includes("그룹 정책") ||
+    text.includes("시스템 관리자") ||
+    text.includes("스크립트를 실행할 수 없")
+  );
+};
+
+const createPowerShellBlockedException = (
+  reason: unknown,
+  cause?: unknown,
+): PowerShellBlockedException => {
+  return new PowerShellBlockedException(formatUnknownError(reason), cause);
+};
+
 interface PSResult {
   stdout: string;
   stderr: string;
@@ -128,6 +184,10 @@ export class PowerShellManager {
         // 이미 child exit handler에서 warn을 남겼지만 호출부에서도 명확히 에러로 처리
         throw err;
       }
+      if (err instanceof PowerShellBlockedException) {
+        logger.error(err.message);
+        throw err;
+      }
       const msg = `Failed to establish connection to PowerShell session: ${err instanceof Error ? err.message : String(err)}`;
       logger.error(msg);
       return { stdout: "", stderr: msg, code: 1 };
@@ -147,7 +207,7 @@ export class PowerShellManager {
     const id = randomUUID();
     const request: IPCRequest = { id, command };
 
-    return new Promise<PSResult>((resolve) => {
+    return new Promise<PSResult>((resolve, reject) => {
       const timeoutMs = isAdmin ? 30000 : 10000;
       const timeout = setTimeout(() => {
         if (session.pendingRequests.has(id)) {
@@ -164,6 +224,14 @@ export class PowerShellManager {
 
       session.pendingRequests.set(id, (res) => {
         clearTimeout(timeout);
+        if (isPowerShellBlockedReason(res.stderr || res.stdout)) {
+          const blockedError = createPowerShellBlockedException(
+            res.stderr || res.stdout,
+          );
+          logger.error(blockedError.message);
+          reject(blockedError);
+          return;
+        }
         // Log Result
         if (silent) {
           if (res.stdout) logger.silent().log(res.stdout.trim());
@@ -280,32 +348,35 @@ export class PowerShellManager {
 
           // Initialization Complete
           session.initializing = null;
+          session.rejectInit = undefined;
           resolve();
         });
 
         session.server.listen(session.pipePath, () => {
           this.spawnProcess(session, isAdmin, pipeName).catch((err) => {
             this.cleanupSession(session);
-            // Ensure promise rejects and clears initializing
-            session.initializing = null;
-            if (session.rejectInit) session.rejectInit(err);
-            else reject(err);
+            this.rejectSessionInitialization(session, err);
           });
         });
 
         session.server.on("error", (err) => {
-          session.initializing = null;
-          if (session.rejectInit) session.rejectInit(err);
-          else reject(err);
+          this.rejectSessionInitialization(session, err);
         });
       } catch (e) {
-        session.initializing = null;
-        if (session.rejectInit) session.rejectInit(e);
-        else reject(e);
+        this.rejectSessionInitialization(session, e);
       }
     });
 
     return session.initializing;
+  }
+
+  private rejectSessionInitialization(session: SessionState, reason: unknown) {
+    const rejectInit = session.rejectInit;
+    session.initializing = null;
+    session.rejectInit = undefined;
+    if (rejectInit) {
+      rejectInit(reason);
+    }
   }
 
   private async spawnProcess(
@@ -426,10 +497,22 @@ try {
     session.process = child;
 
     child.on("error", (err) => {
-      logger.error(
-        `Failed to spawn ${isAdmin ? "Admin" : "Normal"} process:`,
-        err,
-      );
+      const reason = `Failed to spawn ${isAdmin ? "Admin" : "Normal"} PowerShell process: ${formatUnknownError(err)}`;
+      const error = isPowerShellBlockedReason(err)
+        ? createPowerShellBlockedException(reason, err)
+        : new Error(reason);
+      const wasInitializing = !!session.initializing;
+
+      if (session.server) {
+        session.server.close();
+        session.server = null;
+      }
+      session.process = null;
+      this.rejectSessionInitialization(session, error);
+      if (!wasInitializing) {
+        logger.error(error.message);
+      }
+      this.failAllPendingRequests(session, isAdmin, formatUnknownError(error));
     });
 
     child.on("exit", (code) => {
@@ -447,17 +530,13 @@ try {
       if (isAdmin && code === 1223) {
         logger.warn("UAC prompt was canceled by the user.");
         const uacErr = new UACDeniedException();
-        if (session.rejectInit) {
-          session.rejectInit(uacErr);
-        }
+        this.rejectSessionInitialization(session, uacErr);
         this.failAllPendingRequests(session, isAdmin, uacErr.message);
         return;
       }
 
       const errMsg = `Process exited with code ${code}`;
-      if (session.rejectInit) {
-        session.rejectInit(new Error(errMsg));
-      }
+      this.rejectSessionInitialization(session, new Error(errMsg));
       this.failAllPendingRequests(session, isAdmin, errMsg);
     });
   }

--- a/src/main/utils/registry.ts
+++ b/src/main/utils/registry.ts
@@ -1,3 +1,4 @@
+import { execFile } from "node:child_process";
 import fs from "node:fs/promises";
 import path from "node:path";
 
@@ -6,6 +7,18 @@ import { app } from "electron";
 import { PowerShellManager } from "./powershell";
 import { AppConfig } from "../../shared/types";
 import { logger } from "../utils/logger";
+
+type RegistryReadResult =
+  | { ok: true; value: string | null }
+  | { ok: false; error: string };
+
+export type GameInstallationStatus = "installed" | "uninstalled" | "unknown";
+
+type ExecFileError = Error & {
+  code?: number | string;
+  stdout?: string | Buffer;
+  stderr?: string | Buffer;
+};
 
 /**
  * Registry Mapping for Game Installation Paths
@@ -58,6 +71,23 @@ const standardizeRegPath = (path: string): string => {
   return path;
 };
 
+const toRegExePath = (regPath: string): string | null => {
+  const finalPath = standardizeRegPath(regPath);
+  const prefixMap: Array<[string, string]> = [
+    ["Registry::HKEY_CURRENT_USER\\", "HKCU\\"],
+    ["Registry::HKEY_LOCAL_MACHINE\\", "HKLM\\"],
+    ["Registry::HKEY_CLASSES_ROOT\\", "HKCR\\"],
+  ];
+
+  for (const [powershellPrefix, regExePrefix] of prefixMap) {
+    if (finalPath.startsWith(powershellPrefix)) {
+      return finalPath.replace(powershellPrefix, regExePrefix);
+    }
+  }
+
+  return null;
+};
+
 /**
  * Normalize installation path by removing trailing slashes and ensuring consistent separators
  */
@@ -84,17 +114,89 @@ export const runPowerShell = async (
   return PowerShellManager.getInstance().execute(psCommand, useAdmin);
 };
 
-/**
- * Reads a single registry value
- */
-export const readRegistryValue = async (
+const toOutputString = (value: string | Buffer | undefined): string => {
+  if (Buffer.isBuffer(value)) return value.toString("utf8");
+  return value ?? "";
+};
+
+const formatError = (error: unknown): string => {
+  if (error instanceof Error) return error.message;
+  return String(error);
+};
+
+const isMissingPathError = (error: unknown): boolean => {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    ((error as NodeJS.ErrnoException).code === "ENOENT" ||
+      (error as NodeJS.ErrnoException).code === "ENOTDIR")
+  );
+};
+
+const parseRegQueryValue = (stdout: string, key: string): string | null => {
+  const lowerKey = key.toLowerCase();
+
+  for (const line of stdout.split(/\r?\n/)) {
+    const match = line.trimStart().match(/^(.*?)\s+REG_\S+\s*(.*)$/i);
+    if (!match) continue;
+
+    if (match[1].trim().toLowerCase() === lowerKey) {
+      const value = match[2].trim();
+      return value || null;
+    }
+  }
+
+  return null;
+};
+
+const queryRegistryWithRegExe = async (
   regPath: string,
   key: string,
-): Promise<string | null> => {
-  try {
-    const finalPath = standardizeRegPath(regPath);
-    // Safer retrieval: Get-ItemProperty directly
-    const psCommand = `
+): Promise<RegistryReadResult> => {
+  const queryPath = toRegExePath(regPath);
+  if (!queryPath) {
+    return { ok: false, error: `Unsupported registry path: ${regPath}` };
+  }
+
+  return new Promise<RegistryReadResult>((resolve) => {
+    execFile(
+      "reg.exe",
+      ["query", queryPath, "/v", key],
+      { windowsHide: true, timeout: 5000 },
+      (error, stdout, stderr) => {
+        if (!error) {
+          resolve({
+            ok: true,
+            value: parseRegQueryValue(toOutputString(stdout), key),
+          });
+          return;
+        }
+
+        const execError = error as ExecFileError;
+        if (execError.code === 1 || execError.code === "1") {
+          resolve({ ok: true, value: null });
+          return;
+        }
+
+        resolve({
+          ok: false,
+          error:
+            toOutputString(execError.stderr) ||
+            toOutputString(stderr) ||
+            formatError(execError),
+        });
+      },
+    );
+  });
+};
+
+const readRegistryValueDetailed = async (
+  regPath: string,
+  key: string,
+): Promise<RegistryReadResult> => {
+  const finalPath = standardizeRegPath(regPath);
+  const psCommand = `
       if (Test-Path "${finalPath}") {
         $prop = Get-ItemProperty -Path "${finalPath}" -Name "${key}" -ErrorAction SilentlyContinue
         if ($prop) {
@@ -103,15 +205,41 @@ export const readRegistryValue = async (
       }
     `.trim();
 
-    const { stdout, code } = await runPowerShell(psCommand);
+  try {
+    const { stdout, stderr, code } = await runPowerShell(psCommand);
 
-    if (code === 0 && stdout && stdout.trim()) {
-      return stdout.trim();
+    if (code === 0) {
+      const value = stdout.trim();
+      return { ok: true, value: value || null };
     }
-    return null;
-  } catch (_e) {
-    return null;
+
+    const fallback = await queryRegistryWithRegExe(regPath, key);
+    if (fallback.ok) return fallback;
+
+    return {
+      ok: false,
+      error: `PowerShell failed (${stderr || `exit code ${code}`}); reg.exe failed (${fallback.error})`,
+    };
+  } catch (error) {
+    const fallback = await queryRegistryWithRegExe(regPath, key);
+    if (fallback.ok) return fallback;
+
+    return {
+      ok: false,
+      error: `PowerShell threw (${formatError(error)}); reg.exe failed (${fallback.error})`,
+    };
   }
+};
+
+/**
+ * Reads a single registry value
+ */
+export const readRegistryValue = async (
+  regPath: string,
+  key: string,
+): Promise<string | null> => {
+  const result = await readRegistryValueDetailed(regPath, key);
+  return result.ok ? result.value : null;
 };
 
 /**
@@ -214,20 +342,49 @@ export const setDaumGameStarterCommand = async (
 /**
  * Checks if the game is actually installed by verifying registry path and folder presence
  */
+export const getGameInstallationStatus = async (
+  serviceId: AppConfig["serviceChannel"],
+  gameId: AppConfig["activeGame"],
+): Promise<GameInstallationStatus> => {
+  const registryInfo = REGISTRY_MAP[serviceId]?.[gameId];
+  if (!registryInfo) return "unknown";
+
+  const registryResult = await readRegistryValueDetailed(
+    registryInfo.path,
+    registryInfo.key,
+  );
+
+  if (!registryResult.ok) {
+    logger.warn(
+      `[Registry] Could not determine installation status for ${gameId} (${serviceId}): ${registryResult.error}`,
+    );
+    return "unknown";
+  }
+
+  if (!registryResult.value) return "uninstalled";
+
+  const installPath = normalizePath(registryResult.value);
+  if (!installPath) return "uninstalled";
+
+  try {
+    // Check if directory exists
+    const stats = await fs.stat(installPath);
+    return stats.isDirectory() ? "installed" : "uninstalled";
+  } catch (error) {
+    if (isMissingPathError(error)) return "uninstalled";
+
+    logger.warn(
+      `[Registry] Could not verify installation path for ${gameId} (${serviceId}): ${formatError(error)}`,
+    );
+    return "unknown";
+  }
+};
+
 export const isGameInstalled = async (
   serviceId: AppConfig["serviceChannel"],
   gameId: AppConfig["activeGame"],
 ): Promise<boolean> => {
-  try {
-    const installPath = await getGameInstallPath(serviceId, gameId);
-    if (!installPath) return false;
-
-    // Check if directory exists
-    const stats = await fs.stat(installPath);
-    return stats.isDirectory();
-  } catch (_e) {
-    return false;
-  }
+  return (await getGameInstallationStatus(serviceId, gameId)) === "installed";
 };
 
 /**

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -63,6 +63,10 @@ interface StatusMessageConfig {
 const STATUS_MESSAGES: Record<RunStatus, StatusMessageConfig> = {
   idle: { message: "", timeout: 0 }, // [Updated] Clean idle state
   uninstalled: { message: "설치된 게임을 찾을 수 없습니다.", timeout: -1 }, // Sticky
+  install_check_blocked: {
+    message: "설치 경로 확인이 차단되었습니다.",
+    timeout: -1,
+  },
   preparing: { message: "실행 절차 준비 중...", timeout: 3000 },
   processing: { message: "실행 절차 진행 중...", timeout: 3000 },
   authenticating: { message: "지정 PC 확인 중...", timeout: 3000 },
@@ -627,7 +631,10 @@ function App() {
 
     // Also ignore transition from "uninstalled" to "idle" (re-install or config switch)
     // BUT we must CLEAR the sticky "uninstalled" message!
-    if (status === "idle" && prevStatus === "uninstalled") {
+    if (
+      status === "idle" &&
+      (prevStatus === "uninstalled" || prevStatus === "install_check_blocked")
+    ) {
       setTimeout(() => setActiveMessage(""), 0);
       prevStatusRef.current = status;
       return;
@@ -693,6 +700,7 @@ function App() {
     // ACTIVE: "Install" button should be ENABLED (not disabled)
     // allowing user to click and go to download page.
     if (s === "uninstalled") return false;
+    if (s === "install_check_blocked") return true;
 
     // Running states -> Disabled
     if (
@@ -712,7 +720,12 @@ function App() {
   // Whether the install needs patching: local last-seen version differs from remote latest.
   // Only meaningful when game is installed and we have both versions.
   const isUpdateNeeded = useMemo(() => {
-    if (activeGameStatus.status === "uninstalled") return false;
+    if (
+      activeGameStatus.status === "uninstalled" ||
+      activeGameStatus.status === "install_check_blocked"
+    ) {
+      return false;
+    }
     const key = `${config.activeGame}_${config.serviceChannel}`;
     const localVersion = config.knownGameVersions?.[key]?.version;
     const remoteVersion = remoteVersions?.[config.activeGame]?.version;
@@ -934,6 +947,11 @@ function App() {
           `[App] No download URL found for ${config.activeGame} / ${config.serviceChannel}`,
         );
       }
+      return;
+    }
+
+    if (activeGameStatus.status === "install_check_blocked") {
+      logger.warn("[App] Game start blocked because install check failed.");
       return;
     }
 
@@ -1375,6 +1393,7 @@ function App() {
                 <GameStartButton
                   onClick={handleGameStart}
                   label={gameStartButtonLabel}
+                  disabled={isButtonDisabled}
                   className={isButtonDisabled ? "disabled" : ""}
                   style={
                     isButtonDisabled

--- a/src/renderer/components/GameStartButton.tsx
+++ b/src/renderer/components/GameStartButton.tsx
@@ -6,6 +6,7 @@ interface GameStartButtonProps {
   label?: string;
   style?: React.CSSProperties;
   className?: string; // Allow external class injection
+  disabled?: boolean;
 }
 
 const GameStartButton: React.FC<GameStartButtonProps> = ({
@@ -13,12 +14,14 @@ const GameStartButton: React.FC<GameStartButtonProps> = ({
   label = "게임 시작",
   style,
   className = "",
+  disabled = false,
 }) => {
   return (
     <button
       className={`main-start__link ${className}`}
       onClick={onClick}
       style={style}
+      disabled={disabled}
     >
       {/* Defined SVG Filter for Chiseled 3D Effect */}
       <svg

--- a/src/renderer/utils/game-start-label.test.ts
+++ b/src/renderer/utils/game-start-label.test.ts
@@ -7,6 +7,7 @@ import {
 import { RunStatus } from "../../shared/types";
 
 const launchActiveStatuses: RunStatus[] = [
+  "install_check_blocked",
   "preparing",
   "processing",
   "authenticating",

--- a/src/renderer/utils/game-start-label.ts
+++ b/src/renderer/utils/game-start-label.ts
@@ -1,6 +1,7 @@
 import { RunStatus } from "../../shared/types";
 
 const UPDATE_LABEL_SUPPRESSED_STATUSES: RunStatus[] = [
+  "install_check_blocked",
   "preparing",
   "processing",
   "authenticating",

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -136,6 +136,7 @@ export interface ThemesRemoteData {
 export type RunStatus =
   | "idle"
   | "uninstalled" // "게시판이나 공식 홈페이지를 통해 먼저 설치해주세요."
+  | "install_check_blocked" // "설치 경로 확인이 차단되었습니다."
   | "preparing" // "실행 절차 준비"
   | "processing" // "실행 절차 진행 중"
   | "authenticating" // "지정 PC 확인"


### PR DESCRIPTION
**Summary**
- PowerShell 또는 reg.exe 접근이 보안 정책/백신 등에 의해 차단될 때 설치 여부를 unknown으로 처리하고, 설치하기 대신 비활성화된 시작 버튼과 명확한 상태 메시지를 표시합니다.
- 자동 게시판 새로고침에서 글 목록이 변하지 않아도 마지막 확인 시간이 갱신되도록 수정했습니다.
- README용 런처 미리보기 GIF를 최신 화면으로 갱신했습니다.

**Motivation**
- 설치된 게임이 보안 정책 때문에 감지되지 않는 경우 사용자가 재설치를 유도받지 않도록 하기 위함입니다.
- 런처가 비포커스 상태 이후 복귀했을 때 게시판 확인이 실행됐는지 UI에서 명확히 확인할 수 있도록 하기 위함입니다.