### PR TITLE
fix: 폰트 적용 안정성 개선

### DIFF
--- a/.agents/skills/architecture-management/SKILL.md
+++ b/.agents/skills/architecture-management/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: architecture-management
+description: Use when adding or changing features that affect lifecycle phases, service startup/shutdown, EventBus/IPC boundaries, shared state ownership, background processes, or cross-module responsibilities.
+---
+
+# Skill: Architecture Responsibility Management
+
+Use this before implementing any feature or fix that crosses module boundaries or depends on runtime ordering.
+
+## When to Use
+
+- Startup, shutdown, resume, updater, process watcher, font migration, or background scheduler work
+- Any change that writes shared state from more than one place
+- Any new EventBus event, IPC bridge, service, manager, or long-running task
+- Any feature where an initial check, post-init reconciliation, or user action can overwrite another state
+
+## Required Pass
+
+1. Name the lifecycle phase: bootstrap, service init, post-init reconciliation, runtime, suspend/resume, or shutdown.
+2. Identify the owner for each state. Only the owner may create the strongest runtime state.
+3. Define ordering guarantees. If a later step relies on a result, do not fire-and-forget the earlier step.
+4. Define overwrite rules. Reconciliation and background checks must not downgrade stronger runtime state without owner confirmation.
+5. Keep event boundaries explicit. Business logic belongs in services/handlers, not random IPC or renderer callbacks.
+6. Add a test for the ordering or ownership contract when the change can regress silently.
+
+## Pair With
+
+- `event-ipc-integration` when adding or changing EventBus or renderer IPC flows.
+- `config-management` when adding or changing any `AppConfig` field.
+- `settings-management` when exposing a setting in the settings screen.
+- `windows-electron-debugging` for Electron runtime, dev server, or visual verification work.
+
+## Local Rule
+
+For game status, runtime/process state is stronger than install-check state. Install reconciliation may fill unknown/idle/uninstalled status, but must not overwrite `preparing`, `processing`, `authenticating`, `ready`, or `running` unless the runtime owner has first cleared that state.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,15 @@ Before any repo-local `gh` command or GitHub HTTPS push, use the
 It defines the repo-local `GH_TOKEN` injection pattern and avoids mutating
 global GitHub CLI auth state.
 
+## Architecture management
+
+When a task adds or changes lifecycle phases, service startup/shutdown,
+EventBus/IPC boundaries, shared state ownership, process watching, updater/font
+migration, or cross-module workflows, use
+`.agents/skills/architecture-management/SKILL.md` before implementation. Pair it
+with `config-management`, `settings-management`, `event-ipc-integration`, or
+`windows-electron-debugging` when their triggers also apply.
+
 ## WSL execution rules
 
 Detect WSL at session start. If `uname -r` contains `microsoft` or `WSL`, this is WSL.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,15 @@ Before any repo-local `gh` command or GitHub HTTPS push, use the
 It defines the repo-local `GH_TOKEN` injection pattern and avoids mutating
 global GitHub CLI auth state.
 
