### PR TITLE
fix: 커스텀 게임 폰트가 런처 UI 폰트에 영향을 주지 않도록 분리

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Unofficial Launcher</title>
     <style>
+      :root {
+        --launcher-font-family: "Noto Sans KR", "Malgun Gothic", "Segoe UI",
+          sans-serif;
+      }
+
       /* Splash Screen Styles */
       #launcher-splash {
         position: fixed;
@@ -32,7 +37,7 @@
       }
 
       .splash-logo {
-        font-family: "Fontin", "Noto Sans KR", sans-serif;
+        font-family: var(--launcher-font-family);
         font-size: 32px;
         color: #dfcf99; /* theme-accent */
         text-transform: uppercase;

--- a/src/renderer/App.css
+++ b/src/renderer/App.css
@@ -27,6 +27,8 @@
 }
 
 :root {
+  --launcher-font-family: "Noto Sans KR", "Malgun Gothic", "Segoe UI",
+    sans-serif;
   --theme-text: #c8c8c8;
   --text-secondary: #888888;
   --theme-accent: #dfcf99;
@@ -39,7 +41,7 @@ body {
   height: 100%;
   margin: 0;
   padding: 0;
-  font-family: "Fontin", "Noto Sans KR", sans-serif;
+  font-family: var(--launcher-font-family);
   overflow: hidden;
   user-select: none;
   background-color: #000000; /* True black for fade transition */

--- a/src/renderer/components/TitleBar.tsx
+++ b/src/renderer/components/TitleBar.tsx
@@ -39,7 +39,7 @@ const TitleBar: React.FC<TitleBarProps> = ({
               opacity: 0.8,
               borderRadius: "2px",
               cursor: "pointer",
-              fontFamily: "Fontin-SmallCaps, sans-serif",
+              fontFamily: "var(--launcher-font-family)",
               fontSize: "13px",
               letterSpacing: "1px",
               textTransform: "uppercase",


### PR DESCRIPTION
**Summary**
- 런처 전역 폰트 스택에서 인게임 타깃 폰트명인 Fontin 계열 참조를 제거했습니다.
- 스플래시, 본문, 타이틀바 업데이트 버튼이 런처 전용 폰트 변수를 사용하도록 정리했습니다.

**Motivation**
- 커스텀 게임 폰트가 시스템에 게임 폰트명으로 등록되더라도 런처 UI가 해당 폰트를 잡아 화면에 영향을 받지 않도록 분리하기 위함입니다.