### PR TITLE
fix: 카카오게임즈가 점검 중 일 때 비공식런처에서도 표시 될 수 있도록 개선

### DIFF
--- a/src/main/events/handlers/KakaoMaintenanceUISyncHandler.ts
+++ b/src/main/events/handlers/KakaoMaintenanceUISyncHandler.ts
@@ -1,0 +1,21 @@
+import {
+  AppContext,
+  EventHandler,
+  EventType,
+  KakaoMaintenanceDetectedEvent,
+} from "../types";
+
+export const KakaoMaintenanceUISyncHandler: EventHandler<KakaoMaintenanceDetectedEvent> =
+  {
+    id: "KakaoMaintenanceUISyncHandler",
+    targetEvent: EventType.KAKAO_MAINTENANCE_DETECTED,
+
+    handle: async (event, context: AppContext) => {
+      if (context.mainWindow && !context.mainWindow.isDestroyed()) {
+        context.mainWindow.webContents.send(
+          "kakao:maintenance-detected",
+          event.payload,
+        );
+      }
+    },
+  };

--- a/src/main/events/handlers/StartPoe1KakaoHandler.ts
+++ b/src/main/events/handlers/StartPoe1KakaoHandler.ts
@@ -3,6 +3,7 @@ import {
   type KakaoTransitionUrlCandidate,
 } from "../../../shared/kakao-service-transition";
 import { AppConfig } from "../../../shared/types";