+## Architecture management
+
+When a task adds or changes lifecycle phases, service startup/shutdown,
+EventBus/IPC boundaries, shared state ownership, process watching, updater/font
+migration, or cross-module workflows, use
+`.agents/skills/architecture-management/SKILL.md` before implementation. Pair it
+with `config-management`, `settings-management`, `event-ipc-integration`, or
+`windows-electron-debugging` when their triggers also apply.
+
 ### WSL execution rules (detect at session start)
 
 If `uname -r` contains `microsoft`/`WSL`, this is WSL — WSL is the development primary (edit/git/lint/rtk) and Windows is the build/run primary (Electron + actual POE / POE2 game test, which Linux cannot run). Both OSes share the same `node_modules` under `D:\project_poe2\POE2-unofficial-launcher\`.

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -87,6 +87,10 @@ import {
 } from "./services/register-services";
 import { serviceManager } from "./services/ServiceManager";
 import { themeCacheManager } from "./services/ThemeCacheManager";
+import {
+  getGameStatus,
+  shouldPreserveRuntimeGameStatus,
+} from "./state/GameStatusStore";
 import { getConfig, setupStoreObservers, default as store } from "./store";
 import {
   isAdmin,
@@ -2066,12 +2070,28 @@ async function createWindow() {
     logger.log("[Main] Checking initial status for all game contexts...");
 
     for (const combo of combinations) {
+      const currentStatus = getGameStatus(combo.game, combo.service);
+      if (shouldPreserveRuntimeGameStatus(currentStatus)) {
+        logger.log(
+          `[Main] Preserving active runtime status for ${combo.game} (${combo.service}): ${currentStatus.status}`,
+        );
+        continue;
+      }
+
       const installationStatus = await getGameInstallationStatus(
         combo.service as AppConfig["serviceChannel"],
         combo.game as AppConfig["activeGame"],
       );
 
-      eventBus.emit<GameStatusChangeEvent>(
+      const latestStatus = getGameStatus(combo.game, combo.service);
+      if (shouldPreserveRuntimeGameStatus(latestStatus)) {
+        logger.log(
+          `[Main] Preserving active runtime status after install check for ${combo.game} (${combo.service}): ${latestStatus.status}`,
+        );
+        continue;
+      }
+
+      await eventBus.emit<GameStatusChangeEvent>(
         EventType.GAME_STATUS_CHANGE,
         appContext,
         {
@@ -2090,7 +2110,6 @@ async function createWindow() {
       );
     }
   };
-  checkAllGameStatuses();
 
   // Sync Auto Launch Status
   // Sync Auto Launch Status
@@ -2101,6 +2120,7 @@ async function createWindow() {
 
   const { processWatcher } = await initializeCoreServices(appContext);
   appContext.processWatcher = processWatcher;
+  await checkAllGameStatuses();
 
   // --- ProcessWatcher Optimization & wake-up integrated in Class ---
   mainWindow.on("blur", () => {

--- a/src/main/services/FontManager.ts
+++ b/src/main/services/FontManager.ts
@@ -1043,9 +1043,9 @@ if (Get-ItemProperty -Path $p1 -Name "${name}" -ErrorAction SilentlyContinue) {
     rule: FontMutationRule,
     scale: number,
   ): Promise<ArrayBuffer> {
-    // sfnt scaler가 OTTO이면 CFF 컨테이너 → OtfMutatorWorker(SFNT 바이트 패치).
-    // 그 외(0x00010000 등)는 TrueType → FontMutatorWorker(fonteditor-core).
-    // fonteditor-core는 CFF→glyf 변환에서 한글 글리프를 손실시키므로 OTF는 따로 다룬다.
+    // sfnt scaler가 OTTO이면 CFF 컨테이너 → OtfMutatorWorker.
+    // 그 외(0x00010000 등)는 TrueType → FontMutatorWorker.
+    // 두 워커 모두 SFNT 패치 방식으로 glyph/레이아웃 보조 테이블을 보존한다.
     const headHandle = await fs.open(filePath, "r");
     let isOTF: boolean;
     try {

--- a/src/main/services/FontManager.ts
+++ b/src/main/services/FontManager.ts
@@ -25,10 +25,24 @@ import {
   DetectedExternalFont,
   ImportSelection,
 } from "../../shared/types";
+import {
+  getAllGameStatuses,
+  isLaunchBlockingStatus,
+} from "../state/GameStatusStore";
 import { getConfig } from "../store";
 import { setConfigWithEvent } from "../utils/config-utils";
 import { Logger } from "../utils/logger";
 import { PowerShellManager } from "../utils/powershell";
+import { getProcessesInfo } from "../utils/process";
+
+const FONT_UPDATE_BLOCKING_PROCESSES = [
+  "POE2_Launcher.exe",
+  "POE_Launcher.exe",
+  "PathOfExile_KG.exe",
+  "PathOfExile_x64_KG.exe",
+  "PathOfExile.exe",
+  "PathOfExile_x64.exe",
+] as const;
 
 export interface AddFontOptions {
   filePath: string;
@@ -500,6 +514,31 @@ if (Get-ItemProperty -Path $p1 -Name "${name}" -ErrorAction SilentlyContinue) {
     );
   }
 
+  private async assertNoGameBlockingFontUpdate(): Promise<void> {
+    const blockingStatus = getAllGameStatuses().find((statusState) =>
+      isLaunchBlockingStatus(statusState.status),
+    );
+    if (blockingStatus) {
+      throw new Error(
+        `게임 실행 중에는 폰트를 업데이트할 수 없습니다. 먼저 게임을 종료해 주세요. (${blockingStatus.gameId} / ${blockingStatus.serviceId})`,
+      );
+    }
+
+    const processes = await getProcessesInfo([
+      ...FONT_UPDATE_BLOCKING_PROCESSES,
+    ]);
+    const blockingProcess = processes.find((process) =>
+      FONT_UPDATE_BLOCKING_PROCESSES.some(
+        (name) => name.toLowerCase() === process.name.toLowerCase(),
+      ),
+    );
+    if (!blockingProcess) return;
+
+    throw new Error(
+      `게임 프로세스가 실행 중이라 폰트를 업데이트할 수 없습니다. 먼저 게임을 완전히 종료해 주세요. (${blockingProcess.name}, PID ${blockingProcess.pid})`,
+    );
+  }
+
   /**
    * 부팅 시 호출. 폰트 변조 스키마 마이그레이션 상태를 판정한다.
    *
@@ -544,6 +583,7 @@ if (Get-ItemProperty -Path $p1 -Name "${name}" -ErrorAction SilentlyContinue) {
     options?: { force?: boolean },
   ): Promise<void> {
     await this.initPromise;
+    await this.assertNoGameBlockingFontUpdate();
     const pm = PowerShellManager.getInstance();
     const currentApplied =
       (getConfig("appliedFonts") as Record<string, string>) || {};

--- a/src/main/services/FontManager.ts
+++ b/src/main/services/FontManager.ts
@@ -60,6 +60,7 @@ export class FontManager {
   private fontsMap: Map<string, CustomFontData> = new Map();
   private remoteCatalog: RemoteFontItem[] = [];
   private initPromise: Promise<void>;
+  private systemFontCleanupPromise: Promise<void> | null = null;
 
   private constructor() {
     this.customFontsDir = path.join(app.getPath("userData"), "CustomFonts");
@@ -514,6 +515,35 @@ if (Get-ItemProperty -Path $p1 -Name "${name}" -ErrorAction SilentlyContinue) {
     );
   }
 
+  private cleanupOrphanedManagedSystemFonts(): void {
+    if (this.systemFontCleanupPromise) return;
+
+    this.systemFontCleanupPromise = this.runOrphanedManagedSystemFontCleanup()
+      .catch((err) => {
+        logger.warn(`Managed system font cleanup skipped: ${err}`);
+      })
+      .finally(() => {
+        this.systemFontCleanupPromise = null;
+      });
+  }
+
+  private async runOrphanedManagedSystemFontCleanup(): Promise<void> {
+    const managedTargetNames = Array.from(
+      new Set(Object.values(TARGET_SERVICES_CONFIG).flat()),
+    );
+    const registryTargetNames = Array.from(
+      new Set(expandTargetNames(managedTargetNames)),
+    );
+    const ttfFileNames = managedTargetNames.map(
+      (targetName) => `${targetName.replace(/\s+/g, "")}.ttf`,
+    );
+
+    await PowerShellManager.getInstance().cleanupOrphanedManagedFontFiles(
+      ttfFileNames,
+      registryTargetNames,
+    );
+  }
+
   private async assertNoGameBlockingFontUpdate(): Promise<void> {
     const blockingStatus = getAllGameStatuses().find((statusState) =>
       isLaunchBlockingStatus(statusState.status),
@@ -549,6 +579,8 @@ if (Get-ItemProperty -Path $p1 -Name "${name}" -ErrorAction SilentlyContinue) {
    */
   public async checkFontMigration(): Promise<{ prompt: boolean }> {
     await this.initPromise;
+    this.cleanupOrphanedManagedSystemFonts();
+
     const hasCustom = Object.keys(this.getActiveCustomAssignments()).length > 0;
 
     if (!hasCustom) {

--- a/src/main/services/ProcessWatcher.ts
+++ b/src/main/services/ProcessWatcher.ts
@@ -23,6 +23,7 @@ import * as processUtils from "../utils/process";
 import type { AppConfig } from "../../shared/types";
 
 const TARGET_PROCESSES = SUPPORTED_PROCESS_NAMES;
+const DEFAULT_WATCH_INTERVAL_MS = 3000;
 const SUSPEND_DELAY_MS = 60 * 1000;
 const PROCESS_EXPECTED_GRACE_MS = 30 * 1000;
 
@@ -58,7 +59,8 @@ export class ProcessWatcher implements IService {
 
   public async init(): Promise<void> {
     this.registerLaunchIntentListener();
-    this.startWatching();
+    this.startWatching(DEFAULT_WATCH_INTERVAL_MS, false);
+    await this.checkNow();
   }
 
   public async stop(): Promise<void> {
@@ -69,16 +71,21 @@ export class ProcessWatcher implements IService {
     this.stopWatching();
   }
 
-  public startWatching(intervalMs: number = 3000) {
+  public startWatching(
+    intervalMs: number = DEFAULT_WATCH_INTERVAL_MS,
+    runInitialCheck = true,
+  ) {
     if (this.timer) {
       // Already running (Idempotent)
       return;
     }
     this.logger.log("Starting Watcher Service (PID-based)...");
-    this.runCheck(); // Initial check
+    if (runInitialCheck) {
+      void this.checkNow();
+    }
 
     this.timer = setInterval(() => {
-      this.runCheck();
+      void this.checkNow();
     }, intervalMs);
   }
 
@@ -88,6 +95,10 @@ export class ProcessWatcher implements IService {
       this.timer = null;
       this.logger.log("Watcher Service Stopped.");
     }
+  }
+
+  public async checkNow(): Promise<void> {
+    await this.runCheck();
   }
 
   /**
@@ -255,13 +266,17 @@ export class ProcessWatcher implements IService {
             `Process Started: ${p.name} (PID: ${p.pid}, Path: ${p.path || "Unknown"}, Game: ${identity.gameId || "Unknown"}, Service: ${identity.serviceId || "Unknown"})`,
           );
 
-          eventBus.emit<ProcessEvent>(EventType.PROCESS_START, this.context, {
-            name: p.name,
-            path: p.path,
-            pid: p.pid,
-            gameId: identity.gameId,
-            serviceId: identity.serviceId,
-          });
+          await eventBus.emit<ProcessEvent>(
+            EventType.PROCESS_START,
+            this.context,
+            {
+              name: p.name,
+              path: p.path,
+              pid: p.pid,
+              gameId: identity.gameId,
+              serviceId: identity.serviceId,
+            },
+          );
         }
       }
 
@@ -278,19 +293,23 @@ export class ProcessWatcher implements IService {
           // Process Stopped
           this.logger.log(`Process Stopped: ${info.name} (PID: ${pid})`);
 
-          eventBus.emit<ProcessEvent>(EventType.PROCESS_STOP, this.context, {
-            name: info.name,
-            path: info.path,
-            pid: pid, // Using the key from valid iteration
-            gameId: info.gameId,
-            serviceId: info.serviceId,
-          });
+          await eventBus.emit<ProcessEvent>(
+            EventType.PROCESS_STOP,
+            this.context,
+            {
+              name: info.name,
+              path: info.path,
+              pid: pid, // Using the key from valid iteration
+              gameId: info.gameId,
+              serviceId: info.serviceId,
+            },
+          );
 
           this.activePids.delete(pid);
         }
       }
 
-      this.reconcileStaleActiveStatuses();
+      await this.reconcileStaleActiveStatuses();
     } catch (e) {
       this.logger.error(`Error during runCheck:`, e);
     } finally {
@@ -298,7 +317,7 @@ export class ProcessWatcher implements IService {
     }
   }
 
-  private reconcileStaleActiveStatuses() {
+  private async reconcileStaleActiveStatuses() {
     const now = Date.now();
 
     for (const statusState of getAllGameStatuses()) {
@@ -325,7 +344,7 @@ export class ProcessWatcher implements IService {
         `[ProcessWatcher] Reconciled stale ${statusState.status} status to idle: ${statusState.gameId} / ${statusState.serviceId}`,
       );
 
-      eventBus.emit<GameStatusChangeEvent>(
+      await eventBus.emit<GameStatusChangeEvent>(
         EventType.GAME_STATUS_CHANGE,
         this.context,
         payload,

--- a/src/main/state/GameStatusStore.ts
+++ b/src/main/state/GameStatusStore.ts
@@ -43,6 +43,10 @@ export const isLaunchBlockingStatus = (status: RunStatus): boolean =>
   status === "ready" ||
   status === "running";
 
+export const shouldPreserveRuntimeGameStatus = (
+  statusState: GameStatusState,
+): boolean => isLaunchBlockingStatus(statusState.status);
+
 export const isProcessExpectedStatus = (status: RunStatus): boolean =>
   status === "ready" || status === "running";
 

--- a/src/main/tests/FontMutatorWorker.integration.test.ts
+++ b/src/main/tests/FontMutatorWorker.integration.test.ts
@@ -6,9 +6,9 @@ import { Font } from "fonteditor-core";
 import { describe, it, expect } from "vitest";
 
 /**
- * 회귀 가설: FontMutatorWorker는 Font.create(buf, { type: "ttf" })로 고정 파싱한다.
- * 사용자가 IPC pick-file 다이얼로그에서 .otf를 골랐을 경우(현재 허용됨),
- * 이 경로에서 "ttf file damaged" 또는 유사 에러가 발생해야 한다 (=현재 버그 재현).
+ * 회귀 배경: 구버전 FontMutatorWorker는 Font.create(buf, { type: "ttf" })로
+ * 고정 파싱했다. 사용자가 IPC pick-file 다이얼로그에서 .otf를 골랐을 경우,
+ * 이 경로에서 "ttf file damaged" 또는 유사 에러가 발생했다.
  *
  * 샘플 폰트 경로: D:\project_poe2\POE2-unofficial-launcher-gh-pages\fonts
  * (gh-pages 리포 체크아웃 필요. 없으면 테스트는 skip 처리.)
@@ -52,7 +52,7 @@ describe.skipIf(!hasSamples)(
       const buf = fs.readFileSync(otfFile);
       expect(readFontType(otfFile)).toBe("otf");
 
-      // 현재 FontMutatorWorker.ts:52 와 동일한 호출
+      // 구버전 FontMutatorWorker의 고정 TTF 파싱 경로와 동일한 호출
       expect(() => Font.create(buf, { type: "ttf" })).toThrow();
     });
 

--- a/src/main/tests/GameStatusStore.test.ts
+++ b/src/main/tests/GameStatusStore.test.ts
@@ -4,6 +4,7 @@ import {
   getGameStatus,
   isLaunchBlockingStatus,
   resetGameStatusCacheForTests,
+  shouldPreserveRuntimeGameStatus,
   shouldResetStatusOnAutomationWindowClosed,
   updateGameStatusCache,
 } from "../state/GameStatusStore";
@@ -44,6 +45,30 @@ describe("GameStatusStore", () => {
     expect(isLaunchBlockingStatus("stopping")).toBe(false);
     expect(isLaunchBlockingStatus("install_check_blocked")).toBe(false);
     expect(isLaunchBlockingStatus("idle")).toBe(false);
+  });
+
+  it("preserves active runtime statuses during install reconciliation", () => {
+    expect(
+      shouldPreserveRuntimeGameStatus({
+        gameId: "POE2",
+        serviceId: "Kakao Games",
+        status: "running",
+      }),
+    ).toBe(true);
+    expect(
+      shouldPreserveRuntimeGameStatus({
+        gameId: "POE2",
+        serviceId: "Kakao Games",
+        status: "processing",
+      }),
+    ).toBe(true);
+    expect(
+      shouldPreserveRuntimeGameStatus({
+        gameId: "POE2",
+        serviceId: "Kakao Games",
+        status: "idle",
+      }),
+    ).toBe(false);
   });
 
   it("resets an interrupted automation window only when the game is not already tracked", () => {

--- a/src/main/tests/ProcessWatcher.test.ts
+++ b/src/main/tests/ProcessWatcher.test.ts
@@ -126,6 +126,34 @@ describe("ProcessWatcher suspension", () => {
     watcher.stopWatching();
   });
 
+  it("waits for the initial process scan during init", async () => {
+    vi.mocked(processUtils.getProcessesInfo).mockResolvedValueOnce([
+      {
+        pid: 88,
+        name: "POE2_Launcher.exe",
+        path: "",
+      },
+    ]);
+
+    const watcher = new ProcessWatcher(createContext());
+
+    await watcher.init();
+
+    expect(watcher.isProcessRunning("POE2_Launcher.exe")).toBe(true);
+    expect(eventBus.emit).toHaveBeenCalledWith(
+      EventType.PROCESS_START,
+      expect.anything(),
+      expect.objectContaining({
+        pid: 88,
+        name: "POE2_Launcher.exe",
+        gameId: "POE2",
+        serviceId: "Kakao Games",
+      }),
+    );
+
+    await watcher.stop();
+  });
+
   it("keeps inferred context on process stop events", async () => {
     vi.mocked(processUtils.getProcessesInfo)
       .mockResolvedValueOnce([

--- a/src/main/tests/TtfMutator.integration.test.ts
+++ b/src/main/tests/TtfMutator.integration.test.ts
@@ -1,0 +1,71 @@
+// src/main/tests/TtfMutator.integration.test.ts
+import fs from "node:fs";
+import path from "node:path";
+
+import { Font } from "fonteditor-core";
+import { describe, expect, it } from "vitest";
+
+import { FONT_MUTATION_DEFINITIONS } from "../../shared/font-targets";
+import { mutateTtfSfnt } from "../workers/otfMutator";
+
+const SAMPLE_DIR = path.resolve(
+  __dirname,
+  "../../../../POE2-unofficial-launcher-gh-pages/fonts",
+);
+const hasSamples = fs.existsSync(SAMPLE_DIR);
+
+function readTables(buf: Buffer): Record<string, Buffer> {
+  const numTables = buf.readUInt16BE(4);
+  const tables: Record<string, Buffer> = {};
+  for (let i = 0; i < numTables; i++) {
+    const off = 12 + i * 16;
+    const tag = buf.toString("ascii", off, off + 4);
+    const tableOffset = buf.readUInt32BE(off + 8);
+    const tableLength = buf.readUInt32BE(off + 12);
+    tables[tag] = buf.subarray(tableOffset, tableOffset + tableLength);
+  }
+  return tables;
+}
+
+describe.skipIf(!hasSamples)("TtfMutator — SFNT 테이블 보존 변조기", () => {
+  it("DNFForgedBlade-Light.ttf의 렌더링 보조 테이블을 보존한다", () => {
+    const src = path.join(SAMPLE_DIR, "DNFForgedBlade-Light.ttf");
+    if (!fs.existsSync(src)) return;
+
+    const original = fs.readFileSync(src);
+    const rule = FONT_MUTATION_DEFINITIONS["Noto Sans CJK TC Book"];
+    const mutated = mutateTtfSfnt(original, rule, 100);
+
+    expect(mutated.subarray(0, 4).toString("hex")).toBe("00010000");
+
+    const originalTables = readTables(original);
+    const mutatedTables = readTables(mutated);
+    for (const tag of ["gasp", "GPOS", "GSUB", "kern"]) {
+      const originalTable = originalTables[tag];
+      const mutatedTable = mutatedTables[tag];
+      expect(
+        mutatedTable,
+        `${tag} 테이블이 변조 후에도 있어야 함`,
+      ).toBeTruthy();
+      expect(
+        originalTable,
+        `${tag} 원본 테이블이 테스트 샘플에 있어야 함`,
+      ).toBeTruthy();
+      if (!originalTable || !mutatedTable)
+        throw new Error(`${tag} 테이블 누락`);
+      expect(Buffer.compare(mutatedTable, originalTable)).toBe(0);
+    }
+
+    const parsed = Font.create(mutated, { type: "ttf" }).get();
+    expect(parsed.name.fontFamily).toBe(rule.family);
+    expect(parsed.name.fontSubFamily).toBe(rule.subfamily);
+    expect(parsed.name.fullName).toBe(rule.fullName);
+    expect(parsed.name.postScriptName).toBe(rule.postScript);
+    expect(parsed.name.uniqueSubFamily).toBe(rule.metrics!.uniqueSubFamily);
+    expect(parsed.name.version).toBe(rule.metrics!.version);
+    expect(parsed.hhea.ascent).toBe(rule.metrics!.baseHheaAscent);
+    expect(parsed.hhea.descent).toBe(rule.metrics!.baseHheaDescent);
+    expect(parsed["OS/2"].usWinAscent).toBe(rule.metrics!.baseWinAscent);
+    expect(parsed["OS/2"].usWinDescent).toBe(rule.metrics!.baseWinDescent);
+  });
+});

--- a/src/main/tests/powershell-blocked.test.ts
+++ b/src/main/tests/powershell-blocked.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
 
 import {
+  buildCleanupManagedFontFilesScript,
+  buildInstallSystemFontScript,
+  buildRemoveSystemFontScript,
   isPowerShellBlockedReason,
   PowerShellBlockedException,
   PowerShellManager,
@@ -31,14 +34,27 @@ describe("PowerShell blocked diagnostics", () => {
     expect(
       isPowerShellBlockedReason(
         "File cannot be loaded because running scripts is disabled on this system.",
+        "command",
       ),
     ).toBe(true);
-    expect(isPowerShellBlockedReason("액세스가 거부되었습니다.")).toBe(true);
     expect(
       isPowerShellBlockedReason(
         "이 시스템에서 스크립트를 실행할 수 없으므로 파일을 로드할 수 없습니다.",
+        "command",
       ),
     ).toBe(true);
+  });
+
+  it("does not treat command file access denial as a policy block", () => {
+    expect(
+      isPowerShellBlockedReason(
+        "C:\\Windows\\Fonts\\NotoSansCJKTCBook.ttf 경로에 대한 액세스가 거부되었습니다.",
+        "command",
+      ),
+    ).toBe(false);
+    expect(isPowerShellBlockedReason("액세스가 거부되었습니다.", "spawn")).toBe(
+      true,
+    );
   });
 
   it("includes likely security causes in the thrown error", () => {
@@ -94,5 +110,125 @@ describe("PowerShell blocked diagnostics", () => {
     );
 
     consoleError.mockRestore();
+  });
+
+  it("preserves non-policy command failures as normal PowerShell results", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    const session = {
+      server: {},
+      socket: {
+        destroyed: false,
+        write: vi.fn((_payload: string, callback?: (error?: Error) => void) => {
+          callback?.();
+        }),
+      },
+      process: null,
+      pendingRequests: new Map<string, PendingCallback>(),
+      pipePath: null,
+      initializing: null,
+      rejectInit: undefined,
+    } as unknown as PowerShellSession & {
+      pendingRequests: Map<string, PendingCallback>;
+    };
+
+    const result = PowerShellManager.getInstance().executeCommand(
+      "Remove-Item C:\\Windows\\Fonts\\NotoSansCJKTCBook.ttf",
+      session,
+      true,
+      true,
+    );
+    await Promise.resolve();
+    const callback = [...session.pendingRequests.values()][0];
+    if (!callback) throw new Error("PowerShell request was not queued.");
+
+    callback({
+      stdout: "",
+      stderr:
+        "C:\\Windows\\Fonts\\NotoSansCJKTCBook.ttf 경로에 대한 액세스가 거부되었습니다.",
+      code: 1,
+    });
+
+    await expect(result).resolves.toMatchObject({
+      code: 1,
+      stderr:
+        "C:\\Windows\\Fonts\\NotoSansCJKTCBook.ttf 경로에 대한 액세스가 거부되었습니다.",
+    });
+
+    consoleError.mockRestore();
+  });
+
+  it("installs fonts with a content-addressed file name instead of replacing the locked target file", () => {
+    const script = buildInstallSystemFontScript(
+      "C:\\Temp\\font's.ttf",
+      "Noto Sans CJK TC Book",
+      "NotoSansCJKTCBook.ttf",
+    );
+
+    expect(script).toContain("$sourcePath = 'C:\\Temp\\font''s.ttf'");
+    expect(script).toContain("Get-FileHash -Algorithm SHA256");
+    expect(script).toContain(
+      '$destFileName = "$baseName-$sourceHash$extension"',
+    );
+    expect(script).toContain(
+      "Set-ItemProperty -Path $regPath -Name $regName -Value $destFileName",
+    );
+    expect(script).toContain(
+      "Copy-Item -Path $sourcePath -Destination $destPath -Force",
+    );
+    expect(script).toContain("MoveFileEx");
+    expect(script).toContain("GetLastWin32Error");
+    expect(script).toContain("PendingFileRenameOperations");
+    expect(script).not.toContain("Remove-Item $destPath -Force");
+    expect(script).not.toContain('Value "NotoSansCJKTCBook.ttf"');
+  });
+
+  it("only schedules orphaned launcher-owned hash font files during startup cleanup", () => {
+    const script = buildCleanupManagedFontFilesScript(
+      ["NotoSansCJKTCBook.ttf", "SpoqaHanSansNeoRegular.ttf"],
+      [
+        "Noto Sans CJK TC Book",
+        "Noto Sans CJK TC",
+        "Spoqa Han Sans Neo Regular",
+      ],
+      false,
+    );
+
+    expect(script).toContain("-[0-9a-fA-F]{12}");
+    expect(script).toContain("$usedPaths.Contains($_.FullName)");
+    expect(script).toContain("HKLM:\\SOFTWARE\\Microsoft\\Windows NT");
+    expect(script).toContain(
+      "HKCU:\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Fonts",
+    );
+    expect(script).toContain("Remove-Or-DeferFontFile $fontPath");
+    expect(script).toContain("PendingFileRenameOperations");
+    expect(script).not.toContain("Join-Path $fontDir 'NotoSansCJKTCBook.ttf'");
+  });
+
+  it("scans startup cleanup candidates without admin before scheduling deletion", () => {
+    const script = buildCleanupManagedFontFilesScript(
+      ["NotoSansCJKTCBook.ttf"],
+      ["Noto Sans CJK TC Book"],
+      true,
+    );
+
+    expect(script).toContain("$dryRun = $true");
+    expect(script).toContain('Write-Output "ORPHAN:$fontPath"');
+    expect(script).not.toContain("Remove-Or-DeferFontFile $fontPath");
+  });
+
+  it("uses deferred deletion when explicit system font removal cannot delete immediately", () => {
+    const script = buildRemoveSystemFontScript(
+      "Noto Sans CJK TC Book",
+      "NotoSansCJKTCBook.ttf",
+      "HKLM",
+    );
+
+    expect(script).toContain("MoveFileEx");
+    expect(script).toContain("PendingFileRenameOperations");
+    expect(script).toContain("Remove-Or-DeferFontFile $target");
+    expect(script).toContain("Remove-Or-DeferFontFile $fallbackPath");
+    expect(script).not.toContain("Remove-Item -Path $target -Force");
   });
 });

--- a/src/main/utils/powershell.ts
+++ b/src/main/utils/powershell.ts
@@ -19,6 +19,8 @@ type ProcessError = Error & {
   code?: string | number;
 };
 
+type PowerShellBlockedReasonContext = "spawn" | "command";
+
 export class PowerShellBlockedException extends Error {
   constructor(reason: string, cause?: unknown) {
     super(`${POWERSHELL_BLOCKED_GUIDANCE} 원본 오류: ${reason}`);
@@ -34,7 +36,10 @@ const formatUnknownError = (error: unknown): string => {
   return String(error);
 };
 
-export const isPowerShellBlockedReason = (reason: unknown): boolean => {
+export const isPowerShellBlockedReason = (
+  reason: unknown,
+  context: PowerShellBlockedReasonContext = "spawn",
+): boolean => {
   const code =
     typeof reason === "object" && reason !== null && "code" in reason
       ? String((reason as ProcessError).code).toUpperCase()
@@ -42,6 +47,18 @@ export const isPowerShellBlockedReason = (reason: unknown): boolean => {
   if (code === "EPERM" || code === "EACCES") return true;
 
   const text = formatUnknownError(reason).toLowerCase();
+  const isExplicitPolicyBlock =
+    text.includes("blocked by group policy") ||
+    text.includes("blocked by your system administrator") ||
+    text.includes("disabled on this system") ||
+    text.includes("running scripts is disabled") ||
+    text.includes("그룹 정책") ||
+    text.includes("시스템 관리자") ||
+    text.includes("스크립트를 실행할 수 없");
+  if (isExplicitPolicyBlock) return true;
+
+  if (context === "command") return false;
+
   return (
     text.includes("eperm") ||
     text.includes("eacces") ||
@@ -49,15 +66,8 @@ export const isPowerShellBlockedReason = (reason: unknown): boolean => {
     text.includes("access denied") ||
     text.includes("permission denied") ||
     text.includes("operation not permitted") ||
-    text.includes("blocked by group policy") ||
-    text.includes("blocked by your system administrator") ||
-    text.includes("disabled on this system") ||
-    text.includes("running scripts is disabled") ||
     text.includes("unauthorizedaccessexception") ||
-    text.includes("액세스가 거부") ||
-    text.includes("그룹 정책") ||
-    text.includes("시스템 관리자") ||
-    text.includes("스크립트를 실행할 수 없")
+    text.includes("액세스가 거부")
   );
 };
 
@@ -83,6 +93,7 @@ interface IPCResponse {
   id: string;
   stdout: string;
   stderr: string;
+  code?: number | null;
   error?: string;
 }
 
@@ -95,6 +106,324 @@ interface SessionState {
   initializing: Promise<void> | null;
   rejectInit?: (reason: unknown) => void;
 }
+
+const quotePowerShellString = (value: string): string =>
+  `'${value.replace(/'/g, "''")}'`;
+
+const quotePowerShellArray = (values: string[]): string =>
+  `@(${values.map(quotePowerShellString).join(", ")})`;
+
+const buildDeferredFontCleanupFunctions = (): string => `
+  function Remove-Or-DeferFontFile([string]$fontPath) {
+    if ([string]::IsNullOrWhiteSpace($fontPath) -or -not (Test-Path $fontPath)) { return }
+    try {
+      Remove-Item -LiteralPath $fontPath -Force -ErrorAction Stop
+    } catch {
+      $MOVEFILE_DELAY_UNTIL_REBOOT = 0x4
+      $scheduled = $Win32API::MoveFileEx($fontPath, $null, $MOVEFILE_DELAY_UNTIL_REBOOT)
+      if ($scheduled) {
+        Write-Output "Scheduled font cleanup after reboot: $fontPath"
+        return
+      }
+
+      $nativeError = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
+      try {
+        Add-PendingDeleteRegistry $fontPath $nativeError
+      } catch {
+        Write-Output "Failed to schedule font cleanup after reboot: $fontPath (MoveFileEx=$nativeError, Registry=$($_.Exception.Message))"
+      }
+    }
+  }
+
+  function Add-PendingDeleteRegistry([string]$fontPath, [int]$moveFileError) {
+    $sessionManagerPath = "HKLM:\\SYSTEM\\CurrentControlSet\\Control\\Session Manager"
+    $pendingName = "PendingFileRenameOperations"
+    $deletePath = if ($fontPath.StartsWith("\\??\\")) { $fontPath } else { "\\??\\$fontPath" }
+
+    $prop = Get-ItemProperty -Path $sessionManagerPath -Name $pendingName -ErrorAction SilentlyContinue
+    $pending = @()
+    if ($prop -and $null -ne $prop.$pendingName) {
+      $pending = @($prop.$pendingName)
+    }
+
+    $alreadyScheduled = $false
+    for ($i = 0; $i -lt $pending.Count; $i += 2) {
+      $source = $pending[$i]
+      $destination = if ($i + 1 -lt $pending.Count) { $pending[$i + 1] } else { "" }
+      if ($source -ieq $deletePath -and [string]::IsNullOrEmpty($destination)) {
+        $alreadyScheduled = $true
+        break
+      }
+    }
+
+    if (-not $alreadyScheduled) {
+      $pending = @($pending) + $deletePath + ""
+    }
+
+    if ($prop) {
+      Set-ItemProperty -Path $sessionManagerPath -Name $pendingName -Value ([string[]]$pending)
+    } else {
+      New-ItemProperty -Path $sessionManagerPath -Name $pendingName -PropertyType MultiString -Value ([string[]]$pending) -Force | Out-Null
+    }
+
+    Write-Output "Scheduled font cleanup after reboot via registry fallback: $fontPath (MoveFileEx=$moveFileError)"
+  }
+`;
+
+export const buildInstallSystemFontScript = (
+  ttfFilePath: string,
+  targetFontName: string,
+  ttfFileName: string,
+): string => {
+  const apiClassName = `Win32FontAPIInstall${randomUUID().replace(/-/g, "")}`;
+
+  return `
+try {
+  $sourcePath = ${quotePowerShellString(ttfFilePath)}
+  $targetFontName = ${quotePowerShellString(targetFontName)}
+  $requestedFileName = ${quotePowerShellString(ttfFileName)}
+  $fontDir = Join-Path $env:windir "Fonts"
+  $baseName = [System.IO.Path]::GetFileNameWithoutExtension($requestedFileName)
+  $extension = [System.IO.Path]::GetExtension($requestedFileName)
+  $sourceHash = (Get-FileHash -Algorithm SHA256 -Path $sourcePath).Hash.Substring(0, 12).ToLowerInvariant()
+  $destFileName = "$baseName-$sourceHash$extension"
+  $destPath = Join-Path $fontDir $destFileName
+  $legacyPath = Join-Path $fontDir $requestedFileName
+
+  $Signature = @'
+    [DllImport("gdi32.dll", CharSet = CharSet.Unicode)]
+    public static extern int AddFontResource(string lpszFilename);
+
+    [DllImport("gdi32.dll", CharSet = CharSet.Unicode)]
+    public static extern bool RemoveFontResource(string lpFileName);
+
+    [DllImport("user32.dll", CharSet = CharSet.Auto)]
+    public static extern bool PostMessage(IntPtr hWnd, uint Msg, IntPtr wParam, IntPtr lParam);
+
+    [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public static extern bool MoveFileEx(string lpExistingFileName, string lpNewFileName, int dwFlags);
+'@
+  $Win32API = Add-Type -MemberDefinition $Signature -Name ${quotePowerShellString(apiClassName)} -Namespace "Win32Functions" -PassThru
+
+  function Resolve-FontPath([string]$fontValue) {
+    if ([string]::IsNullOrWhiteSpace($fontValue)) { return $null }
+    if ($fontValue -match '[\\\\/:]') { return $fontValue }
+    return Join-Path $fontDir $fontValue
+  }
+
+  function Unregister-FontPath([string]$fontPath) {
+    if ([string]::IsNullOrWhiteSpace($fontPath) -or -not (Test-Path $fontPath)) { return }
+    for ($i = 0; $i -lt 10; $i++) {
+      if (-not $Win32API::RemoveFontResource($fontPath)) { break }
+    }
+  }
+
+${buildDeferredFontCleanupFunctions()}
+
+  $regPath = "HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts"
+  $regName = "$targetFontName (TrueType)"
+  $oldPaths = New-Object System.Collections.Generic.List[string]
+
+  $prop = Get-ItemProperty -Path $regPath -Name $regName -ErrorAction SilentlyContinue
+  if ($prop) {
+    $oldPath = Resolve-FontPath $prop."$regName"
+    if ($oldPath) { [void]$oldPaths.Add($oldPath) }
+  }
+  if (Test-Path $legacyPath) { [void]$oldPaths.Add($legacyPath) }
+
+  Get-ChildItem -LiteralPath $fontDir -Filter "$baseName-*$extension" -ErrorAction SilentlyContinue |
+    ForEach-Object { [void]$oldPaths.Add($_.FullName) }
+
+  $uniqueOldPaths = $oldPaths |
+    Where-Object { $_ -and ([System.String]::Compare($_, $destPath, $true) -ne 0) } |
+    Select-Object -Unique
+
+  foreach ($oldPath in $uniqueOldPaths) {
+    Unregister-FontPath $oldPath
+  }
+  [void]$Win32API::PostMessage(0xffff, 0x001D, [IntPtr]::Zero, [IntPtr]::Zero)
+  Start-Sleep -Milliseconds 200
+
+  Unblock-File -Path $sourcePath
+  if (-not (Test-Path $destPath)) {
+    Copy-Item -Path $sourcePath -Destination $destPath -Force
+  }
+
+  Set-ItemProperty -Path $regPath -Name $regName -Value $destFileName
+
+  $added = $Win32API::AddFontResource($destPath)
+  if ($added -le 0) {
+    throw "AddFontResource failed for $destPath"
+  }
+  [void]$Win32API::PostMessage(0xffff, 0x001D, [IntPtr]::Zero, [IntPtr]::Zero)
+
+  foreach ($oldPath in $uniqueOldPaths) {
+    Remove-Or-DeferFontFile $oldPath
+  }
+
+  Write-Output "Successfully installed: $targetFontName ($destFileName)"
+} catch {
+  Write-Error $_.Exception.Message
+  exit 1
+}
+    `;
+};
+
+export const buildCleanupManagedFontFilesScript = (
+  ttfFileNames: string[],
+  targetFontNames: string[],
+  dryRun: boolean,
+): string => {
+  const apiClassName = `Win32FontAPICleanup${randomUUID().replace(/-/g, "")}`;
+  const actionScript = dryRun
+    ? `
+  foreach ($fontPath in $uniqueCandidates) {
+    Write-Output "ORPHAN:$fontPath"
+  }
+`
+    : `
+  if (@($uniqueCandidates).Count -eq 0) {
+    Write-Output "Managed font cleanup candidates: 0"
+    return
+  }
+
+  $Signature = @'
+    [DllImport("gdi32.dll", CharSet = CharSet.Unicode)]
+    public static extern bool RemoveFontResource(string lpFileName);
+
+    [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public static extern bool MoveFileEx(string lpExistingFileName, string lpNewFileName, int dwFlags);
+'@
+  $Win32API = Add-Type -MemberDefinition $Signature -Name ${quotePowerShellString(apiClassName)} -Namespace "Win32Functions" -PassThru
+
+${buildDeferredFontCleanupFunctions()}
+
+  foreach ($fontPath in $uniqueCandidates) {
+    [void]$Win32API::RemoveFontResource($fontPath)
+    Remove-Or-DeferFontFile $fontPath
+  }
+
+  Write-Output "Managed font cleanup candidates: $(@($uniqueCandidates).Count)"
+`;
+
+  return `
+try {
+  $requestedFileNames = ${quotePowerShellArray(ttfFileNames)}
+  $targetFontNames = ${quotePowerShellArray(targetFontNames)}
+  $dryRun = ${dryRun ? "$true" : "$false"}
+  $fontDir = Join-Path $env:windir "Fonts"
+  $localFontDir = Join-Path $env:LOCALAPPDATA "Microsoft\\Windows\\Fonts"
+  $usedPaths = New-Object 'System.Collections.Generic.HashSet[string]' -ArgumentList ([System.StringComparer]::OrdinalIgnoreCase)
+
+  function Add-UsedFontPath([string]$fontValue, [string]$baseDir) {
+    if ([string]::IsNullOrWhiteSpace($fontValue)) { return }
+    $resolved = if ($fontValue -match '[\\\\/:]') { $fontValue } else { Join-Path $baseDir $fontValue }
+    if (-not [string]::IsNullOrWhiteSpace($resolved)) {
+      [void]$usedPaths.Add($resolved)
+    }
+  }
+
+  foreach ($targetFontName in $targetFontNames) {
+    $regName = "$targetFontName (TrueType)"
+    $registries = @(
+      @{ Path = "HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts"; FontDir = $fontDir },
+      @{ Path = "HKCU:\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Fonts"; FontDir = $localFontDir }
+    )
+    foreach ($regInfo in $registries) {
+      $prop = Get-ItemProperty -Path $regInfo.Path -Name $regName -ErrorAction SilentlyContinue
+      if ($prop) {
+        Add-UsedFontPath $prop."$regName" $regInfo.FontDir
+      }
+    }
+  }
+
+  $candidates = New-Object System.Collections.Generic.List[string]
+  foreach ($requestedFileName in $requestedFileNames) {
+    $baseName = [System.IO.Path]::GetFileNameWithoutExtension($requestedFileName)
+    $extension = [System.IO.Path]::GetExtension($requestedFileName)
+    $pattern = "^" + [regex]::Escape($baseName) + "-[0-9a-fA-F]{12}" + [regex]::Escape($extension) + "$"
+    Get-ChildItem -LiteralPath $fontDir -File -ErrorAction SilentlyContinue |
+      Where-Object { $_.Name -match $pattern -and -not $usedPaths.Contains($_.FullName) } |
+      ForEach-Object { [void]$candidates.Add($_.FullName) }
+  }
+
+  $uniqueCandidates = $candidates | Select-Object -Unique
+${actionScript}
+} catch {
+  Write-Error $_.Exception.Message
+  exit 1
+}
+    `;
+};
+
+export const buildRemoveSystemFontScript = (
+  targetFontName: string,
+  ttfFileName: string,
+  hive: "HKLM" | "HKCU",
+): string => {
+  const regPath =
+    hive === "HKLM"
+      ? "HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts"
+      : "HKCU:\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Fonts";
+  const fontDirExpression =
+    hive === "HKLM"
+      ? 'Join-Path $env:windir "Fonts"'
+      : 'Join-Path $env:LOCALAPPDATA "Microsoft\\Windows\\Fonts"';
+  const className = `Win32FontAPIRemove${hive}${randomUUID().replace(/-/g, "")}`;
+
+  return `
+try {
+  $regPath = ${quotePowerShellString(regPath)}
+  $regName = ${quotePowerShellString(`${targetFontName} (TrueType)`)}
+  $fontDir = ${fontDirExpression}
+  $fallbackPath = Join-Path $fontDir ${quotePowerShellString(ttfFileName)}
+
+  $Signature = @'
+    [DllImport("gdi32.dll", CharSet = CharSet.Unicode)]
+    public static extern bool RemoveFontResource(string lpFileName);
+
+    [DllImport("user32.dll", CharSet = CharSet.Auto)]
+    public static extern bool PostMessage(IntPtr hWnd, uint Msg, IntPtr wParam, IntPtr lParam);
+
+    [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public static extern bool MoveFileEx(string lpExistingFileName, string lpNewFileName, int dwFlags);
+'@
+  $Win32API = Add-Type -MemberDefinition $Signature -Name ${quotePowerShellString(className)} -Namespace "Win32Functions" -PassThru
+
+${buildDeferredFontCleanupFunctions()}
+
+  # --- 1차: 레지스트리 이름 기반 (임의 파일명 잔재) ---
+  $prop = Get-ItemProperty -Path $regPath -Name $regName -ErrorAction SilentlyContinue
+  if ($prop) {
+    $regVal = $prop."$regName"
+    # 값이 절대경로면 그대로, 파일명만이면 폰트 디렉터리와 결합
+    if ($regVal -match '[\\\\/:]') { $target = $regVal } else { $target = Join-Path $fontDir $regVal }
+    if (Test-Path $target) {
+      [void]$Win32API::RemoveFontResource($target)
+      Remove-Or-DeferFontFile $target
+    }
+    Remove-ItemProperty -Path $regPath -Name $regName -Force -ErrorAction SilentlyContinue
+  }
+
+  # --- 2차: 런처 규칙 파일명 폴백 (레지스트리 깨진 런처 잔재) ---
+  if (Test-Path $fallbackPath) {
+    [void]$Win32API::RemoveFontResource($fallbackPath)
+    Remove-Or-DeferFontFile $fallbackPath
+  }
+
+  # 변경 전파
+  [void]$Win32API::PostMessage(0xffff, 0x001D, [IntPtr]::Zero, [IntPtr]::Zero) # HWND_BROADCAST, WM_FONTCHANGE
+
+  Write-Output "Removed (${hive}): ${targetFontName}"
+} catch {
+  Write-Error $_.Exception.Message
+  exit 1
+}
+    `;
+};
 
 export class PowerShellManager {
   private static instance: PowerShellManager;
@@ -224,7 +553,7 @@ export class PowerShellManager {
 
       session.pendingRequests.set(id, (res) => {
         clearTimeout(timeout);
-        if (isPowerShellBlockedReason(res.stderr || res.stdout)) {
+        if (isPowerShellBlockedReason(res.stderr || res.stdout, "command")) {
           const blockedError = createPowerShellBlockedException(
             res.stderr || res.stdout,
           );
@@ -327,7 +656,7 @@ export class PowerShellManager {
                     callback({
                       stdout: response.stdout,
                       stderr: response.stderr,
-                      code: 0,
+                      code: response.code ?? 0,
                     });
                   }
                 }
@@ -412,6 +741,7 @@ try {
 
             $outData = @()
             $errData = @()
+            $exitCode = 0
             
             try {
                 $results = Invoke-Expression $cmd 2>&1 | ForEach-Object {
@@ -421,14 +751,19 @@ try {
                         $outData += $_.ToString()
                     }
                 }
+                if ($errData.Count -gt 0) {
+                    $exitCode = 1
+                }
             } catch {
                 $errData += $_.Exception.Message
+                $exitCode = 1
             }
             
             $res = @{
                 id = $id
                 stdout = ($outData -join "\`n")
                 stderr = ($errData -join "\`n")
+                code = $exitCode
             }
             
             $jsonRes = $res | ConvertTo-Json -Compress
@@ -546,56 +881,60 @@ try {
     targetFontName: string,
     ttfFileName: string,
   ): Promise<boolean> {
-    const script = `
-try {
-  $sourcePath = "${ttfFilePath}"
-  $destPath = "$env:windir\\Fonts\\${ttfFileName}"
-
-  $Signature = @'
-    [DllImport("gdi32.dll", CharSet = CharSet.Unicode)]
-    public static extern int AddFontResource(string lpszFilename);
-
-    [DllImport("gdi32.dll", CharSet = CharSet.Unicode)]
-    public static extern bool RemoveFontResource(string lpFileName);
-
-    [DllImport("user32.dll", CharSet = CharSet.Auto)]
-    public static extern bool PostMessage(IntPtr hWnd, uint Msg, IntPtr wParam, IntPtr lParam);
-'@
-  $Win32API = Add-Type -MemberDefinition $Signature -Name "Win32FontAPI_Install" -Namespace "Win32Functions" -PassThru
-
-  # 1. 같은 경로 폰트가 이미 GDI에 매핑돼 있으면 ref count 0까지 unregister.
-  #    같은 파일명 in-place 갱신 시 AddFontResource가 새 데이터를 reload하지
-  #    않는 문제(재부팅 전까지 stale metrics 사용) 회피. 최대 10회 반복.
-  if (Test-Path $destPath) {
-    for ($i = 0; $i -lt 10; $i++) {
-      if (-not $Win32API::RemoveFontResource($destPath)) { break }
+    const script = buildInstallSystemFontScript(
+      ttfFilePath,
+      targetFontName,
+      ttfFileName,
+    );
+    const result = await this.execute(script, true);
+    if (result.code !== 0) {
+      const reason =
+        result.stderr || result.stdout || `PowerShell exit code ${result.code}`;
+      throw new Error(
+        `Failed to install system font '${targetFontName}': ${reason}`,
+      );
     }
-    [void]$Win32API::PostMessage(0xffff, 0x001D, [IntPtr]::Zero, [IntPtr]::Zero)
-    Start-Sleep -Milliseconds 200
-    Remove-Item $destPath -Force
+    return true;
   }
 
-  # 2. 보안 차단 해제 및 Fonts 경로로 복사
-  Unblock-File -Path $sourcePath
-  Copy-Item -Path $sourcePath -Destination $destPath -Force
+  public async cleanupOrphanedManagedFontFiles(
+    ttfFileNames: string[],
+    targetFontNames: string[],
+  ): Promise<boolean> {
+    const scanScript = buildCleanupManagedFontFilesScript(
+      ttfFileNames,
+      targetFontNames,
+      true,
+    );
+    const scanResult = await this.execute(scanScript, false, true);
+    if (scanResult.code !== 0) {
+      const reason =
+        scanResult.stderr ||
+        scanResult.stdout ||
+        `PowerShell exit code ${scanResult.code}`;
+      throw new Error(`Failed to scan managed font cleanup targets: ${reason}`);
+    }
 
-  # 3. 레지스트리 등록
-  $regPath = "HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts"
-  $regName = "${targetFontName} (TrueType)"
-  Set-ItemProperty -Path $regPath -Name $regName -Value "${ttfFileName}"
+    const hasOrphan = scanResult.stdout
+      .split(/\r?\n/)
+      .some((line) => line.trim().startsWith("ORPHAN:"));
+    if (!hasOrphan) return true;
 
-  # 4. GDI 등록 + 변경 전파
-  [void]$Win32API::AddFontResource($destPath)
-  [void]$Win32API::PostMessage(0xffff, 0x001D, [IntPtr]::Zero, [IntPtr]::Zero) # HWND_BROADCAST, WM_FONTCHANGE
+    const cleanupScript = buildCleanupManagedFontFilesScript(
+      ttfFileNames,
+      targetFontNames,
+      false,
+    );
+    const cleanupResult = await this.execute(cleanupScript, true, true);
+    if (cleanupResult.code !== 0) {
+      const reason =
+        cleanupResult.stderr ||
+        cleanupResult.stdout ||
+        `PowerShell exit code ${cleanupResult.code}`;
+      throw new Error(`Failed to cleanup managed font files: ${reason}`);
+    }
 
-  Write-Output "Successfully installed: ${targetFontName}"
-} catch {
-  Write-Error $_.Exception.Message
-  exit 1
-}
-    `;
-    const result = await this.execute(script, true);
-    return result.code === 0;
+    return true;
   }
 
   /**
@@ -640,61 +979,11 @@ try {
     hive: "HKLM" | "HKCU",
     useAdmin: boolean,
   ): Promise<boolean> {
-    const regPath =
-      hive === "HKLM"
-        ? "HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Fonts"
-        : "HKCU:\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Fonts";
-    // 하이브별 기본 폰트 디렉터리 (레지스트리 값이 파일명만일 때 결합 + 폴백)
-    const fontDir =
-      hive === "HKLM"
-        ? "$env:windir\\Fonts"
-        : "$env:LOCALAPPDATA\\Microsoft\\Windows\\Fonts";
-    const className = `Win32FontAPI_Remove_${hive}`;
-
-    const script = `
-try {
-  $regPath = "${regPath}"
-  $regName = "${targetFontName} (TrueType)"
-  $fontDir = "${fontDir}"
-  $fallbackPath = Join-Path $fontDir "${ttfFileName}"
-
-  $Signature = @'
-    [DllImport("gdi32.dll", CharSet = CharSet.Unicode)]
-    public static extern bool RemoveFontResource(string lpFileName);
-
-    [DllImport("user32.dll", CharSet = CharSet.Auto)]
-    public static extern bool PostMessage(IntPtr hWnd, uint Msg, IntPtr wParam, IntPtr lParam);
-'@
-  $Win32API = Add-Type -MemberDefinition $Signature -Name "${className}" -Namespace "Win32Functions" -PassThru
-
-  # --- 1차: 레지스트리 이름 기반 (임의 파일명 잔재) ---
-  $prop = Get-ItemProperty -Path $regPath -Name $regName -ErrorAction SilentlyContinue
-  if ($prop) {
-    $regVal = $prop."$regName"
-    # 값이 절대경로면 그대로, 파일명만이면 폰트 디렉터리와 결합
-    if ($regVal -match '[\\\\/:]') { $target = $regVal } else { $target = Join-Path $fontDir $regVal }
-    if (Test-Path $target) {
-      [void]$Win32API::RemoveFontResource($target)
-      Remove-Item -Path $target -Force -ErrorAction SilentlyContinue
-    }
-    Remove-ItemProperty -Path $regPath -Name $regName -Force -ErrorAction SilentlyContinue
-  }
-
-  # --- 2차: 런처 규칙 파일명 폴백 (레지스트리 깨진 런처 잔재) ---
-  if (Test-Path $fallbackPath) {
-    [void]$Win32API::RemoveFontResource($fallbackPath)
-    Remove-Item -Path $fallbackPath -Force -ErrorAction SilentlyContinue
-  }
-
-  # 변경 전파
-  [void]$Win32API::PostMessage(0xffff, 0x001D, [IntPtr]::Zero, [IntPtr]::Zero) # HWND_BROADCAST, WM_FONTCHANGE
-
-  Write-Output "Removed (${hive}): ${targetFontName}"
-} catch {
-  Write-Error $_.Exception.Message
-  exit 1
-}
-    `;
+    const script = buildRemoveSystemFontScript(
+      targetFontName,
+      ttfFileName,
+      hive,
+    );
     const result = await this.execute(script, useAdmin, true);
     return result.code === 0;
   }

--- a/src/main/workers/FontMutatorWorker.ts
+++ b/src/main/workers/FontMutatorWorker.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import { parentPort } from "node:worker_threads";
 
-import { Font } from "fonteditor-core";
+import { mutateTtfSfnt } from "./otfMutator";
 
 /**
  * 폰트 메타데이터 + metrics 변조 워커 (Precision Mutator)
@@ -11,30 +11,16 @@ import { Font } from "fonteditor-core";
  * - metrics: 게임 본체 폰트(slider 100% 기준)를 scale%로 비례 조정.
  *   공식 근거: scratch/font-mutation-analysis.md 9.4.
  *   글리프는 건드리지 않는다(수직 보정은 STEP 3 별도).
+ * - SFNT 테이블 패치 방식으로 gasp/GPOS/GSUB/kern/힌팅 테이블을 보존한다.
  */
 
-import { FontMutationRule } from "../../shared/font-targets";
+import type { FontMutationRule } from "../../shared/font-targets";
 
 interface MutatorMessage {
   filePath: string;
   rule: FontMutationRule;
   /** 크기 보정 % (50~150). 미지정 시 100. */
   scale?: number;
-}
-
-/** scale% 적용한 라인높이/ascent/descent 산출 (9.4 공식). */
-function scaledLine(
-  baseAscent: number,
-  baseDescent: number,
-  scale: number,
-): { ascent: number; descent: number } {
-  const baseLine = baseAscent - baseDescent; // descent는 음수
-  const ascRatio = baseAscent / baseLine;
-  // 글자 크기 ∝ 1/라인높이 → scale% 크게 보이려면 라인높이 (100/scale)배
-  const newLine = Math.round((baseLine * 100) / scale);
-  const ascent = Math.round(newLine * ascRatio);
-  const descent = ascent - newLine; // 음수
-  return { ascent, descent };
 }
 
 if (parentPort) {
@@ -49,65 +35,7 @@ if (parentPort) {
       }
 
       const buffer = fs.readFileSync(filePath);
-      const font = Font.create(buffer, { type: "ttf" });
-      const fontData = font.get();
-      const name = fontData.name;
-      const m = rule.metrics;
-
-      // 1. Name Table 주입
-      name.fontFamily = rule.family; // ID 1
-      name.fontSubFamily = rule.subfamily; // ID 2
-      name.fullName = rule.fullName; // ID 4
-      name.postScriptName = rule.postScript; // ID 6
-
-      if (m) {
-        // 본체 정답값: uniqueSubFamily(ID 3) / version(ID 5) 원문 주입
-        name.uniqueSubFamily = m.uniqueSubFamily;
-        name.version = m.version;
-      } else {
-        // 본체 미확보(GGG): 기존 동작 유지 (합성 ID 3)
-        name.uniqueSubFamily = `${rule.postScript};${name.version || "1.000"}`;
-      }
-      // ID 16/17(preferredFamily/SubFamily)는 본체에 없으므로 주입하지 않는다.
-      // fonteditor-core가 미설정 필드를 비우도록 명시적으로 삭제.
-      delete (name as Record<string, unknown>).preferredFamily;
-      delete (name as Record<string, unknown>).preferredSubFamily;
-
-      // 2. metrics 주입 (정답 폰트만)
-      if (m) {
-        const head = fontData.head;
-        const hhea = fontData.hhea;
-        const os2 = fontData["OS/2"];
-
-        // 본체 정답값은 unitsPerEm=1000 기준. 입력 폰트가 다른 upm이면 비율로 보정한다
-        // (예: Pretendard 2048, 일부 maplestory/binggrae 900). 안 그러면 게임이 본체와
-        // 다른 단위로 ascent/descent를 해석해 글자가 작게 또는 잘리게 나온다.
-        const upmRatio = head.unitsPerEm / m.unitsPerEm;
-        const u = (v: number) => Math.round(v * upmRatio);
-
-        // hhea.descent는 음수, baseWinDescent는 양수 표기 → 음수로 변환해 전달
-        const h = scaledLine(u(m.baseHheaAscent), u(m.baseHheaDescent), scale);
-        const w = scaledLine(u(m.baseWinAscent), u(-m.baseWinDescent), scale);
-
-        hhea.ascent = h.ascent;
-        hhea.descent = h.descent;
-        hhea.lineGap = 0;
-
-        os2.usWinAscent = w.ascent;
-        os2.usWinDescent = -w.descent; // scaledLine descent(음수) → 양수 표기
-
-        // scale 무관, upm만 보정
-        os2.sTypoAscender = u(m.typoAscender);
-        os2.sTypoDescender = u(m.typoDescender);
-        os2.sTypoLineGap = u(m.typoLineGap);
-        os2.fsSelection = m.fsSelection;
-        os2.usWeightClass = m.usWeightClass;
-        head.macStyle = m.macStyle;
-      }
-
-      // 3. 변조 버퍼 생성 및 반환
-      const outputData = font.write({ type: "ttf" });
-      const finalBuffer = Buffer.from(outputData as Uint8Array);
+      const finalBuffer = mutateTtfSfnt(buffer, rule, scale);
       const arrayBuffer = finalBuffer.buffer.slice(
         finalBuffer.byteOffset,
         finalBuffer.byteOffset + finalBuffer.byteLength,

--- a/src/main/workers/otfMutator.ts
+++ b/src/main/workers/otfMutator.ts
@@ -1,12 +1,11 @@
 import type { FontMutationRule } from "../../shared/font-targets";
 
 /**
- * OTF(CFF) 전용 SFNT 레벨 변조 로직.
+ * SFNT 레벨 폰트 변조 로직.
  *
- * fonteditor-core는 OTF write를 지원하지 않고, type:'ttf'로 write하면
- * CFF→glyf 변환 단계에서 한글 음절 대부분의 outline이 손실된다.
- * → CFF 컨테이너는 절대 손대지 않고 SFNT 레벨에서 name/OS-2/hhea/head 4개
- *   테이블만 교체·패치한다. 결과 파일은 OTTO scaler를 유지한 OpenType.
+ * fonteditor-core로 폰트를 다시 쓰면 OTF(CFF)는 한글 outline이 손실되고,
+ * 일부 TTF는 gasp/GPOS/GSUB/kern 같은 렌더링 보조 테이블이 사라진다.
+ * → glyph/레이아웃 테이블은 원본 그대로 두고 name/OS-2/hhea/head만 패치한다.
  *
  * 워커 IPC와 분리되어 있어 vitest 등에서 직접 import해 단위 검증 가능.
  */
@@ -30,35 +29,101 @@ function readTableDirectory(buf: Buffer): {
   return { scaler: buf.slice(0, 4), tables };
 }
 
-function buildNameTable(names: Record<number, string>): Buffer {
-  const order = [1, 2, 3, 4, 5, 6];
-  const records: { nameID: number; length: number; offset: number }[] = [];
-  const storage: Buffer[] = [];
-  let storageOffset = 0;
-  for (const nameID of order) {
-    const str = names[nameID];
-    const utf16 = Buffer.from(str, "utf16le");
+type NameRecord = {
+  platformID: number;
+  encodingID: number;
+  languageID: number;
+  nameID: number;
+  data: Buffer;
+};
+
+type WritableNameRecord = NameRecord & {
+  length: number;
+  offset: number;
+};
+
+function decodeUtf16BE(buf: Buffer): string {
+  const le = Buffer.alloc(buf.length);
+  for (let i = 0; i < buf.length; i += 2) {
+    le[i] = buf[i + 1];
+    le[i + 1] = buf[i];
+  }
+  return le.toString("utf16le");
+}
+
+function encodeNameValue(record: NameRecord, value: string): Buffer {
+  if (record.platformID === 0 || record.platformID === 3) {
+    const utf16 = Buffer.from(value, "utf16le");
     const be = Buffer.alloc(utf16.length);
     for (let i = 0; i < utf16.length; i += 2) {
       be[i] = utf16[i + 1];
       be[i + 1] = utf16[i];
     }
-    records.push({ nameID, length: be.length, offset: storageOffset });
-    storage.push(be);
-    storageOffset += be.length;
+    return be;
   }
-  const stringOffset = 6 + records.length * 12;
+
+  return Buffer.from(value, "latin1");
+}
+
+function readNameRecords(nameTable: Buffer): NameRecord[] {
+  const count = nameTable.readUInt16BE(2);
+  const stringOffset = nameTable.readUInt16BE(4);
+  const records: NameRecord[] = [];
+  for (let i = 0; i < count; i++) {
+    const off = 6 + i * 12;
+    const length = nameTable.readUInt16BE(off + 8);
+    const offset = nameTable.readUInt16BE(off + 10);
+    const start = stringOffset + offset;
+    records.push({
+      platformID: nameTable.readUInt16BE(off),
+      encodingID: nameTable.readUInt16BE(off + 2),
+      languageID: nameTable.readUInt16BE(off + 4),
+      nameID: nameTable.readUInt16BE(off + 6),
+      data: Buffer.from(nameTable.subarray(start, start + length)),
+    });
+  }
+  return records;
+}
+
+function readNameValue(nameTable: Buffer, nameID: number): string | undefined {
+  const records = readNameRecords(nameTable).filter((r) => r.nameID === nameID);
+  const preferred =
+    records.find((r) => r.platformID === 3 && r.languageID === 0x0409) ||
+    records.find((r) => r.platformID === 3) ||
+    records[0];
+  if (!preferred) return undefined;
+  if (preferred.platformID === 0 || preferred.platformID === 3) {
+    return decodeUtf16BE(preferred.data);
+  }
+  return preferred.data.toString("latin1");
+}
+
+function buildNameTable(records: NameRecord[]): Buffer {
+  const writableRecords: WritableNameRecord[] = [];
+  const storage: Buffer[] = [];
+  let storageOffset = 0;
+  for (const record of records) {
+    writableRecords.push({
+      ...record,
+      length: record.data.length,
+      offset: storageOffset,
+    });
+    storage.push(record.data);
+    storageOffset += record.data.length;
+  }
+
+  const stringOffset = 6 + writableRecords.length * 12;
   const out = Buffer.alloc(stringOffset + storageOffset);
   out.writeUInt16BE(0, 0); // format 0
-  out.writeUInt16BE(records.length, 2);
+  out.writeUInt16BE(writableRecords.length, 2);
   out.writeUInt16BE(stringOffset, 4);
   let p = 6;
-  for (const r of records) {
-    out.writeUInt16BE(3, p); // platformID Windows
+  for (const r of writableRecords) {
+    out.writeUInt16BE(r.platformID, p);
     p += 2;
-    out.writeUInt16BE(1, p); // encodingID Unicode BMP
+    out.writeUInt16BE(r.encodingID, p);
     p += 2;
-    out.writeUInt16BE(0x0409, p); // languageID en-US
+    out.writeUInt16BE(r.languageID, p);
     p += 2;
     out.writeUInt16BE(r.nameID, p);
     p += 2;
@@ -73,6 +138,48 @@ function buildNameTable(names: Record<number, string>): Buffer {
     sp += s.length;
   }
   return out;
+}
+
+function patchNameTable(
+  nameTable: Buffer,
+  replacements: Record<number, string>,
+): Buffer {
+  const replaceIds = new Set(Object.keys(replacements).map(Number));
+  const removeIds = new Set([16, 17]);
+  const sourceRecords = readNameRecords(nameTable);
+  const patchedRecords: NameRecord[] = [];
+  const seenReplaceIds = new Set<number>();
+
+  for (const record of sourceRecords) {
+    if (removeIds.has(record.nameID)) continue;
+    const replacement = replacements[record.nameID];
+    if (replacement !== undefined) {
+      patchedRecords.push({
+        ...record,
+        data: encodeNameValue(record, replacement),
+      });
+      seenReplaceIds.add(record.nameID);
+    } else {
+      patchedRecords.push(record);
+    }
+  }
+
+  for (const nameID of replaceIds) {
+    if (seenReplaceIds.has(nameID)) continue;
+    const record: NameRecord = {
+      platformID: 3,
+      encodingID: 1,
+      languageID: 0x0409,
+      nameID,
+      data: Buffer.alloc(0),
+    };
+    patchedRecords.push({
+      ...record,
+      data: encodeNameValue(record, replacements[nameID]),
+    });
+  }
+
+  return buildNameTable(patchedRecords);
 }
 
 function pad4(n: number): number {
@@ -189,7 +296,25 @@ export function mutateOtfSfnt(
   if (buffer.slice(0, 4).toString("ascii") !== "OTTO") {
     throw new Error("OtfMutator: 입력이 OTTO scaler가 아님");
   }
+  return mutateSfnt(buffer, rule, scale);
+}
 
+export function mutateTtfSfnt(
+  buffer: Buffer,
+  rule: FontMutationRule,
+  scale: number,
+): Buffer {
+  if (buffer.slice(0, 4).toString("ascii") === "OTTO") {
+    throw new Error("TtfMutator: 입력이 TrueType scaler가 아님");
+  }
+  return mutateSfnt(buffer, rule, scale);
+}
+
+export function mutateSfnt(
+  buffer: Buffer,
+  rule: FontMutationRule,
+  scale: number,
+): Buffer {
   const { scaler, tables } = readTableDirectory(buffer);
   const m = rule.metrics;
   const newTables: Record<string, Buffer> = { ...tables };
@@ -197,9 +322,12 @@ export function mutateOtfSfnt(
   // === name table 교체 ===
   // ID 3(uniqueSubFamily)/5(version)는 metrics가 있을 때만 본체 원문, 없으면 합성
   // (FontMutatorWorker의 분기와 동일).
-  const uniqueSubFamily = m ? m.uniqueSubFamily : `${rule.postScript};1.000`;
-  const version = m ? m.version : "Version 1.000";
-  newTables["name"] = buildNameTable({
+  const sourceVersion = readNameValue(tables["name"], 5) || "1.000";
+  const uniqueSubFamily = m
+    ? m.uniqueSubFamily
+    : `${rule.postScript};${sourceVersion}`;
+  const version = m ? m.version : sourceVersion;
+  newTables["name"] = patchNameTable(tables["name"], {
     1: rule.family,
     2: rule.subfamily,
     3: uniqueSubFamily,

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -207,6 +207,10 @@ function App() {
   // [New] Theme Settings Version to trigger Effects
   const [themeVersion, setThemeVersion] = useState(0);
 
+  const [isUpdateModalOpen, setIsUpdateModalOpen] = useState(false);
+  const [isMigrationModalOpen, setIsMigrationModalOpen] = useState(false); // [UAC Migration]
+  const [isFontMigrationOpen, setIsFontMigrationOpen] = useState(false);
+
   // --- Global Game State ---
   const { getActiveGameState, syncGameState } = useGameState();
 
@@ -214,11 +218,24 @@ function App() {
   const activeGameStatus = useMemo(() => {
     return getActiveGameState(config.activeGame, config.serviceChannel);
   }, [config.activeGame, config.serviceChannel, getActiveGameState]);
+  const isFontMigrationBlockedByRunningGame = useMemo(() => {
+    return (
+      getActiveGameState(config.activeGame, "Kakao Games").status ===
+        "running" ||
+      getActiveGameState(config.activeGame, "GGG").status === "running"
+    );
+  }, [config.activeGame, getActiveGameState]);
 
   // Sync initial and switched state
   useEffect(() => {
     syncGameState(config.activeGame, config.serviceChannel);
   }, [config.activeGame, config.serviceChannel, syncGameState]);
+
+  useEffect(() => {
+    if (!isFontMigrationOpen) return;
+    syncGameState(config.activeGame, "Kakao Games");
+    syncGameState(config.activeGame, "GGG");
+  }, [config.activeGame, isFontMigrationOpen, syncGameState]);
 
   // Active Status Message State
   const [activeMessage, setActiveMessage] = useState<string>("");
@@ -282,10 +299,6 @@ function App() {
       );
     };
   }, []);
-
-  const [isUpdateModalOpen, setIsUpdateModalOpen] = useState(false);
-  const [isMigrationModalOpen, setIsMigrationModalOpen] = useState(false); // [UAC Migration]
-  const [isFontMigrationOpen, setIsFontMigrationOpen] = useState(false);
 
   // Forced Repair Modal State
   const [isForcedRepairOpen, setIsForcedRepairOpen] = useState(false);
@@ -1165,6 +1178,7 @@ function App() {
         isOpen={isFontMigrationOpen}
         onConfirm={handleFontMigrationConfirm}
         onCancel={() => setIsFontMigrationOpen(false)}
+        isGameRunning={isFontMigrationBlockedByRunningGame}
       />
 
       {isChangelogOpen && (

--- a/src/renderer/components/modals/FontMigrationModal.tsx
+++ b/src/renderer/components/modals/FontMigrationModal.tsx
@@ -6,6 +6,7 @@ interface FontMigrationModalProps {
   /** 재적용 실행. 성공 시 resolve, 실패 시 reject. */
   onConfirm: () => Promise<void>;
   onCancel: () => void;
+  isGameRunning?: boolean;
 }
 
 /**
@@ -18,6 +19,7 @@ const FontMigrationModal: React.FC<FontMigrationModalProps> = ({
   isOpen,
   onConfirm,
   onCancel,
+  isGameRunning = false,
 }) => {
   const [applying, setApplying] = useState(false);
   const [errorMsg, setErrorMsg] = useState("");
@@ -25,6 +27,10 @@ const FontMigrationModal: React.FC<FontMigrationModalProps> = ({
   if (!isOpen) return null;
 
   const handleConfirm = async () => {
+    if (isGameRunning) {
+      setErrorMsg("게임 실행 중에는 폰트를 업데이트할 수 없습니다.");
+      return;
+    }
     setErrorMsg("");
     setApplying(true);
     try {
@@ -61,7 +67,9 @@ const FontMigrationModal: React.FC<FontMigrationModalProps> = ({
               폰트 적용 방식이 개선되었습니다. 현재 설치된 커스텀 폰트는 이전
               방식으로 만들어져 게임에서 글자 크기가 어긋날 수 있습니다.
               {"\n\n"}
-              지금 새 방식으로 다시 설치하시겠습니까?
+              {isGameRunning
+                ? "현재 게임이 실행 중입니다. 게임을 먼저 종료한 뒤 다시 업데이트해 주세요."
+                : "지금 새 방식으로 다시 설치하시겠습니까?"}
               {errorMsg && (
                 <>
                   {"\n\n"}
@@ -84,9 +92,13 @@ const FontMigrationModal: React.FC<FontMigrationModalProps> = ({
           <button
             className="btn-confirm-primary btn-primary"
             onClick={handleConfirm}
-            disabled={applying}
+            disabled={applying || isGameRunning}
           >
-            {applying ? "적용 중…" : "지금 업데이트 (권장)"}
+            {applying
+              ? "적용 중…"
+              : isGameRunning
+                ? "게임 종료 후 업데이트"
+                : "지금 업데이트 (권장)"}
           </button>
         </div>
       </div>

--- a/src/shared/font-targets.ts
+++ b/src/shared/font-targets.ts
@@ -153,6 +153,7 @@ export const FONT_SCALE_DEFAULT = 100;
  * 폰트 변조 스키마 버전. 변조 로직(name table/metrics 규칙)이 바뀔 때마다 올린다.
  * - 1: 구버전 (name table 6필드, metrics 미변조) — 명시 저장 안 됨, 미설정=1로 간주
  * - 2: 본체 metrics 주입 + name table 결함 정정 (STEP 2)
+ * - 3: TTF도 SFNT 패치 방식으로 변조해 gasp/GPOS/GSUB/kern/힌팅 테이블 보존
  * 설치된 폰트의 schema < 현재값이면 재적용 마이그레이션이 필요하다.
  */
-export const FONT_MUTATION_SCHEMA = 2;
+export const FONT_MUTATION_SCHEMA = 3;

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -2,6 +2,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { readFileSync } from "node:fs";
 import { execSync } from "node:child_process";
+import type { ChildProcess } from "node:child_process";
 
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
@@ -46,8 +47,12 @@ type ElectronStartupOptions = {
   reload: () => void;
 };
 
+type ManagedElectronProcess = ChildProcess & {
+  __poe2IpcErrorHandlerAttached?: boolean;
+};
+
 type ElectronProcess = NodeJS.Process & {
-  electronApp?: unknown;
+  electronApp?: ManagedElectronProcess;
 };
 
 type ExecError = Error & {
@@ -66,7 +71,9 @@ const getElectronStartupArgs = () => {
 
 const startElectronApp = async (options: ElectronStartupOptions) => {
   try {
-    return await options.startup(getElectronStartupArgs());
+    const result = await options.startup(getElectronStartupArgs());
+    attachElectronProcessErrorHandler();
+    return result;
   } catch (error) {
     if (!isMissingTaskkillProcessError(error)) {
       throw error;
@@ -77,18 +84,66 @@ const startElectronApp = async (options: ElectronStartupOptions) => {
       "[vite] Ignoring stale Electron PID cleanup failure and retrying startup.",
     );
     electronProcess.electronApp = undefined;
-    return options.startup(getElectronStartupArgs());
+    const result = await options.startup(getElectronStartupArgs());
+    attachElectronProcessErrorHandler();
+    return result;
   }
 };
 
 const reloadElectronRenderer = (options: ElectronStartupOptions) => {
-  if ((process as ElectronProcess).electronApp) {
-    options.reload();
-    return;
+  const electronProcess = process as ElectronProcess;
+
+  if (isElectronAppReloadable(electronProcess.electronApp)) {
+    try {
+      options.reload();
+      return;
+    } catch (error) {
+      if (!isClosedIpcError(error)) {
+        throw error;
+      }
+
+      console.warn(
+        "[vite] Electron IPC channel was closed during reload. Restarting app.",
+      );
+    }
+  } else if (electronProcess.electronApp) {
+    console.warn("[vite] Electron app handle is stale. Restarting app.");
   }
 
+  electronProcess.electronApp = undefined;
   return startElectronApp(options);
 };
+
+function isElectronAppReloadable(electronApp?: ManagedElectronProcess) {
+  return (
+    !!electronApp && !electronApp.killed && electronApp.connected !== false
+  );
+}
+
+function attachElectronProcessErrorHandler() {
+  const electronApp = (process as ElectronProcess).electronApp;
+  if (!electronApp || electronApp.__poe2IpcErrorHandlerAttached) return;
+
+  electronApp.__poe2IpcErrorHandlerAttached = true;
+  electronApp.on("error", (error) => {
+    if (isClosedIpcError(error)) {
+      console.warn("[vite] Ignoring closed Electron IPC channel.");
+      (process as ElectronProcess).electronApp = undefined;
+      return;
+    }
+
+    console.error("[vite] Electron process error:", error);
+  });
+}
+
+function isClosedIpcError(error: unknown) {
+  if (!(error instanceof Error)) return false;
+
+  const code = (error as Error & { code?: string }).code;
+  return (
+    code === "ERR_IPC_CHANNEL_CLOSED" || error.message === "Channel closed"
+  );
+}
 
 function isMissingTaskkillProcessError(error: unknown) {
   if (!(error instanceof Error)) return false;


### PR DESCRIPTION
## 요약

- 저해상도에서 일부 커스텀 폰트가 계단져 보이는 문제를 줄이도록 폰트 재가공 방식을 보정했습니다.
- 게임 실행 중에는 폰트 업데이트 재적용을 진행하지 않도록 막고, 런처 시작/재시작 시 실행 중인 게임 상태가 반영되도록 개선했습니다.
- Windows가 기존 폰트 파일을 사용 중이어도 새 폰트를 설치할 수 있도록 해시 기반 파일명으로 설치하고, 기존 런처 관리 파일은 재부팅 후 정리되도록 개선했습니다.
- 시작 단계, 프로세스 감시, 설치 상태 보정의 책임 기준을 아키텍처 관리 스킬과 에이전트 문서에 추가했습니다.

## 배경

폰트 파일은 게임이나 Windows 글꼴 시스템이 잡고 있을 수 있어 기존 파일을 바로 삭제하거나 교체하는 방식이 실패할 수 있었습니다. 또한 런처 시작 직후 설치 상태 점검이 프로세스 감시보다 늦게 반영되면 실행 중 상태가 다시 초기화될 수 있어, 런타임 상태를 우선 보존하도록 시작 순서를 정리했습니다.