### PR TITLE
KakaoGamesStarter 전환 안내 개선

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -107,7 +107,12 @@ import {
   syncInstallLocation,
 } from "./utils/registry";
 import { RemoteVersionResolver } from "./utils/RemoteVersionResolver";
-import { LegacyUacManager, SimpleUacBypass } from "./utils/uac/uac-migration";
+import { KAKAO_GAMES_STARTER_INSTALLER_URL } from "./utils/uac/kakao-game-starter";
+import {
+  KakaoGameStarterMigration,
+  LegacyUacManager,
+  SimpleUacBypass,
+} from "./utils/uac/uac-migration";
 import {
   applyResolutionRules,
   enforceConstraints,
@@ -895,6 +900,10 @@ ipcMain.on("uac-migration:ready", async () => {
     return;
   }
 
+  if (await requestKakaoGameStarterMigrationIfNeeded()) {
+    return;
+  }
+
   await requestKakaoGamesStarterUacRepairIfNeeded();
 });
 
@@ -925,6 +934,33 @@ ipcMain.handle("kakao-starter-uac:decline", async () => {
   setConfigWithEvent("skipDaumGameStarterUac", false);
   return true;
 });
+
+ipcMain.handle("kakao-starter-migration:open-installer", async () => {
+  logger.log("[Main] Opening Kakao Games starter installer link.");
+  await shell.openExternal(KAKAO_GAMES_STARTER_INSTALLER_URL);
+  return true;
+});
+
+ipcMain.handle("kakao-starter-migration:dismiss", async () => {
+  logger.log("[Main] Kakao game starter migration prompt dismissed.");
+  await requestKakaoGamesStarterUacRepairIfNeeded();
+  return true;
+});
+
+async function requestKakaoGameStarterMigrationIfNeeded(): Promise<boolean> {
+  const request = await KakaoGameStarterMigration.getRequest();
+
+  if (!request) return false;
+
+  logger.log(
+    `[Main] Kakao game starter migration prompt requested: ${request.action}`,
+  );
+  context.mainWindow?.webContents.send(
+    "kakao-starter-migration:request",
+    request,
+  );
+  return true;
+}
 
 async function requestKakaoGamesStarterUacRepairIfNeeded(): Promise<void> {
   if (getEffectiveConfig("skipDaumGameStarterUac") !== true) return;

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -941,6 +941,11 @@ ipcMain.handle("kakao-starter-migration:open-installer", async () => {
   return true;
 });
 
+ipcMain.handle("kakao-starter-migration:uninstall-daum", async () => {
+  logger.log("[Main] User confirmed DaumGameStarter uninstall.");
+  return await KakaoGameStarterMigration.uninstallDaumGameStarter();
+});
+
 ipcMain.handle("kakao-starter-migration:dismiss", async () => {
   logger.log("[Main] Kakao game starter migration prompt dismissed.");
   await requestKakaoGamesStarterUacRepairIfNeeded();

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -16,6 +16,7 @@ import {
   ImportSelection,
   GameLaunchContext,
   KakaoMaintenanceInfo,
+  KakaoGameStarterMigrationRequest,
 } from "../shared/types";
 
 const logger = new PreloadLogger({ type: "PRELOAD", typeColor: "#8BE9FD" });
@@ -291,12 +292,26 @@ contextBridge.exposeInMainWorld("electronAPI", {
     ipcRenderer.on("kakao-starter-uac:request", handler);
     return () => ipcRenderer.off("kakao-starter-uac:request", handler);
   },
+  onKakaoStarterMigrationRequest: (
+    callback: (request: KakaoGameStarterMigrationRequest) => void,
+  ) => {
+    const handler = (
+      _event: IpcRendererEvent,
+      request: KakaoGameStarterMigrationRequest,
+    ) => callback(request);
+    ipcRenderer.on("kakao-starter-migration:request", handler);
+    return () => ipcRenderer.off("kakao-starter-migration:request", handler);
+  },
   reportUacMigrationReady: () => ipcRenderer.send("uac-migration:ready"),
   confirmUacMigration: () => ipcRenderer.send("uac-migration:confirm"),
   confirmKakaoStarterUacBypass: () =>
     ipcRenderer.invoke("kakao-starter-uac:confirm"),
   declineKakaoStarterUacBypass: () =>
     ipcRenderer.invoke("kakao-starter-uac:decline"),
+  openKakaoGamesStarterInstaller: () =>
+    ipcRenderer.invoke("kakao-starter-migration:open-installer"),
+  dismissKakaoStarterMigrationPrompt: () =>
+    ipcRenderer.invoke("kakao-starter-migration:dismiss"),
 
   initialGameName: getGameName(
     ipcRenderer.sendSync("config:get-sync", "activeGame"),

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -310,6 +310,8 @@ contextBridge.exposeInMainWorld("electronAPI", {
     ipcRenderer.invoke("kakao-starter-uac:decline"),
   openKakaoGamesStarterInstaller: () =>
     ipcRenderer.invoke("kakao-starter-migration:open-installer"),
+  uninstallDaumGameStarter: () =>
+    ipcRenderer.invoke("kakao-starter-migration:uninstall-daum"),
   dismissKakaoStarterMigrationPrompt: () =>
     ipcRenderer.invoke("kakao-starter-migration:dismiss"),
 

--- a/src/main/tests/kakao-game-starter.test.ts
+++ b/src/main/tests/kakao-game-starter.test.ts
@@ -5,6 +5,7 @@ import {
   getKakaoGameStarterMigrationRequest,
   isAnyStarterRunAsInvokerEnabled,
   isStarterMissingRunAsInvoker,
+  parseWindowsExecutableCommand,
   resolveInstalledKakaoGameStarters,
   type ResolvedKakaoGameStarter,
   type KakaoGameStarterUacStatus,
@@ -61,7 +62,9 @@ describe("Kakao game starter resolver", () => {
   it("falls back to the known install path when registry lookup is missing", async () => {
     const starters = await resolveInstalledKakaoGameStarters(
       async () => null,
-      (path) => path.includes("\\KakaoGames\\KakaogamesStarter.exe"),
+      (path) =>
+        path ===
+        "C:\\Users\\Default\\AppData\\Roaming\\KakaoGames\\KakaogamesStarter.exe",
     );
 
     expect(starters).toEqual([
@@ -73,6 +76,36 @@ describe("Kakao game starter resolver", () => {
         source: "fallback",
       },
     ]);
+  });
+
+  it("falls back to the current user APPDATA install path", async () => {
+    const previousAppData = process.env.APPDATA;
+    process.env.APPDATA = "C:\\Users\\test\\AppData\\Roaming";
+
+    try {
+      const starters = await resolveInstalledKakaoGameStarters(
+        async () => null,
+        (path) =>
+          path ===
+          "C:\\Users\\test\\AppData\\Roaming\\KakaoGames\\KakaogamesStarter.exe",
+      );
+
+      expect(starters).toEqual([
+        {
+          id: "kakaogames",
+          label: "KakaogamesStarter",
+          exePath:
+            "C:\\Users\\test\\AppData\\Roaming\\KakaoGames\\KakaogamesStarter.exe",
+          source: "fallback",
+        },
+      ]);
+    } finally {
+      if (previousAppData === undefined) {
+        delete process.env.APPDATA;
+      } else {
+        process.env.APPDATA = previousAppData;
+      }
+    }
   });
 
   it("ignores legacy proxy commands and missing executable paths", async () => {
@@ -128,13 +161,19 @@ describe("Kakao game starter resolver", () => {
     });
   });
 
-  it("does not ask for migration when Kakao Games starter is already installed", () => {
-    expect(
-      getKakaoGameStarterMigrationRequest([
-        createResolvedStarter("kakaogames"),
-        createResolvedStarter("daum"),
-      ]),
-    ).toBeNull();
+  it("asks to remove DaumGameStarter when both starters exist", () => {
+    const request = getKakaoGameStarterMigrationRequest([
+      createResolvedStarter("kakaogames"),
+      createResolvedStarter("daum"),
+    ]);
+
+    expect(request).toMatchObject({
+      action: "remove-daum",
+      daumExePath:
+        "C:\\Users\\Default\\AppData\\Roaming\\DaumGames\\DaumGameStarter.exe",
+      kakaoExePath:
+        "C:\\Users\\Default\\AppData\\Roaming\\KakaoGames\\KakaogamesStarter.exe",
+    });
   });
 
   it("does not ask for migration when DaumGameStarter is absent", () => {
@@ -143,6 +182,22 @@ describe("Kakao game starter resolver", () => {
         createResolvedStarter("kakaogames"),
       ]),
     ).toBeNull();
+  });
+
+  it("parses quoted and unquoted Windows uninstall commands", () => {
+    expect(
+      parseWindowsExecutableCommand(
+        '"C:\\Program Files\\DaumGames\\Uninstall.exe" /uninstall',
+      ),
+    ).toEqual({
+      filePath: "C:\\Program Files\\DaumGames\\Uninstall.exe",
+      arguments: "/uninstall",
+    });
+
+    expect(parseWindowsExecutableCommand("MsiExec.exe /X{TEST-GUID}")).toEqual({
+      filePath: "MsiExec.exe",
+      arguments: "/X{TEST-GUID}",
+    });
   });
 });
 

--- a/src/main/tests/kakao-game-starter.test.ts
+++ b/src/main/tests/kakao-game-starter.test.ts
@@ -2,9 +2,11 @@ import { describe, expect, it } from "vitest";
 
 import {
   extractStarterExePath,
+  getKakaoGameStarterMigrationRequest,
   isAnyStarterRunAsInvokerEnabled,
   isStarterMissingRunAsInvoker,
   resolveInstalledKakaoGameStarters,
+  type ResolvedKakaoGameStarter,
   type KakaoGameStarterUacStatus,
 } from "../utils/uac/kakao-game-starter";
 
@@ -111,6 +113,37 @@ describe("Kakao game starter resolver", () => {
     expect(isStarterMissingRunAsInvoker(statuses, "kakaogames")).toBe(true);
     expect(isStarterMissingRunAsInvoker(statuses, "daum")).toBe(false);
   });
+
+  it("asks for Kakao Games starter installation when only DaumGameStarter exists", () => {
+    const request = getKakaoGameStarterMigrationRequest([
+      createResolvedStarter("daum"),
+    ]);
+
+    expect(request).toMatchObject({
+      action: "install-kakaogames",
+      daumExePath:
+        "C:\\Users\\Default\\AppData\\Roaming\\DaumGames\\DaumGameStarter.exe",
+      installerUrl:
+        "https://common.gdn.gamecdn.net/live/KakaogamesStarterSetup.exe",
+    });
+  });
+
+  it("does not ask for migration when Kakao Games starter is already installed", () => {
+    expect(
+      getKakaoGameStarterMigrationRequest([
+        createResolvedStarter("kakaogames"),
+        createResolvedStarter("daum"),
+      ]),
+    ).toBeNull();
+  });
+
+  it("does not ask for migration when DaumGameStarter is absent", () => {
+    expect(
+      getKakaoGameStarterMigrationRequest([
+        createResolvedStarter("kakaogames"),
+      ]),
+    ).toBeNull();
+  });
 });
 
 function createStarterStatus(
@@ -125,5 +158,19 @@ function createStarterStatus(
     exePath: `C:\\Users\\Default\\AppData\\Roaming\\${label}\\${label}.exe`,
     source: "test",
     runAsInvokerEnabled,
+  };
+}
+
+function createResolvedStarter(
+  id: "kakaogames" | "daum",
+): ResolvedKakaoGameStarter {
+  const label = id === "kakaogames" ? "KakaogamesStarter" : "DaumGameStarter";
+  const folder = id === "kakaogames" ? "KakaoGames" : "DaumGames";
+
+  return {
+    id,
+    label,
+    exePath: `C:\\Users\\Default\\AppData\\Roaming\\${folder}\\${label}.exe`,
+    source: "test",
   };
 }

--- a/src/main/utils/uac/kakao-game-starter.ts
+++ b/src/main/utils/uac/kakao-game-starter.ts
@@ -1,5 +1,7 @@
 import { existsSync } from "fs";
 
+import type { KakaoGameStarterMigrationRequest } from "../../../shared/types";
+
 export type KakaoGameStarterId = "kakaogames" | "daum";
 
 export type KakaoGameStarterDefinition = {
@@ -27,6 +29,9 @@ export type RegistryReader = (
 ) => Promise<string | null>;
 
 export type PathExists = (path: string) => boolean;
+
+export const KAKAO_GAMES_STARTER_INSTALLER_URL =
+  "https://common.gdn.gamecdn.net/live/KakaogamesStarterSetup.exe";
 
 export const KAKAO_GAME_STARTERS = [
   {
@@ -105,6 +110,21 @@ export function isStarterMissingRunAsInvoker(
   return statuses.some(
     (starter) => starter.id === id && !starter.runAsInvokerEnabled,
   );
+}
+
+export function getKakaoGameStarterMigrationRequest(
+  starters: readonly ResolvedKakaoGameStarter[],
+): KakaoGameStarterMigrationRequest | null {
+  const kakaoStarter = starters.find((starter) => starter.id === "kakaogames");
+  const daumStarter = starters.find((starter) => starter.id === "daum");
+
+  if (!daumStarter || kakaoStarter) return null;
+
+  return {
+    action: "install-kakaogames",
+    installerUrl: KAKAO_GAMES_STARTER_INSTALLER_URL,
+    daumExePath: daumStarter.exePath,
+  };
 }
 
 async function resolveStarterExecutable(

--- a/src/main/utils/uac/kakao-game-starter.ts
+++ b/src/main/utils/uac/kakao-game-starter.ts
@@ -10,6 +10,7 @@ export type KakaoGameStarterDefinition = {
   protocol: string;
   protocolCommandKeys: readonly string[];
   fallbackExePath: string;
+  fallbackSubPath: string;
 };
 
 export type ResolvedKakaoGameStarter = {
@@ -45,6 +46,7 @@ export const KAKAO_GAME_STARTERS = [
     ],
     fallbackExePath:
       "C:\\Users\\Default\\AppData\\Roaming\\KakaoGames\\KakaogamesStarter.exe",
+    fallbackSubPath: "KakaoGames\\KakaogamesStarter.exe",
   },
   {
     id: "daum",
@@ -57,6 +59,7 @@ export const KAKAO_GAME_STARTERS = [
     ],
     fallbackExePath:
       "C:\\Users\\Default\\AppData\\Roaming\\DaumGames\\DaumGameStarter.exe",
+    fallbackSubPath: "DaumGames\\DaumGameStarter.exe",
   },
 ] as const satisfies readonly KakaoGameStarterDefinition[];
 
@@ -118,12 +121,49 @@ export function getKakaoGameStarterMigrationRequest(
   const kakaoStarter = starters.find((starter) => starter.id === "kakaogames");
   const daumStarter = starters.find((starter) => starter.id === "daum");
 
-  if (!daumStarter || kakaoStarter) return null;
+  if (!daumStarter) return null;
+
+  if (kakaoStarter) {
+    return {
+      action: "remove-daum",
+      installerUrl: KAKAO_GAMES_STARTER_INSTALLER_URL,
+      daumExePath: daumStarter.exePath,
+      kakaoExePath: kakaoStarter.exePath,
+    };
+  }
 
   return {
     action: "install-kakaogames",
     installerUrl: KAKAO_GAMES_STARTER_INSTALLER_URL,
     daumExePath: daumStarter.exePath,
+  };
+}
+
+export type WindowsExecutableCommand = {
+  filePath: string;
+  arguments: string;
+};
+
+export function parseWindowsExecutableCommand(
+  command: string,
+): WindowsExecutableCommand | null {
+  const trimmed = command.trim();
+  if (!trimmed) return null;
+
+  const quoted = trimmed.match(/^"([^"]+)"\s*(.*)$/);
+  if (quoted?.[1]) {
+    return {
+      filePath: quoted[1],
+      arguments: quoted[2]?.trim() ?? "",
+    };
+  }
+
+  const unquoted = trimmed.match(/^(\S+)(?:\s+(.*))?$/);
+  if (!unquoted?.[1]) return null;
+
+  return {
+    filePath: unquoted[1],
+    arguments: unquoted[2]?.trim() ?? "",
   };
 }
 
@@ -146,11 +186,13 @@ async function resolveStarterExecutable(
     }
   }
 
-  if (pathExists(starter.fallbackExePath)) {
+  for (const fallbackExePath of getStarterFallbackExePaths(starter)) {
+    if (!pathExists(fallbackExePath)) continue;
+
     return {
       id: starter.id,
       label: starter.label,
-      exePath: starter.fallbackExePath,
+      exePath: fallbackExePath,
       source: "fallback",
     };
   }
@@ -158,7 +200,28 @@ async function resolveStarterExecutable(
   return null;
 }
 
+function getStarterFallbackExePaths(
+  starter: KakaoGameStarterDefinition,
+): string[] {
+  const candidates = [
+    joinWindowsPath(process.env.APPDATA, starter.fallbackSubPath),
+    joinWindowsPath(process.env.LOCALAPPDATA, starter.fallbackSubPath),
+    starter.fallbackExePath,
+  ].filter((path): path is string => Boolean(path));
+
+  return Array.from(new Set(candidates.map(normalizeWindowsPath)));
+}
+
 function isUsableStarterPath(exePath: string): boolean {
   const normalized = exePath.toLowerCase();
   return normalized.endsWith(".exe") && !normalized.includes("wscript.exe");
+}
+
+function joinWindowsPath(root: string | undefined, subPath: string): string {
+  if (!root) return "";
+  return `${root.replace(/[\\/]+$/, "")}\\${subPath}`;
+}
+
+function normalizeWindowsPath(targetPath: string): string {
+  return targetPath.replace(/\//g, "\\");
 }

--- a/src/main/utils/uac/uac-migration.ts
+++ b/src/main/utils/uac/uac-migration.ts
@@ -9,6 +9,7 @@ import {
   getKakaoGameStarterMigrationRequest,
   isAnyStarterRunAsInvokerEnabled,
   isStarterMissingRunAsInvoker,
+  parseWindowsExecutableCommand,
   resolveInstalledKakaoGameStarters,
   type KakaoGameStarterId,
   type KakaoGameStarterUacStatus,
@@ -267,6 +268,50 @@ export const KakaoGameStarterMigration = {
     const starters = await resolveInstalledKakaoGameStarters(getRegValue);
     return getKakaoGameStarterMigrationRequest(starters);
   },
+
+  async uninstallDaumGameStarter(): Promise<boolean> {
+    const uninstallCommand = await findDaumGameStarterUninstallCommand();
+
+    if (!uninstallCommand) {
+      logger.warn(
+        "[KakaoGameStarterMigration] DaumGameStarter uninstall command was not found.",
+      );
+      return false;
+    }
+
+    const parsed = parseWindowsExecutableCommand(uninstallCommand);
+
+    if (!parsed) {
+      logger.warn(
+        `[KakaoGameStarterMigration] Could not parse DaumGameStarter uninstall command: ${uninstallCommand}`,
+      );
+      return false;
+    }
+
+    const script = [
+      `$filePath = '${escapePowerShellSingleQuotedString(parsed.filePath)}'`,
+      `$arguments = '${escapePowerShellSingleQuotedString(parsed.arguments)}'`,
+      "if ([string]::IsNullOrWhiteSpace($arguments)) {",
+      "  Start-Process -FilePath $filePath -ErrorAction Stop",
+      "} else {",
+      "  Start-Process -FilePath $filePath -ArgumentList $arguments -ErrorAction Stop",
+      "}",
+    ].join("\n");
+
+    const result = await PowerShellManager.getInstance().execute(script, false);
+
+    if (result.code !== 0) {
+      logger.error(
+        `[KakaoGameStarterMigration] Failed to start DaumGameStarter uninstaller: ${result.stderr}`,
+      );
+      return false;
+    }
+
+    logger.log(
+      `[KakaoGameStarterMigration] Started DaumGameStarter uninstaller: ${uninstallCommand}`,
+    );
+    return true;
+  },
 };
 
 async function setRunAsInvokerForStarters(
@@ -394,4 +439,57 @@ function formatStarterStatuses(statuses: KakaoGameStarterUacStatus[]): string {
         } (${starter.exePath})`,
     )
     .join(", ");
+}
+
+async function findDaumGameStarterUninstallCommand(): Promise<string | null> {
+  const script = `
+$roots = @(
+  "HKCU:\\Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\*",
+  "HKLM:\\Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\*",
+  "HKLM:\\Software\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\*"
+)
+
+$entries = foreach ($root in $roots) {
+  Get-ItemProperty -Path $root -ErrorAction SilentlyContinue
+}
+
+$target = $entries | Where-Object {
+  $text = @(
+    $_.DisplayName,
+    $_.Publisher,
+    $_.InstallLocation,
+    $_.UninstallString,
+    $_.QuietUninstallString
+  ) -join "\`n"
+
+  $text -match "(?i)(DaumGameStarter|Daum Game Starter|DaumGames|다음게임 스타터|다음 게임 스타터)"
+} | Select-Object -First 1
+
+if ($null -ne $target) {
+  if ($target.UninstallString) {
+    $target.UninstallString
+  } elseif ($target.QuietUninstallString) {
+    $target.QuietUninstallString
+  }
+}
+`;
+
+  const result = await PowerShellManager.getInstance().execute(
+    script,
+    false,
+    true,
+  );
+
+  if (result.code !== 0) {
+    logger.error(
+      `[KakaoGameStarterMigration] Failed to query DaumGameStarter uninstall command: ${result.stderr}`,
+    );
+    return null;
+  }
+
+  return result.stdout.trim() || null;
+}
+
+function escapePowerShellSingleQuotedString(value: string): string {
+  return value.replace(/'/g, "''");
 }

--- a/src/main/utils/uac/uac-migration.ts
+++ b/src/main/utils/uac/uac-migration.ts
@@ -6,6 +6,7 @@ import { app } from "electron";
 import { logger } from "../logger";
 import { PowerShellManager } from "../powershell";
 import {
+  getKakaoGameStarterMigrationRequest,
   isAnyStarterRunAsInvokerEnabled,
   isStarterMissingRunAsInvoker,
   resolveInstalledKakaoGameStarters,
@@ -258,6 +259,13 @@ export const SimpleUacBypass = {
 
   async isDaumGameStarterMissingRunAsInvoker(): Promise<boolean> {
     return isInstalledStarterMissingRunAsInvoker("daum");
+  },
+};
+
+export const KakaoGameStarterMigration = {
+  async getRequest() {
+    const starters = await resolveInstalledKakaoGameStarters(getRegValue);
+    return getKakaoGameStarterMigrationRequest(starters);
   },
 };
 

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -501,6 +501,10 @@ function App() {
     );
   };
 
+  const handleUninstallDaumGameStarter = async () => {
+    return (await window.electronAPI?.uninstallDaumGameStarter()) === true;
+  };
+
   const handleCloseKakaoStarterMigration = () => {
     setKakaoStarterMigrationRequest(null);
     void window.electronAPI?.dismissKakaoStarterMigrationPrompt();
@@ -1264,6 +1268,7 @@ function App() {
       <KakaoStarterMigrationModal
         request={kakaoStarterMigrationRequest}
         onInstall={handleOpenKakaoStarterInstaller}
+        onUninstallDaum={handleUninstallDaumGameStarter}
         onClose={handleCloseKakaoStarterMigration}
       />
 

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -19,6 +19,7 @@ import {
   PatchProgress,
   ThemeDefinition,
   KakaoMaintenanceInfo,
+  KakaoGameStarterMigrationRequest,
 } from "../shared/types";
 import { DOWNLOAD_URLS, SUPPORT_URLS } from "../shared/urls";
 
@@ -35,6 +36,7 @@ import FontManagerModal from "./components/modals/FontManagerModal";
 import FontMigrationModal from "./components/modals/FontMigrationModal";
 import { ForcedRepairModal } from "./components/modals/ForcedRepairModal";
 import KakaoMaintenanceModal from "./components/modals/KakaoMaintenanceModal";
+import KakaoStarterMigrationModal from "./components/modals/KakaoStarterMigrationModal";
 import KakaoStarterUacModal from "./components/modals/KakaoStarterUacModal";
 import MigrationModal from "./components/modals/MigrationModal";
 import NoticeModal from "./components/modals/NoticeModal";
@@ -219,6 +221,8 @@ function App() {
   const [isMigrationModalOpen, setIsMigrationModalOpen] = useState(false); // [UAC Migration]
   const [isKakaoStarterUacModalOpen, setIsKakaoStarterUacModalOpen] =
     useState(false);
+  const [kakaoStarterMigrationRequest, setKakaoStarterMigrationRequest] =
+    useState<KakaoGameStarterMigrationRequest | null>(null);
   const [kakaoMaintenanceInfo, setKakaoMaintenanceInfo] =
     useState<KakaoMaintenanceModalInfo | null>(null);
   const [isFontMigrationOpen, setIsFontMigrationOpen] = useState(false);
@@ -421,6 +425,14 @@ function App() {
         );
       }
 
+      if (window.electronAPI.onKakaoStarterMigrationRequest) {
+        cleanups.push(
+          window.electronAPI.onKakaoStarterMigrationRequest((request) => {
+            setKakaoStarterMigrationRequest(request);
+          }),
+        );
+      }
+
       if (window.electronAPI.onKakaoMaintenanceDetected) {
         cleanups.push(
           window.electronAPI.onKakaoMaintenanceDetected((info) => {
@@ -481,6 +493,17 @@ function App() {
   const handleKakaoStarterUacDecline = async () => {
     await window.electronAPI?.declineKakaoStarterUacBypass();
     setIsKakaoStarterUacModalOpen(false);
+  };
+
+  const handleOpenKakaoStarterInstaller = async () => {
+    return (
+      (await window.electronAPI?.openKakaoGamesStarterInstaller()) === true
+    );
+  };
+
+  const handleCloseKakaoStarterMigration = () => {
+    setKakaoStarterMigrationRequest(null);
+    void window.electronAPI?.dismissKakaoStarterMigrationPrompt();
   };
 
   // Launcher Title State (Managed by Main Process via Events)
@@ -1236,6 +1259,12 @@ function App() {
         isOpen={isKakaoStarterUacModalOpen}
         onConfirm={handleKakaoStarterUacConfirm}
         onDecline={handleKakaoStarterUacDecline}
+      />
+
+      <KakaoStarterMigrationModal
+        request={kakaoStarterMigrationRequest}
+        onInstall={handleOpenKakaoStarterInstaller}
+        onClose={handleCloseKakaoStarterMigration}
       />
 
       <KakaoMaintenanceModal

--- a/src/renderer/components/modals/KakaoStarterMigrationModal.tsx
+++ b/src/renderer/components/modals/KakaoStarterMigrationModal.tsx
@@ -6,12 +6,14 @@ import "../ui/ConfirmModal.css";
 interface KakaoStarterMigrationModalProps {
   request: KakaoGameStarterMigrationRequest | null;
   onInstall: () => Promise<boolean>;
+  onUninstallDaum: () => Promise<boolean>;
   onClose: () => void;
 }
 
 const KakaoStarterMigrationModal: React.FC<KakaoStarterMigrationModalProps> = ({
   request,
   onInstall,
+  onUninstallDaum,
   onClose,
 }) => {
   const [processing, setProcessing] = useState(false);
@@ -19,12 +21,16 @@ const KakaoStarterMigrationModal: React.FC<KakaoStarterMigrationModalProps> = ({
 
   if (!request) return null;
 
+  const isInstallPrompt = request.action === "install-kakaogames";
+
   const handlePrimary = async () => {
     setErrorMsg("");
     setProcessing(true);
 
     try {
-      const success = await onInstall();
+      const success = isInstallPrompt
+        ? await onInstall()
+        : await onUninstallDaum();
 
       if (success) {
         onClose();
@@ -32,7 +38,9 @@ const KakaoStarterMigrationModal: React.FC<KakaoStarterMigrationModalProps> = ({
       }
 
       setErrorMsg(
-        "설치 링크를 열지 못했습니다. 아래 주소를 브라우저에서 열어 주세요.",
+        isInstallPrompt
+          ? "설치 링크를 열지 못했습니다. 아래 주소를 브라우저에서 열어 주세요."
+          : "DaumGameStarter 제거 프로그램을 찾지 못했습니다. Windows 설정 > 앱에서 제거해 주세요.",
       );
     } catch (error) {
       setErrorMsg(
@@ -53,17 +61,33 @@ const KakaoStarterMigrationModal: React.FC<KakaoStarterMigrationModalProps> = ({
         style={{ maxWidth: "540px" }}
       >
         <div className="confirm-modal-header">
-          <h2 className="confirm-title">카카오게임 스타터 설치 필요</h2>
+          <h2 className="confirm-title">
+            {isInstallPrompt
+              ? "카카오게임 스타터 설치 필요"
+              : "DaumGameStarter 제거"}
+          </h2>
         </div>
         <div className="confirm-modal-body">
           <p className="confirm-message" style={{ whiteSpace: "pre-line" }}>
-            DaumGameStarter가 설치되어 있습니다.
-            {"\n\n"}
-            현재 카카오 게임 실행에는 카카오게임 스타터가 필요합니다. 설치
-            링크를 열어 최신 스타터를 설치해 주세요.
+            {isInstallPrompt ? (
+              <>
+                DaumGameStarter가 설치되어 있습니다.
+                {"\n\n"}
+                현재 카카오 게임 실행에는 카카오게임 스타터가 필요합니다. 설치
+                링크를 열어 최신 스타터를 설치해 주세요.
+              </>
+            ) : (
+              <>
+                카카오게임 스타터와 DaumGameStarter가 함께 설치되어 있습니다.
+                {"\n\n"}새 스타터가 설치되어 있으므로 기존 DaumGameStarter를
+                제거할 수 있습니다. 지금 제거 프로그램을 실행하시겠습니까?
+              </>
+            )}
             {"\n\n"}
             <small style={{ color: "#aaa", wordBreak: "break-all" }}>
-              {request.installerUrl}
+              {isInstallPrompt
+                ? request.installerUrl
+                : `DaumGameStarter: ${request.daumExePath}`}
             </small>
             {errorMsg && (
               <>
@@ -84,11 +108,17 @@ const KakaoStarterMigrationModal: React.FC<KakaoStarterMigrationModalProps> = ({
             나중에
           </button>
           <button
-            className="btn-confirm-primary btn-primary"
+            className={`btn-confirm-primary ${
+              isInstallPrompt ? "btn-primary" : "btn-danger"
+            }`}
             onClick={handlePrimary}
             disabled={processing}
           >
-            {processing ? "처리 중..." : "설치 링크 열기"}
+            {processing
+              ? "처리 중..."
+              : isInstallPrompt
+                ? "설치 링크 열기"
+                : "제거 프로그램 실행"}
           </button>
         </div>
       </div>

--- a/src/renderer/components/modals/KakaoStarterMigrationModal.tsx
+++ b/src/renderer/components/modals/KakaoStarterMigrationModal.tsx
@@ -1,0 +1,99 @@
+import React, { useState } from "react";
+
+import type { KakaoGameStarterMigrationRequest } from "../../../shared/types";
+import "../ui/ConfirmModal.css";
+
+interface KakaoStarterMigrationModalProps {
+  request: KakaoGameStarterMigrationRequest | null;
+  onInstall: () => Promise<boolean>;
+  onClose: () => void;
+}
+
+const KakaoStarterMigrationModal: React.FC<KakaoStarterMigrationModalProps> = ({
+  request,
+  onInstall,
+  onClose,
+}) => {
+  const [processing, setProcessing] = useState(false);
+  const [errorMsg, setErrorMsg] = useState("");
+
+  if (!request) return null;
+
+  const handlePrimary = async () => {
+    setErrorMsg("");
+    setProcessing(true);
+
+    try {
+      const success = await onInstall();
+
+      if (success) {
+        onClose();
+        return;
+      }
+
+      setErrorMsg(
+        "설치 링크를 열지 못했습니다. 아래 주소를 브라우저에서 열어 주세요.",
+      );
+    } catch (error) {
+      setErrorMsg(
+        error instanceof Error
+          ? error.message
+          : "요청 처리 중 오류가 발생했습니다.",
+      );
+    } finally {
+      setProcessing(false);
+    }
+  };
+
+  return (
+    <div className="confirm-modal-overlay">
+      <div
+        className="confirm-modal-content variant-primary"
+        onClick={(e) => e.stopPropagation()}
+        style={{ maxWidth: "540px" }}
+      >
+        <div className="confirm-modal-header">
+          <h2 className="confirm-title">카카오게임 스타터 설치 필요</h2>
+        </div>
+        <div className="confirm-modal-body">
+          <p className="confirm-message" style={{ whiteSpace: "pre-line" }}>
+            DaumGameStarter가 설치되어 있습니다.
+            {"\n\n"}
+            현재 카카오 게임 실행에는 카카오게임 스타터가 필요합니다. 설치
+            링크를 열어 최신 스타터를 설치해 주세요.
+            {"\n\n"}
+            <small style={{ color: "#aaa", wordBreak: "break-all" }}>
+              {request.installerUrl}
+            </small>
+            {errorMsg && (
+              <>
+                {"\n\n"}
+                <span style={{ color: "#f48771", fontWeight: "bold" }}>
+                  {errorMsg}
+                </span>
+              </>
+            )}
+          </p>
+        </div>
+        <div className="confirm-modal-actions">
+          <button
+            className="btn-confirm-secondary"
+            onClick={onClose}
+            disabled={processing}
+          >
+            나중에
+          </button>
+          <button
+            className="btn-confirm-primary btn-primary"
+            onClick={handlePrimary}
+            disabled={processing}
+          >
+            {processing ? "처리 중..." : "설치 링크 열기"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default KakaoStarterMigrationModal;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -463,6 +463,7 @@ export interface ElectronAPI {
   confirmKakaoStarterUacBypass: () => Promise<boolean>;
   declineKakaoStarterUacBypass: () => Promise<boolean>;
   openKakaoGamesStarterInstaller: () => Promise<boolean>;
+  uninstallDaumGameStarter: () => Promise<boolean>;
   dismissKakaoStarterMigrationPrompt: () => Promise<boolean>;
 
   // [Fatal Error Handling]
@@ -536,9 +537,10 @@ export interface KakaoMaintenanceInfo {
 }
 
 export interface KakaoGameStarterMigrationRequest {
-  action: "install-kakaogames";
+  action: "install-kakaogames" | "remove-daum";
   installerUrl: string;
   daumExePath: string;
+  kakaoExePath?: string;
 }
 
 export interface NewsContent {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -455,10 +455,15 @@ export interface ElectronAPI {
   // [UAC Migration]
   onUacMigrationRequest: (callback: () => void) => () => void;
   onKakaoStarterUacRequest: (callback: () => void) => () => void;
+  onKakaoStarterMigrationRequest: (
+    callback: (request: KakaoGameStarterMigrationRequest) => void,
+  ) => () => void;
   reportUacMigrationReady: () => void;
   confirmUacMigration: () => void;
   confirmKakaoStarterUacBypass: () => Promise<boolean>;
   declineKakaoStarterUacBypass: () => Promise<boolean>;
+  openKakaoGamesStarterInstaller: () => Promise<boolean>;
+  dismissKakaoStarterMigrationPrompt: () => Promise<boolean>;
 
   // [Fatal Error Handling]
   onFatalError: (callback: (errorDetails: string) => void) => () => void;
@@ -528,6 +533,12 @@ export interface KakaoMaintenanceInfo {
     label: string;
     value: string;
   }>;
+}
+
+export interface KakaoGameStarterMigrationRequest {
+  action: "install-kakaogames";
+  installerUrl: string;
+  daumExePath: string;
 }
 
 export interface NewsContent {


### PR DESCRIPTION
## Summary

- DaumGameStarter만 설치된 환경에서 KakaoGamesStarter 설치 안내를 표시합니다.
- KakaoGamesStarter와 DaumGameStarter가 함께 설치된 환경에서 DaumGameStarter 제거 안내 및 uninstaller 실행을 제공합니다.
- 현재 사용자 AppData fallback으로 KakaoGamesStarter 감지 누락을 줄입니다.

## Motivation
DaumGameStarter 잔존 또는 전환 환경에서 잘못된 스타터 안내가 표시되거나 중복 설치 상태를 정리하기 어려웠습니다. 새 스타터 감지 후 설치와 제거 안내를 분리해 KakaoGamesStarter 전환 흐름을 명확하게 만듭니다.