+import { extractKakaoMaintenanceInfoFromWebContents } from "../../kakao/maintenance-info";
 import { logger } from "../../utils/logger";
 import { eventBus } from "../EventBus";
 import {
@@ -10,6 +11,7 @@ import {
   EventHandler,
   EventType,
   GameStatusChangeEvent,
+  KakaoMaintenanceDetectedEvent,
   UIEvent,
 } from "../types";
 
@@ -92,6 +94,36 @@ export const StartPoe1KakaoHandler: EventHandler<UIEvent> = {
           serviceId: "Kakao Games",
           status: "error",
           errorCode: "URL_LOAD_FAILED",
+        },
+      );
+      return;
+    }
+
+    const maintenanceInfo = await extractKakaoMaintenanceInfoFromWebContents(
+      gameWindow.webContents,
+    );
+
+    if (maintenanceInfo) {
+      logger.log(
+        `[StartPoe1KakaoHandler] Kakao maintenance detected: ${maintenanceInfo.url}`,
+      );
+      context.hideAutomationWindow?.(gameWindow, "kakao-maintenance-detected");
+      await eventBus.emit<KakaoMaintenanceDetectedEvent>(
+        EventType.KAKAO_MAINTENANCE_DETECTED,
+        context,
+        {
+          ...maintenanceInfo,
+          gameId: "POE1",
+          serviceId: "Kakao Games",
+        },
+      );
+      eventBus.emit<GameStatusChangeEvent>(
+        EventType.GAME_STATUS_CHANGE,
+        context,
+        {
+          gameId: "POE1",
+          serviceId: "Kakao Games",
+          status: "idle",
         },
       );
       return;

--- a/src/main/events/handlers/StartPoe2KakaoHandler.ts
+++ b/src/main/events/handlers/StartPoe2KakaoHandler.ts
@@ -3,6 +3,7 @@ import {
   type KakaoTransitionUrlCandidate,
 } from "../../../shared/kakao-service-transition";
 import { AppConfig } from "../../../shared/types";
+import { extractKakaoMaintenanceInfoFromWebContents } from "../../kakao/maintenance-info";
 import { logger } from "../../utils/logger";
 import { eventBus } from "../EventBus";
 import {
@@ -10,6 +11,7 @@ import {
   EventHandler,
   EventType,
   GameStatusChangeEvent,
+  KakaoMaintenanceDetectedEvent,
   UIEvent,
 } from "../types";
 
@@ -93,6 +95,36 @@ export const StartPoe2KakaoHandler: EventHandler<UIEvent> = {
           serviceId: "Kakao Games",
           status: "error",
           errorCode: "URL_LOAD_FAILED",
+        },
+      );
+      return;
+    }
+
+    const maintenanceInfo = await extractKakaoMaintenanceInfoFromWebContents(
+      gameWindow.webContents,
+    );
+
+    if (maintenanceInfo) {
+      logger.log(
+        `[StartPoe2KakaoHandler] Kakao maintenance detected: ${maintenanceInfo.url}`,
+      );
+      context.hideAutomationWindow?.(gameWindow, "kakao-maintenance-detected");
+      await eventBus.emit<KakaoMaintenanceDetectedEvent>(
+        EventType.KAKAO_MAINTENANCE_DETECTED,
+        context,
+        {
+          ...maintenanceInfo,
+          gameId: "POE2",
+          serviceId: "Kakao Games",
+        },
+      );
+      eventBus.emit<GameStatusChangeEvent>(
+        EventType.GAME_STATUS_CHANGE,
+        context,
+        {
+          gameId: "POE2",
+          serviceId: "Kakao Games",
+          status: "idle",
         },
       );
       return;

--- a/src/main/events/register-handlers.ts
+++ b/src/main/events/register-handlers.ts
@@ -24,6 +24,7 @@ import {
 } from "./handlers/GameProcessStatusHandler";
 import { GameStatusSyncHandler } from "./handlers/GameStatusSyncHandler";
 import { InactiveWindowVisibilityHandler } from "./handlers/InactiveWindowVisibilityHandler";
+import { KakaoMaintenanceUISyncHandler } from "./handlers/KakaoMaintenanceUISyncHandler";
 import { StartPoe1KakaoHandler } from "./handlers/StartPoe1KakaoHandler";
 import { StartPoe2KakaoHandler } from "./handlers/StartPoe2KakaoHandler";
 import { StartPoeGggHandler } from "./handlers/StartPoeGggHandler";
@@ -65,6 +66,7 @@ export const CORE_EVENT_HANDLERS = [
   ChangelogUISyncHandler,
   UacHandler,
   InactiveWindowVisibilityHandler,
+  KakaoMaintenanceUISyncHandler,
 ] as const;
 
 export function registerCoreEventHandlers() {

--- a/src/main/events/types.ts
+++ b/src/main/events/types.ts
@@ -7,6 +7,7 @@ import {
   DebugLogPayload,
   ChangelogItem,
   GameLaunchContext,
+  KakaoMaintenanceInfo,
 } from "../../shared/types";
 
 // Event Enums
@@ -49,6 +50,9 @@ export enum EventType {
 
   // Remote version (master socket / gh-pages)
   REMOTE_VERSION_UPDATED = "REMOTE:VERSION_UPDATED",
+
+  // Kakao Games maintenance
+  KAKAO_MAINTENANCE_DETECTED = "KAKAO:MAINTENANCE_DETECTED",
 }
 
 export interface ToolForceRepairEvent {
@@ -270,6 +274,15 @@ export interface ShowChangelogEvent {
   timestamp?: number;
 }
 
+export interface KakaoMaintenanceDetectedEvent {
+  type: EventType.KAKAO_MAINTENANCE_DETECTED;
+  payload: KakaoMaintenanceInfo & {
+    gameId: AppConfig["activeGame"];
+    serviceId: Extract<AppConfig["serviceChannel"], "Kakao Games">;
+  };
+  timestamp?: number;
+}
+
 // --- Discriminated Union ---
 export type AppEvent =
   | ConfigChangeEvent
@@ -299,7 +312,8 @@ export type AppEvent =
   | PatchReservationFailedEvent
   | PatchReservationSuccessEvent
   | PatchUiTitleTickEvent
-  | RemoteVersionUpdatedEvent;
+  | RemoteVersionUpdatedEvent
+  | KakaoMaintenanceDetectedEvent;
 
 export interface RemoteVersionUpdatedEvent {
   type: EventType.REMOTE_VERSION_UPDATED;
@@ -416,6 +430,7 @@ export interface AppContext {
   ensureGameWindow: (options?: { service: string }) => BrowserWindow;
   getConfig: (key?: string) => unknown;
   isForcedVisible?: (windowId: number) => boolean;
+  hideAutomationWindow?: (window: BrowserWindow, reason: string) => void;
   disableValidationMode: () => void;
   getActiveAutomationWindow: () => BrowserWindow | null;
 }

--- a/src/main/kakao/automation-page-dump.ts
+++ b/src/main/kakao/automation-page-dump.ts
@@ -52,6 +52,13 @@ type ArchiveAutomationDumpSessionOptions = {
 const MIN_DUMP_INTERVAL_MS = 1000;
 const DUMP_RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
 const DUMP_CLEANUP_INTERVAL_MS = 24 * 60 * 60 * 1000;
+const DIRECTORY_REMOVE_MAX_RETRIES = 5;
+const DIRECTORY_REMOVE_RETRY_DELAY_MS = 100;
+const RETRIABLE_DIRECTORY_REMOVE_ERRORS = new Set([
+  "EBUSY",
+  "ENOTEMPTY",
+  "EPERM",
+]);
 const lastDumpAtByKey = new Map<string, number>();
 let activeSession: AutomationDumpSession | null = null;
 let cleanupTimer: NodeJS.Timeout | null = null;
@@ -438,7 +445,33 @@ async function hasFiles(dir: string): Promise<boolean> {
 }
 
 async function removeDirectory(dir: string) {
-  await fs.rm(dir, { recursive: true, force: true });
+  try {
+    await fs.rm(dir, {
+      recursive: true,
+      force: true,
+      maxRetries: DIRECTORY_REMOVE_MAX_RETRIES,
+      retryDelay: DIRECTORY_REMOVE_RETRY_DELAY_MS,
+    });
+  } catch (error) {
+    if (isRetriableDirectoryRemoveError(error)) {
+      logger.warn(
+        `[KakaoPageDump] Diagnostic dump directory cleanup was skipped after retries: ${dir} (${String(error)})`,
+      );
+      return;
+    }
+
+    throw error;
+  }
+}
+
+function isRetriableDirectoryRemoveError(error: unknown) {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    typeof error.code === "string" &&
+    RETRIABLE_DIRECTORY_REMOVE_ERRORS.has(error.code)
+  );
 }
 
 function buildPageLabel(url: string) {

--- a/src/main/kakao/maintenance-info.ts
+++ b/src/main/kakao/maintenance-info.ts
@@ -1,0 +1,243 @@
+import { createHash } from "node:crypto";
+
+import { parse, type HTMLElement } from "node-html-parser";
+
+import {
+  isKakaoInspectionUrl,
+  isKakaoInspectionUrlString,
+  KAKAO_POE_INSPECTION_URL,
+} from "../../shared/kakao-service-transition";
+
+import type {
+  KakaoMaintenanceInfo,
+  NewsCategory,
+  NewsItem,
+} from "../../shared/types";
+import type { WebContents } from "electron";
+
+type MaintenanceDetail = KakaoMaintenanceInfo["details"][number];
+
+export async function extractKakaoMaintenanceInfoFromWebContents(
+  webContents: WebContents,
+): Promise<KakaoMaintenanceInfo | null> {
+  const currentUrl = webContents.getURL();
+  if (!isKakaoInspectionUrlString(currentUrl)) return null;
+
+  const url = normalizeInspectionUrl(currentUrl);
+
+  try {
+    const html = await webContents.executeJavaScript(
+      "document.documentElement.outerHTML",
+      true,
+    );
+    return extractKakaoMaintenanceInfoFromHtml(html, url);
+  } catch {
+    return {
+      url,
+      title: "서비스 점검 중 입니다.",
+      details: [],
+    };
+  }
+}
+
+export function extractKakaoMaintenanceInfoFromHtml(
+  html: string,
+  url = KAKAO_POE_INSPECTION_URL,
+): KakaoMaintenanceInfo | null {
+  const normalizedUrl = normalizeInspectionUrl(url);
+  const root = parse(html);
+  const serviceInfo = extractServiceInspectionInfo(root, normalizedUrl);
+  if (serviceInfo) return serviceInfo;
+
+  const poeInfo = extractPoeInspectionInfo(root, normalizedUrl);
+  if (poeInfo) return poeInfo;
+
+  if (!isKakaoInspectionUrlString(normalizedUrl)) return null;
+
+  const title = normalizeText(root.querySelector("title")?.innerText);
+  return {
+    url: normalizedUrl,
+    title: title || "서비스 점검 중 입니다.",
+    details: [],
+  };
+}
+
+export function createKakaoMaintenanceNewsItem(
+  info: KakaoMaintenanceInfo,
+  category: Extract<NewsCategory, "notice" | "patch-notes">,
+  lastReadIds: string[],
+): NewsItem {
+  const id = `kakao-maintenance-${category}-${getMaintenanceHash(info)}`;
+
+  return {
+    id,
+    title: "카카오게임즈 점검 안내",
+    link: info.url,
+    date: getKakaoMaintenanceDateLabel(info),
+    type: category,
+    isNew: !lastReadIds.includes(id),
+    isSticky: true,
+  };
+}
+
+export function formatKakaoMaintenanceContent(
+  info: KakaoMaintenanceInfo,
+): string {
+  const detailsHtml = info.details
+    .map(
+      ({ label, value }) => `
+        <div class="kakao-maintenance-detail">
+          <dt>${escapeHtml(label)}</dt>
+          <dd>${escapeHtml(value)}</dd>
+        </div>
+      `,
+    )
+    .join("");
+
+  return `
+    <div class="kakao-maintenance-content">
+      <div class="kakao-maintenance-summary">
+        <span class="material-symbols-outlined kakao-maintenance-icon">construction</span>
+        <div>
+          <h3>${escapeHtml(info.title)}</h3>
+          ${
+            info.description
+              ? `<p>${escapeHtml(info.description)}</p>`
+              : "<p>카카오게임즈 점검 페이지로 이동했습니다.</p>"
+          }
+        </div>
+      </div>
+      ${
+        detailsHtml
+          ? `<dl class="kakao-maintenance-details">${detailsHtml}</dl>`
+          : ""
+      }
+    </div>
+  `;
+}
+
+export function getKakaoMaintenanceDateLabel(
+  info: KakaoMaintenanceInfo,
+): string {
+  const period = findDetailValue(info, "기간") || findDetailValue(info, "시간");
+  const date = period.match(/\d{4}년\s*\d{1,2}월\s*\d{1,2}일/u)?.[0];
+  return date ? normalizeText(date) : "점검 중";
+}
+
+function extractServiceInspectionInfo(
+  root: HTMLElement,
+  url: string,
+): KakaoMaintenanceInfo | null {
+  const container = root.querySelector(".underconstruction");
+  if (!container) return null;
+
+  const details = container
+    .querySelectorAll(".underconstruction-list__item")
+    .map((item) => {
+      const label = normalizeText(
+        item.querySelector(".underconstruction-list__title")?.innerText,
+      );
+      const value = normalizeText(
+        item.querySelector(".underconstruction-list__text")?.innerText,
+      );
+      return { label, value };
+    })
+    .filter(isValidDetail);
+
+  return {
+    url,
+    title:
+      normalizeText(
+        container.querySelector(".underconstruction__title h2")?.innerText,
+      )
+        .replace(/\s+/g, " ")
+        .trim() || "서비스 점검 중 입니다.",
+    description: normalizeText(
+      container.querySelector(".underconstruction__title p")?.innerText,
+    ),
+    details,
+  };
+}
+
+function extractPoeInspectionInfo(
+  root: HTMLElement,
+  url: string,
+): KakaoMaintenanceInfo | null {
+  const list = root.querySelector(".construction__data");
+  if (!list) return null;
+
+  const details = list
+    .querySelectorAll("li")
+    .map((item) => {
+      const strong = item.querySelector("strong");
+      const label = normalizeText(strong?.innerText);
+      const value = normalizeText(item.innerText).replace(label, "").trim();
+      return { label, value };
+    })
+    .filter(isValidDetail);
+
+  const title =
+    normalizeText(
+      root.querySelector(".kg-contents__header img")?.getAttribute("alt"),
+    ) ||
+    normalizeText(root.querySelector("title")?.innerText) ||
+    "서비스 점검 중 입니다.";
+
+  const sectionTitle = normalizeText(
+    root.querySelector(".construction__title img")?.getAttribute("alt"),
+  );
+
+  return {
+    url,
+    title,
+    description: sectionTitle,
+    details,
+  };
+}
+
+function getMaintenanceHash(info: KakaoMaintenanceInfo): string {
+  const source = [
+    info.title,
+    info.description || "",
+    ...info.details.map(({ label, value }) => `${label}:${value}`),
+  ].join("|");
+
+  return createHash("sha1").update(source).digest("hex").slice(0, 12);
+}
+
+function findDetailValue(info: KakaoMaintenanceInfo, keyword: string): string {
+  return info.details.find(({ label }) => label.includes(keyword))?.value || "";
+}
+
+function isValidDetail(detail: MaintenanceDetail): boolean {
+  return Boolean(detail.label && detail.value);
+}
+
+function normalizeText(value: unknown): string {
+  return String(value || "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function normalizeInspectionUrl(value: string): string {
+  try {
+    const url = new URL(value);
+    if (isKakaoInspectionUrl(url)) {
+      url.hash = "";
+      return url.toString();
+    }
+  } catch {
+    return value;
+  }
+
+  return value;
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}

--- a/src/main/kakao/visibility-policy.ts
+++ b/src/main/kakao/visibility-policy.ts
@@ -1,4 +1,7 @@
-import { isKakaoGameLoginRedirectUrl } from "../../shared/kakao-service-transition";
+import {
+  isKakaoGameLoginRedirectUrl,
+  isKakaoInspectionUrlString,
+} from "../../shared/kakao-service-transition";
 
 export const USER_REQUIRED_PAGE_REVEAL_DELAY_MS = 1200;
 export const UNHANDLED_PAGE_REVEAL_DELAY_MS = 1200;
@@ -112,7 +115,8 @@ export function shouldRevealUnhandledAutomatedPage(
   return (
     (triggerContext === "GAME_START_POE1" ||
       triggerContext === "GAME_START_POE2") &&
-    href !== "about:blank"
+    href !== "about:blank" &&
+    !isKakaoInspectionUrlString(href)
   );
 }
 

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1499,6 +1499,31 @@ const createHandleWindowOpen =
 // --- Visibility Control State ---
 const forcedVisibleWindows = new Set<number>();
 
+function hideAutomationWindow(window: BrowserWindow, reason: string) {
+  if (!window || window.isDestroyed()) return;
+
+  const isMainWindow =
+    context.mainWindow && context.mainWindow.id === window.id;
+  const isDebugWindow =
+    context.debugWindow && context.debugWindow.id === window.id;
+
+  if (isMainWindow || isDebugWindow) return;
+
+  if (forcedVisibleWindows.delete(window.id)) {
+    logger.log(
+      `[Main] Window ${window.id} released FORCED VISIBILITY (${reason}).`,
+    );
+  }
+
+  if (window.isVisible()) {
+    const url = window.webContents.getURL();
+    logger.log(
+      `[Main] Hiding automation window ${window.id} (${reason}): ${url}`,
+    );
+    window.hide();
+  }
+}
+
 // [IPC] Dynamic Visibility Request from Preload
 ipcMain.on("window-visibility-request", async (event, isVisible: boolean) => {
   const window = BrowserWindow.fromWebContents(event.sender);
@@ -1622,6 +1647,7 @@ const context: AppContext = {
   store,
   serviceManager: serviceManager as IServiceManager,
   isForcedVisible: (windowId: number) => forcedVisibleWindows.has(windowId),
+  hideAutomationWindow,
   ensureGameWindow: ensureGameWindow,
   getConfig: (key?: string) => getEffectiveConfig(key),
   disableValidationMode: () => {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1805,6 +1805,86 @@ const triggerDevToolsSync = () => {
 // Cache for title to prevent spam
 let lastBroadcastedTitle: string | null = null;
 
+const TITLE_BAR_HEIGHT = 32;
+const TOP_CENTER_HOVER_WIDTH = 220;
+
+let isTopCenterTitlebarHovered = false;
+let topCenterTitlebarHoverPollTimer: NodeJS.Timeout | null = null;
+
+function isInTopCenterTitlebarHoverZone(
+  win: BrowserWindow,
+  x: number,
+  y: number,
+) {
+  const [contentWidth] = win.getContentSize();
+  const left = (contentWidth - TOP_CENTER_HOVER_WIDTH) / 2;
+  return (
+    x >= left &&
+    x <= left + TOP_CENTER_HOVER_WIDTH &&
+    y >= 0 &&
+    y <= TITLE_BAR_HEIGHT
+  );
+}
+
+function publishTopCenterTitlebarHover(win: BrowserWindow, hovered: boolean) {
+  if (isTopCenterTitlebarHovered === hovered) return;
+
+  isTopCenterTitlebarHovered = hovered;
+  if (!win.webContents.isDestroyed()) {
+    win.webContents.send("app:top-center-titlebar-hover", hovered);
+  }
+}
+
+function stopTopCenterTitlebarHoverPolling() {
+  if (!topCenterTitlebarHoverPollTimer) return;
+  clearInterval(topCenterTitlebarHoverPollTimer);
+  topCenterTitlebarHoverPollTimer = null;
+}
+
+function startTopCenterTitlebarHoverPolling(win: BrowserWindow) {
+  if (topCenterTitlebarHoverPollTimer) return;
+
+  topCenterTitlebarHoverPollTimer = setInterval(() => {
+    if (win.isDestroyed()) {
+      stopTopCenterTitlebarHoverPolling();
+      return;
+    }
+
+    if (!win.isVisible()) {
+      publishTopCenterTitlebarHover(win, false);
+      return;
+    }
+
+    const cursor = screen.getCursorScreenPoint();
+    const bounds = win.getBounds();
+    const x = cursor.x - bounds.x;
+    const y = cursor.y - bounds.y;
+
+    publishTopCenterTitlebarHover(
+      win,
+      isInTopCenterTitlebarHoverZone(win, x, y),
+    );
+  }, 100);
+  topCenterTitlebarHoverPollTimer.unref?.();
+}
+
+function setupTopCenterTitlebarHoverTracking(win: BrowserWindow) {
+  if (process.platform !== "win32") return;
+
+  const clearHover = () => {
+    publishTopCenterTitlebarHover(win, false);
+    stopTopCenterTitlebarHoverPolling();
+  };
+
+  startTopCenterTitlebarHoverPolling(win);
+  win.on("show", () => startTopCenterTitlebarHoverPolling(win));
+  win.on("hide", clearHover);
+  win.on("closed", () => {
+    isTopCenterTitlebarHovered = false;
+    stopTopCenterTitlebarHoverPolling();
+  });
+}
+
 /**
  * Calculates the current title based on global config/state and broadcasts it
  * to the Window, Tray, and Renderer (via Event).
@@ -1861,6 +1941,7 @@ async function createWindow() {
       preload: path.join(__dirname, "preload.js"),
     },
   });
+  setupTopCenterTitlebarHoverTracking(mainWindow);
 
   // [Security] Force external links to open in default browser
   mainWindow.webContents.setWindowOpenHandler(({ url }) => {

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -253,6 +253,12 @@ contextBridge.exposeInMainWorld("electronAPI", {
     ipcRenderer.on("app:title-updated", handler);
     return () => ipcRenderer.off("app:title-updated", handler);
   },
+  onTopCenterTitlebarHover: (callback: (hovered: boolean) => void) => {
+    const handler = (_event: IpcRendererEvent, hovered: boolean) =>
+      callback(hovered);
+    ipcRenderer.on("app:top-center-titlebar-hover", handler);
+    return () => ipcRenderer.off("app:top-center-titlebar-hover", handler);
+  },
   requestTitleUpdate: () => ipcRenderer.send("app:request-title"),
 
   // [UAC Migration]

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -15,6 +15,7 @@ import {
   RemoteFontItem,
   ImportSelection,
   GameLaunchContext,
+  KakaoMaintenanceInfo,
 } from "../shared/types";
 
 const logger = new PreloadLogger({ type: "PRELOAD", typeColor: "#8BE9FD" });
@@ -258,6 +259,24 @@ contextBridge.exposeInMainWorld("electronAPI", {
       callback(hovered);
     ipcRenderer.on("app:top-center-titlebar-hover", handler);
     return () => ipcRenderer.off("app:top-center-titlebar-hover", handler);
+  },
+  onKakaoMaintenanceDetected: (
+    callback: (
+      info: KakaoMaintenanceInfo & {
+        gameId: AppConfig["activeGame"];
+        serviceId: "Kakao Games";
+      },
+    ) => void,
+  ) => {
+    const handler = (
+      _event: IpcRendererEvent,
+      info: KakaoMaintenanceInfo & {
+        gameId: AppConfig["activeGame"];
+        serviceId: "Kakao Games";
+      },
+    ) => callback(info);
+    ipcRenderer.on("kakao:maintenance-detected", handler);
+    return () => ipcRenderer.off("kakao:maintenance-detected", handler);
   },
   requestTitleUpdate: () => ipcRenderer.send("app:request-title"),
 

--- a/src/main/services/NewsService.ts
+++ b/src/main/services/NewsService.ts
@@ -1,6 +1,7 @@
 import Store from "electron-store";
 import { parse } from "node-html-parser";
 
+import { isKakaoInspectionUrlString } from "../../shared/kakao-service-transition";
 import {
   MAX_NEWS_COUNT,
   NEWS_REFRESH_INTERVAL,
@@ -17,6 +18,11 @@ import {
   NewsContent,
   AppConfig,
 } from "../../shared/types";
+import {
+  createKakaoMaintenanceNewsItem,
+  extractKakaoMaintenanceInfoFromHtml,
+  formatKakaoMaintenanceContent,
+} from "../kakao/maintenance-info";
 import { Logger } from "../utils/logger";
 
 type ForumNewsCategory = Extract<NewsCategory, "notice" | "patch-notes">;
@@ -373,6 +379,42 @@ export class NewsService {
 
       const html = await response.text();
       const root = parse(html);
+      const finalUrl = response.url || url;
+      const lastReadIds = this.store.get("lastReadIds");
+      const maintenanceInfo =
+        service === "Kakao Games" || isKakaoInspectionUrlString(finalUrl)
+          ? extractKakaoMaintenanceInfoFromHtml(html, finalUrl)
+          : null;
+
+      if (maintenanceInfo) {
+        const items = [
+          createKakaoMaintenanceNewsItem(
+            maintenanceInfo,
+            category,
+            lastReadIds,
+          ),
+        ];
+        this.updateCache(
+          items[0].id,
+          formatKakaoMaintenanceContent(maintenanceInfo),
+        );
+
+        const cachedItems = this.getCacheItems(key);
+        const isChanged = JSON.stringify(cachedItems) !== JSON.stringify(items);
+
+        if (isChanged) {
+          const allItems = this.store.get("items");
+          allItems[key] = items;
+          this.store.set("items", allItems);
+
+          if (notify) this.emitUpdated();
+          this.logger.log(`Maintenance notice updated for ${key}.`);
+          this.garbageCollect();
+        }
+
+        this.markRefreshed(key);
+        return { items, changed: isChanged, refreshed: true };
+      }
 
       let table = root.getElementById("view_forum_table");
       if (!table) {
@@ -381,7 +423,6 @@ export class NewsService {
 
       const rows = table ? table.querySelectorAll("tr") : [];
       const items: NewsItem[] = [];
-      const lastReadIds = this.store.get("lastReadIds");
 
       for (const row of rows) {
         if (items.length >= MAX_NEWS_COUNT) break;
@@ -581,6 +622,17 @@ export class NewsService {
       });
 
       const html = await response.text();
+      const maintenanceInfo = extractKakaoMaintenanceInfoFromHtml(
+        html,
+        response.url || link,
+      );
+
+      if (maintenanceInfo) {
+        const cleanHtml = formatKakaoMaintenanceContent(maintenanceInfo);
+        this.updateCache(id, cleanHtml);
+        return cleanHtml;
+      }
+
       const isMarkdown =
         link.toLowerCase().endsWith(".md") ||
         id.startsWith("dev-notice-") ||

--- a/src/main/tests/NewsService.test.ts
+++ b/src/main/tests/NewsService.test.ts
@@ -102,6 +102,30 @@ describe("NewsService", () => {
     expect(items[0].id).toBe("12345");
   });
 
+  it("falls back to Kakao maintenance info when forum fetch redirects to inspection", async () => {
+    (globalThis.fetch as Mock).mockResolvedValue({
+      ok: true,
+      url: "https://pathofexile.kakaogames.com/inspection",
+      text: () =>
+        Promise.resolve(`
+          <div class="construction__data">
+            <ul>
+              <li><div><strong>점검시간</strong><div>2026년 06월 17일 07:00 ~ 06월 17일 10:00</div></div></li>
+              <li><div><strong>점검내용</strong><div>카카오게임즈 서비스 전환을 위한 점검</div></div></li>
+            </ul>
+          </div>
+        `),
+    });
+
+    const items = await service.fetchNewsList("POE2", "Kakao Games", "notice");
+
+    expect(items).toHaveLength(1);
+    expect(items[0].title).toBe("카카오게임즈 점검 안내");
+    expect(items[0].link).toBe("https://pathofexile.kakaogames.com/inspection");
+    expect(items[0].date).toBe("2026년 06월 17일");
+    expect(service.getContentFromCache(items[0].id)).toContain("점검내용");
+  });
+
   it("should fetch post content correctly", async () => {
     const mockHtml = `
       <div class="forumPost">

--- a/src/main/tests/kakao-automation-page-dump.test.ts
+++ b/src/main/tests/kakao-automation-page-dump.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  discardAutomationDumpSession,
+  startAutomationDumpSession,
+} from "../kakao/automation-page-dump";
+
+const mocks = vi.hoisted(() => ({
+  rm: vi.fn(),
+  loggerLog: vi.fn(),
+  loggerWarn: vi.fn(),
+}));
+
+vi.mock("node:fs/promises", () => ({
+  default: {
+    rm: mocks.rm,
+  },
+}));
+
+vi.mock("electron", () => ({
+  app: {
+    getPath: vi.fn(
+      () => String.raw`C:\Users\test\AppData\Roaming\POE2 Unofficial Launcher`,
+    ),
+    isPackaged: true,
+  },
+}));
+
+vi.mock("../utils/logger", () => ({
+  logger: {
+    error: vi.fn(),
+    log: mocks.loggerLog,
+    warn: mocks.loggerWarn,
+  },
+}));
+
+describe("Kakao automation page dumps", () => {
+  beforeEach(() => {
+    delete process.env.VITE_KAKAO_PAGE_DUMP;
+    mocks.rm.mockReset();
+    mocks.loggerLog.mockClear();
+    mocks.loggerWarn.mockClear();
+  });
+
+  it("does not surface transient Windows directory cleanup races", async () => {
+    const cleanupError = Object.assign(new Error("directory not empty"), {
+      code: "ENOTEMPTY",
+    });
+    mocks.rm.mockRejectedValueOnce(cleanupError);
+
+    startAutomationDumpSession({
+      gameId: "POE2",
+      serviceId: "Kakao Games",
+      triggerContext: "GAME_START",
+    });
+
+    await expect(
+      discardAutomationDumpSession("status-idle"),
+    ).resolves.toBeUndefined();
+
+    expect(mocks.rm).toHaveBeenCalledWith(
+      expect.stringContaining("kakao-page-dumps"),
+      expect.objectContaining({
+        force: true,
+        maxRetries: 5,
+        recursive: true,
+        retryDelay: 100,
+      }),
+    );
+    expect(mocks.loggerWarn).toHaveBeenCalledWith(
+      expect.stringContaining("Diagnostic dump directory cleanup was skipped"),
+    );
+  });
+});

--- a/src/main/tests/kakao-maintenance-info.test.ts
+++ b/src/main/tests/kakao-maintenance-info.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createKakaoMaintenanceNewsItem,
+  extractKakaoMaintenanceInfoFromHtml,
+  formatKakaoMaintenanceContent,
+  getKakaoMaintenanceDateLabel,
+} from "../kakao/maintenance-info";
+
+describe("Kakao maintenance info", () => {
+  it("extracts the service inspection page structure", () => {
+    const info = extractKakaoMaintenanceInfoFromHtml(
+      `
+        <div class="underconstruction">
+          <div class="underconstruction__title">
+            <h2>서비스 <span>점검 중</span> 입니다.</h2>
+            <p>더 나은 서비스 제공을 위해 서비스 카카오게임즈 웹 서비스 이용이 중단됩니다.</p>
+          </div>
+          <ul class="underconstruction-list">
+            <li class="underconstruction-list__item">
+              <strong class="underconstruction-list__title">점검 기간</strong>
+              <span class="underconstruction-list__text">2026년 6월 17일(Wed) AM 7시 00분 ~ 6월 17일(Wed) AM 10시 00분</span>
+            </li>
+            <li class="underconstruction-list__item">
+              <strong class="underconstruction-list__title">점검 내용</strong>
+              <span class="underconstruction-list__text">카카오게임즈 서비스 전환을 위한 점검</span>
+            </li>
+          </ul>
+        </div>
+      `,
+      "https://service.kakaogames.com/inspection?game=all",
+    );
+
+    expect(info?.title).toBe("서비스 점검 중 입니다.");
+    expect(info?.details).toContainEqual({
+      label: "점검 내용",
+      value: "카카오게임즈 서비스 전환을 위한 점검",
+    });
+    expect(info && getKakaoMaintenanceDateLabel(info)).toBe("2026년 6월 17일");
+  });
+
+  it("extracts the Path of Exile inspection page structure", () => {
+    const info = extractKakaoMaintenanceInfoFromHtml(
+      `
+        <div class="kg-contents__header">
+          <h1><img alt="패스 오브 엑자일 - 지금은 점검 중 입니다."></h1>
+        </div>
+        <div class="construction__title">
+          <h2><img alt="정기점검"></h2>
+        </div>
+        <div class="construction__data">
+          <ul>
+            <li><div><strong>점검시간</strong><div>2026년 06월 17일 07:00 ~ 06월 17일 10:00</div></div></li>
+            <li><div><strong>점검내용</strong><div>카카오게임즈 서비스 전환을 위한 점검</div></div></li>
+          </ul>
+        </div>
+      `,
+      "https://pathofexile.kakaogames.com/inspection",
+    );
+
+    expect(info?.description).toBe("정기점검");
+    expect(info?.details[0]).toEqual({
+      label: "점검시간",
+      value: "2026년 06월 17일 07:00 ~ 06월 17일 10:00",
+    });
+  });
+
+  it("formats extracted info as a sticky news item and cached HTML", () => {
+    const info = extractKakaoMaintenanceInfoFromHtml(
+      `
+        <div class="construction__data">
+          <ul>
+            <li><div><strong>점검시간</strong><div>2026년 06월 17일 07:00 ~ 06월 17일 10:00</div></div></li>
+            <li><div><strong>점검내용</strong><div>카카오게임즈 서비스 전환을 위한 점검</div></div></li>
+          </ul>
+        </div>
+      `,
+      "https://pathofexile.kakaogames.com/inspection",
+    );
+
+    expect(info).not.toBeNull();
+
+    const item = createKakaoMaintenanceNewsItem(info!, "notice", []);
+    expect(item.title).toBe("카카오게임즈 점검 안내");
+    expect(item.isSticky).toBe(true);
+    expect(item.link).toBe("https://pathofexile.kakaogames.com/inspection");
+
+    const content = formatKakaoMaintenanceContent(info!);
+    expect(content).toContain("점검내용");
+    expect(content).toContain("카카오게임즈 서비스 전환을 위한 점검");
+  });
+});

--- a/src/main/tests/kakao-service-transition.test.ts
+++ b/src/main/tests/kakao-service-transition.test.ts
@@ -4,6 +4,7 @@ import {
   getKakaoGameStartUrlCandidates,
   getKakaoPrimaryBaseUrl,
   getKakaoUrlPhase,
+  isKakaoInspectionUrl,
   isKakaoLauncherUrl,
   isKakaoMemberUrl,
   isKakaoPoeHomeUrl,
@@ -125,6 +126,24 @@ describe("kakao service transition policy", () => {
         new URL(
           "https://member.kakaogames.com/popup/install_kakaogamesstarter",
         ),
+      ),
+    ).toBe(false);
+  });
+
+  it("recognizes Kakao maintenance inspection URLs", () => {
+    expect(
+      isKakaoInspectionUrl(
+        new URL("https://pathofexile.kakaogames.com/inspection"),
+      ),
+    ).toBe(true);
+    expect(
+      isKakaoInspectionUrl(
+        new URL("https://service.kakaogames.com/inspection?game=all"),
+      ),
+    ).toBe(true);
+    expect(
+      isKakaoInspectionUrl(
+        new URL("https://service.kakaogames.com/inspection?game=poe2"),
       ),
     ).toBe(false);
   });

--- a/src/main/tests/kakao-visibility-policy.test.ts
+++ b/src/main/tests/kakao-visibility-policy.test.ts
@@ -132,6 +132,12 @@ describe("kakao visibility policy", () => {
     expect(
       shouldRevealUnhandledAutomatedPage("GAME_START_POE2", "about:blank"),
     ).toBe(false);
+    expect(
+      shouldRevealUnhandledAutomatedPage(
+        "GAME_START_POE2",
+        "https://service.kakaogames.com/inspection?game=all#autoStart",
+      ),
+    ).toBe(false);
   });
 
   it("detects Kakao game login redirects during background validation", () => {

--- a/src/main/tests/register-handlers.test.ts
+++ b/src/main/tests/register-handlers.test.ts
@@ -68,6 +68,7 @@ const CORE_HANDLER_IDS = [
   "ChangelogUISyncHandler",
   "UacHandler",
   "InactiveWindowVisibilityHandler",
+  "KakaoMaintenanceUISyncHandler",
 ] as const;
 
 describe("CORE_EVENT_HANDLERS", () => {

--- a/src/renderer/App.css
+++ b/src/renderer/App.css
@@ -486,6 +486,7 @@ img {
 }
 
 /* Ripple Activation: Reveal the filter overlay */
+.top-center.titlebar-hover .top-center-blue,
 .top-center:has(.top-center-trigger:hover) .top-center-blue {
   opacity: 1;
   transform: scale(1);

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -18,6 +18,7 @@ import {
   UpdateStatus,
   PatchProgress,
   ThemeDefinition,
+  KakaoMaintenanceInfo,
 } from "../shared/types";
 import { DOWNLOAD_URLS, SUPPORT_URLS } from "../shared/urls";
 
@@ -33,6 +34,7 @@ import FontCatalogModal from "./components/modals/FontCatalogModal";
 import FontManagerModal from "./components/modals/FontManagerModal";
 import FontMigrationModal from "./components/modals/FontMigrationModal";
 import { ForcedRepairModal } from "./components/modals/ForcedRepairModal";
+import KakaoMaintenanceModal from "./components/modals/KakaoMaintenanceModal";
 import KakaoStarterUacModal from "./components/modals/KakaoStarterUacModal";
 import MigrationModal from "./components/modals/MigrationModal";
 import NoticeModal from "./components/modals/NoticeModal";
@@ -59,6 +61,11 @@ interface StatusMessageConfig {
   message: string;
   timeout: number; // -1 for infinite (sticky), otherwise duration in ms
 }
+
+type KakaoMaintenanceModalInfo = KakaoMaintenanceInfo & {
+  gameId: AppConfig["activeGame"];
+  serviceId: "Kakao Games";
+};
 
 // Status Message Mapping (Configuration)
 const STATUS_MESSAGES: Record<RunStatus, StatusMessageConfig> = {
@@ -212,6 +219,8 @@ function App() {
   const [isMigrationModalOpen, setIsMigrationModalOpen] = useState(false); // [UAC Migration]
   const [isKakaoStarterUacModalOpen, setIsKakaoStarterUacModalOpen] =
     useState(false);
+  const [kakaoMaintenanceInfo, setKakaoMaintenanceInfo] =
+    useState<KakaoMaintenanceModalInfo | null>(null);
   const [isFontMigrationOpen, setIsFontMigrationOpen] = useState(false);
 
   // --- Global Game State ---
@@ -408,6 +417,14 @@ function App() {
         cleanups.push(
           window.electronAPI.onKakaoStarterUacRequest(() => {
             setIsKakaoStarterUacModalOpen(true);
+          }),
+        );
+      }
+
+      if (window.electronAPI.onKakaoMaintenanceDetected) {
+        cleanups.push(
+          window.electronAPI.onKakaoMaintenanceDetected((info) => {
+            setKakaoMaintenanceInfo(info);
           }),
         );
       }
@@ -1219,6 +1236,11 @@ function App() {
         isOpen={isKakaoStarterUacModalOpen}
         onConfirm={handleKakaoStarterUacConfirm}
         onDecline={handleKakaoStarterUacDecline}
+      />
+
+      <KakaoMaintenanceModal
+        info={kakaoMaintenanceInfo}
+        onClose={() => setKakaoMaintenanceInfo(null)}
       />
 
       <FontMigrationModal

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -468,6 +468,8 @@ function App() {
 
   // Launcher Title State (Managed by Main Process via Events)
   const [appTitle, setAppTitle] = useState<string | undefined>(undefined);
+  const [isTopCenterTitlebarHovered, setIsTopCenterTitlebarHovered] =
+    useState(false);
 
   useEffect(() => {
     if (window.electronAPI?.onTitleUpdated) {
@@ -477,6 +479,12 @@ function App() {
       window.electronAPI.requestTitleUpdate();
       return cleanup;
     }
+  }, []);
+
+  useEffect(() => {
+    return window.electronAPI?.onTopCenterTitlebarHover?.(
+      setIsTopCenterTitlebarHovered,
+    );
   }, []);
 
   // Patch Modal State
@@ -1382,7 +1390,11 @@ function App() {
           }}
         >
           {/* Gothic Top Frame Decorations (Now Inside Main Content) */}
-          <div className="frame-decoration top-center">
+          <div
+            className={`frame-decoration top-center ${
+              isTopCenterTitlebarHovered ? "titlebar-hover" : ""
+            }`}
+          >
             {/* Blue Fire Overlay (Localized Ripple) */}
             <div className="top-center-blue" />
             {/* Interactive Hit Zone for Blue Fire (Top Central Demon) */}

--- a/src/renderer/components/modals/KakaoMaintenanceModal.css
+++ b/src/renderer/components/modals/KakaoMaintenanceModal.css
@@ -1,0 +1,63 @@
+.kakao-maintenance-modal {
+  width: 560px;
+  max-width: min(560px, 92vw);
+}
+
+.kakao-maintenance-header {
+  display: flex;
+  gap: 14px;
+  align-items: flex-start;
+}
+
+.kakao-maintenance-modal-icon {
+  color: #dfcf99;
+  font-size: 34px;
+  line-height: 1;
+  margin-top: 2px;
+}
+
+.kakao-maintenance-subtitle {
+  margin: 6px 0 0;
+  color: #b8b8b8;
+  font-size: 0.92rem;
+  line-height: 1.5;
+}
+
+.kakao-maintenance-description {
+  color: #d9d0ad;
+  margin-bottom: 14px;
+}
+
+.kakao-maintenance-modal-details {
+  margin: 0;
+  border-top: 1px solid rgba(223, 207, 153, 0.18);
+}
+
+.kakao-maintenance-modal-row {
+  display: grid;
+  grid-template-columns: 128px minmax(0, 1fr);
+  gap: 18px;
+  padding: 14px 0;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.kakao-maintenance-modal-row dt {
+  color: #949494;
+  font-size: 0.86rem;
+  font-weight: 700;
+}
+
+.kakao-maintenance-modal-row dd {
+  margin: 0;
+  color: #e5e5e5;
+  font-size: 0.92rem;
+  line-height: 1.5;
+  overflow-wrap: anywhere;
+}
+
+@media (max-width: 560px) {
+  .kakao-maintenance-modal-row {
+    grid-template-columns: 1fr;
+    gap: 6px;
+  }
+}

--- a/src/renderer/components/modals/KakaoMaintenanceModal.tsx
+++ b/src/renderer/components/modals/KakaoMaintenanceModal.tsx
@@ -1,0 +1,78 @@
+import React from "react";
+
+import { AppConfig, KakaoMaintenanceInfo } from "../../../shared/types";
+import "../ui/ConfirmModal.css";
+import "./KakaoMaintenanceModal.css";
+
+type KakaoMaintenanceModalInfo = KakaoMaintenanceInfo & {
+  gameId: AppConfig["activeGame"];
+  serviceId: "Kakao Games";
+};
+
+interface KakaoMaintenanceModalProps {
+  info: KakaoMaintenanceModalInfo | null;
+  onClose: () => void;
+}
+
+const KakaoMaintenanceModal: React.FC<KakaoMaintenanceModalProps> = ({
+  info,
+  onClose,
+}) => {
+  if (!info) return null;
+
+  const handleOpenInspection = () => {
+    window.open(info.url, "_blank");
+  };
+
+  return (
+    <div className="confirm-modal-overlay" onClick={onClose}>
+      <div
+        className="confirm-modal-content variant-primary kakao-maintenance-modal"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="confirm-modal-header kakao-maintenance-header">
+          <span className="material-symbols-outlined kakao-maintenance-modal-icon">
+            construction
+          </span>
+          <div>
+            <h2 className="confirm-title">서비스 점검 중</h2>
+            <p className="kakao-maintenance-subtitle">{info.title}</p>
+          </div>
+        </div>
+
+        <div className="confirm-modal-body">
+          {info.description && (
+            <p className="confirm-message kakao-maintenance-description">
+              {info.description}
+            </p>
+          )}
+
+          {info.details.length > 0 && (
+            <dl className="kakao-maintenance-modal-details">
+              {info.details.map(({ label, value }) => (
+                <div className="kakao-maintenance-modal-row" key={label}>
+                  <dt>{label}</dt>
+                  <dd>{value}</dd>
+                </div>
+              ))}
+            </dl>
+          )}
+        </div>
+
+        <div className="confirm-modal-actions">
+          <button
+            className="btn-confirm-secondary"
+            onClick={handleOpenInspection}
+          >
+            점검 페이지 열기
+          </button>
+          <button className="btn-confirm-primary btn-primary" onClick={onClose}>
+            확인
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default KakaoMaintenanceModal;

--- a/src/renderer/components/news/NewsDashboard.css
+++ b/src/renderer/components/news/NewsDashboard.css
@@ -310,6 +310,59 @@
   margin: 8px 0;
 }
 
+.kakao-maintenance-content {
+  color: #d6d6d6;
+}
+
+.kakao-maintenance-summary {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+  margin-bottom: 14px;
+}
+
+.kakao-maintenance-icon {
+  color: #dfcf99;
+  font-size: 28px;
+  line-height: 1;
+  margin-top: 2px;
+}
+
+.kakao-maintenance-summary h3 {
+  margin: 0 0 6px;
+  color: #dfcf99;
+  font-size: 15px;
+}
+
+.kakao-maintenance-summary p {
+  margin: 0;
+  color: #aeb2b4;
+}
+
+.kakao-maintenance-details {
+  margin: 0;
+  border-top: 1px solid rgba(175, 148, 79, 0.24);
+}
+
+.kakao-maintenance-detail {
+  display: grid;
+  grid-template-columns: 110px minmax(0, 1fr);
+  gap: 12px;
+  padding: 10px 0;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.kakao-maintenance-detail dt {
+  color: #909090;
+  font-weight: 700;
+}
+
+.kakao-maintenance-detail dd {
+  margin: 0;
+  color: #e4e4e4;
+  overflow-wrap: anywhere;
+}
+
 /* Browser View Button */
 .news-browser-btn {
   position: absolute;

--- a/src/shared/kakao-service-transition.ts
+++ b/src/shared/kakao-service-transition.ts
@@ -18,6 +18,11 @@ export const KAKAO_SERVICE_TRANSITION_EFFECTIVE_AT =
 export const KAKAO_SERVICE_TRANSITION_CLEANUP_PR_AFTER =
   "2026-06-18T00:00:00+09:00";
 
+export const KAKAO_POE_INSPECTION_URL =
+  "https://pathofexile.kakaogames.com/inspection";
+export const KAKAO_SERVICE_INSPECTION_URL =
+  "https://service.kakaogames.com/inspection?game=all";
+
 export const KAKAO_SERVICE_TRANSITION_DECISIONS = [
   "The official notice identifies kakaogames.com as the new platform URL, but does not publish stable game-specific PoE1/PoE2 start URLs before the transfer.",
   "The launcher keeps ASIS Daum URLs as a transition fallback and prefers TOBE URLs after 2026-06-17 10:00 KST.",
@@ -164,6 +169,31 @@ export function isKakaoStarterInstallPopupUrl(url: URL): boolean {
 
   const pathname = url.pathname.toLowerCase();
   return pathname.includes("/popup/") && pathname.includes("starter");
+}
+
+export function isKakaoInspectionUrl(url: URL): boolean {
+  const pathname = url.pathname.replace(/\/+$/, "");
+
+  if (
+    url.hostname === "pathofexile.kakaogames.com" &&
+    pathname === "/inspection"
+  ) {
+    return true;
+  }
+
+  return (
+    url.hostname === "service.kakaogames.com" &&
+    pathname === "/inspection" &&
+    url.searchParams.get("game") === "all"
+  );
+}
+
+export function isKakaoInspectionUrlString(value: string): boolean {
+  try {
+    return isKakaoInspectionUrl(new URL(value));
+  } catch {
+    return false;
+  }
 }
 
 function createUrlCandidate(

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -433,6 +433,9 @@ export interface ElectronAPI {
   openPath: (path: string) => Promise<void>;
   setWindowTitle: (title: string) => void;
   onTitleUpdated: (callback: (title: string) => void) => () => void;
+  onTopCenterTitlebarHover: (
+    callback: (hovered: boolean) => void,
+  ) => () => void;
   requestTitleUpdate: () => void;
   initialGameName: string;
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -436,6 +436,14 @@ export interface ElectronAPI {
   onTopCenterTitlebarHover: (
     callback: (hovered: boolean) => void,
   ) => () => void;
+  onKakaoMaintenanceDetected: (
+    callback: (
+      info: KakaoMaintenanceInfo & {
+        gameId: AppConfig["activeGame"];
+        serviceId: "Kakao Games";
+      },
+    ) => void,
+  ) => () => void;
   requestTitleUpdate: () => void;
   initialGameName: string;
 
@@ -511,6 +519,16 @@ export interface NewsItem {
 }
 
 export type NewsCategory = "notice" | "news" | "patch-notes" | "dev-notice";
+
+export interface KakaoMaintenanceInfo {
+  url: string;
+  title: string;
+  description?: string;
+  details: Array<{
+    label: string;
+    value: string;
+  }>;
+}
 
 export interface NewsContent {
   id: string;

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -249,6 +249,9 @@ export default defineConfig({
   server: {
     port: 54321,
     strictPort: true,
+    watch: {
+      ignored: ["**/.tmp/kakao-page-dumps/**"],
+    },
   },
   define: defines,
 });


### PR DESCRIPTION
## Summary
- 카카오게임즈 점검 페이지 리다이렉션을 감지해 런처 안에서 점검 모달을 표시합니다.
- 게임 시작 중 뜨는 점검 페이지 자동화 창을 숨기고, 공지사항/패치노트에는 점검 안내 fallback을 표시합니다.
- 점검 흐름에서 진단 dump 정리 레이스와 dev reload 노이즈를 줄입니다.
- 특정 이스터에그 동작 개선.

## Motivation
카카오게임즈 점검 중 실제 웹 점검 페이지가 별도 창으로 남거나 게시판이 비어 보이는 문제를 런처 안에서 명확히 안내하기 위함입니다. 또한 타이틀바 영역이 hover hit-test를 가리던 기존 UI 동작을 함께 개선했습니다.