### PR TITLE
게임 경로 진단 및 설정 접근성 개선

### DIFF
--- a/src/main/events/handlers/StartPoeGggHandler.ts
+++ b/src/main/events/handlers/StartPoeGggHandler.ts
@@ -46,7 +46,7 @@ export const StartPoeGggHandler: EventHandler<UIEvent> = {
       const installPath = await getGameInstallPath(serviceChannel, activeGame);
 
       if (!installPath) {
-        throw new Error("Could not find game installation path in registry.");
+        throw new Error("Could not resolve game installation path.");
       }
 
       // 3. Notify Processing

--- a/src/main/kakao/account-validation-dom.ts
+++ b/src/main/kakao/account-validation-dom.ts
@@ -1,0 +1,37 @@
+export const KAKAO_ACCOUNT_VALIDATION_SELECTORS = {
+  GGB_NICKNAME: ".kg-ggb__btn--my-info em",
+  GGB_LOGIN_BTN: ".kg-ggb__btn--login",
+  STATUS_NICKNAME: "#statusBar .statusItem.loggedInStatus .profile-link a",
+  STATUS_LOGIN_BTN: "#statusBar .row2.loggedOut a.statusItem",
+} as const;
+
+export interface KakaoAccountValidationElements {
+  ggbNickname: Element | null;
+  ggbLoginBtn: Element | null;
+  statusBarNickname: Element | null;
+  statusBarLoginBtn: Element | null;
+}
+
+export function findKakaoAccountValidationElements(
+  root: ParentNode = document,
+): KakaoAccountValidationElements {
+  return {
+    ggbNickname: root.querySelector(
+      KAKAO_ACCOUNT_VALIDATION_SELECTORS.GGB_NICKNAME,
+    ),
+    ggbLoginBtn: root.querySelector(
+      KAKAO_ACCOUNT_VALIDATION_SELECTORS.GGB_LOGIN_BTN,
+    ),
+    statusBarNickname: root.querySelector(
+      KAKAO_ACCOUNT_VALIDATION_SELECTORS.STATUS_NICKNAME,
+    ),
+    statusBarLoginBtn: root.querySelector(
+      KAKAO_ACCOUNT_VALIDATION_SELECTORS.STATUS_LOGIN_BTN,
+    ),
+  };
+}
+
+export function getElementText(element: Element | null): string | null {
+  const text = element?.textContent?.trim();
+  return text ? text : null;
+}

--- a/src/main/kakao/preload.ts
+++ b/src/main/kakao/preload.ts
@@ -1,6 +1,10 @@
 import { ipcRenderer } from "electron";
 
 import {
+  findKakaoAccountValidationElements,
+  getElementText,
+} from "./account-validation-dom";
+import {
   hasVisibleKakaoLoginForm,
   hasVisibleKakaoQrLoginPrompt,
   getSecurityCenterVisibilityState,
@@ -113,14 +117,6 @@ const SELECTORS = {
   KAKAO_GAMES_MEMBER: {
     BTN_KAKAO_LOGIN: "button.btn-common.btn-type--icon.btn-type__emph3",
     BTN_KAKAO_ICON: ".icon-kakaocapri",
-  },
-  ACCOUNT: {
-    // Stage 1: GGB (Global Gate Bar) - Daum Game Login
-    GGB_NICKNAME: "#a_kg_ggb_nickname",
-    GGB_LOGIN_BTN: ".ggb-user a.btn-login:not(#a_kg_ggb_logout)", // Logout button also has btn-login class, exclude it
-    // Stage 2: StatusBar - POE Profile Link
-    STATUS_NICKNAME: "#statusBar .statusItem.loggedInStatus .profile-link a",
-    STATUS_LOGIN_BTN: "#statusBar .row2.loggedOut a.statusItem", // "로그인" text link
   },
 };
 
@@ -367,12 +363,8 @@ const AccountValidationHandler: PageHandler = {
 
     observeAndInteract((obs) => {
       // --- Tier 1: GGB Check (Daum Auth) ---
-      const ggbNickname = document.querySelector(
-        SELECTORS.ACCOUNT.GGB_NICKNAME,
-      );
-      const ggbLoginBtn = document.querySelector(
-        SELECTORS.ACCOUNT.GGB_LOGIN_BTN,
-      );
+      const { ggbNickname, ggbLoginBtn, statusBarNickname, statusBarLoginBtn } =
+        findKakaoAccountValidationElements(document);
 
       if (!ggbNickname) {
         if (ggbLoginBtn) {
@@ -390,21 +382,14 @@ const AccountValidationHandler: PageHandler = {
       const now = Date.now();
       if (now - lastTier1LogTime > 5000) {
         logger.log(
-          `[AccountValidationHandler] Tier 1 Success: GGB Logged in (${ggbNickname.textContent?.trim()})`,
+          `[AccountValidationHandler] Tier 1 Success: GGB Logged in (${getElementText(ggbNickname)})`,
         );
         lastTier1LogTime = now;
       }
 
-      const statusBarNickname = document.querySelector(
-        SELECTORS.ACCOUNT.STATUS_NICKNAME,
-      );
-      const statusBarLoginBtn = document.querySelector(
-        SELECTORS.ACCOUNT.STATUS_LOGIN_BTN,
-      );
-
       // Found POE Account ID!
-      if (statusBarNickname && statusBarNickname.textContent?.trim()) {
-        const accountId = statusBarNickname.textContent.trim();
+      const accountId = getElementText(statusBarNickname);
+      if (accountId) {
         logger.log(
           `[AccountValidationHandler] Tier 2 Success: Found POE Account ID: ${accountId}`,
         );

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -14,6 +14,7 @@ import {
   protocol,
   net,
   webContents,
+  type OpenDialogOptions,
 } from "electron";
 import JSZip from "jszip";
 
@@ -27,10 +28,12 @@ import {
 import { DEBUG_APP_CONFIG } from "../shared/config";
 import { getGameName, getLauncherTitle, getAppName } from "../shared/naming";
 import {
+  ACTIVE_GAMES,
   AppConfig,
   NewsCategory,
   DebugLogPayload,
   GameLaunchContext,
+  SERVICE_CHANNELS,
 } from "../shared/types";
 import { BASE_URLS } from "../shared/urls";
 import { syncAutoLaunch } from "./events/handlers/AutoLaunchHandler";
@@ -103,7 +106,10 @@ import { LogParser } from "./utils/LogParser";
 import { PowerShellManager } from "./utils/powershell";
 import {
   getGameInstallPath,
+  getGameInstallPathDiagnostics,
   getGameInstallationStatus,
+  resolveGameInstallPathConflict,
+  setGameInstallPath,
   syncInstallLocation,
 } from "./utils/registry";
 import { RemoteVersionResolver } from "./utils/RemoteVersionResolver";
@@ -659,6 +665,16 @@ ipcMain.handle("debug:get-history", () => {
 
 // [Removed] Old session:logout handler (duplicates new partitioned one)
 
+const isSupportedGameInstallContext = (
+  serviceId: unknown,
+  gameId: unknown,
+): serviceId is AppConfig["serviceChannel"] => {
+  return (
+    SERVICE_CHANNELS.includes(serviceId as AppConfig["serviceChannel"]) &&
+    ACTIVE_GAMES.includes(gameId as AppConfig["activeGame"])
+  );
+};
+
 ipcMain.handle("config:set", (_event, key: string, value: unknown) => {
   // [Safety] Do not persist if the key is forced in dev:test mode
   if (FORCE_DEBUG && DEBUG_KEYS.includes(key)) {
@@ -685,6 +701,98 @@ ipcMain.handle("config:delete", (_event, key: string) => {
   // Use shared utility to Delete & Broadcast
   deleteConfigWithEvent(key);
 });
+
+ipcMain.handle(
+  "game-install-path:get-diagnostics",
+  async (
+    _event,
+    serviceId: AppConfig["serviceChannel"],
+    gameId: AppConfig["activeGame"],
+  ) => {
+    if (!isSupportedGameInstallContext(serviceId, gameId)) {
+      throw new Error(
+        `Unsupported game install context: ${serviceId}/${gameId}`,
+      );
+    }
+
+    return getGameInstallPathDiagnostics(serviceId, gameId);
+  },
+);
+
+ipcMain.handle(
+  "game-install-path:set",
+  async (
+    _event,
+    serviceId: AppConfig["serviceChannel"],
+    gameId: AppConfig["activeGame"],
+    installPath: string,
+  ) => {
+    if (!isSupportedGameInstallContext(serviceId, gameId)) {
+      throw new Error(
+        `Unsupported game install context: ${serviceId}/${gameId}`,
+      );
+    }
+
+    return setGameInstallPath(serviceId, gameId, installPath);
+  },
+);
+
+ipcMain.handle(
+  "game-install-path:pick",
+  async (
+    event,
+    serviceId: AppConfig["serviceChannel"],
+    gameId: AppConfig["activeGame"],
+  ) => {
+    if (!isSupportedGameInstallContext(serviceId, gameId)) {
+      throw new Error(
+        `Unsupported game install context: ${serviceId}/${gameId}`,
+      );
+    }
+
+    const targetWindow = BrowserWindow.fromWebContents(event.sender);
+    const openDialogOptions: OpenDialogOptions = {
+      title: "게임 설치 폴더 선택",
+      buttonLabel: "이 폴더 사용",
+      properties: ["openDirectory"],
+    };
+    const result = targetWindow
+      ? await dialog.showOpenDialog(targetWindow, openDialogOptions)
+      : await dialog.showOpenDialog(openDialogOptions);
+
+    if (result.canceled || result.filePaths.length === 0) {
+      return {
+        ok: false,
+        canceled: true,
+        verification: "not-checked",
+      };
+    }
+
+    return setGameInstallPath(serviceId, gameId, result.filePaths[0]);
+  },
+);
+
+ipcMain.handle(
+  "game-install-path:resolve-conflict",
+  async (
+    _event,
+    serviceId: AppConfig["serviceChannel"],
+    gameId: AppConfig["activeGame"],
+    action: "launcher-config-only" | "sync-registry",
+  ) => {
+    if (!isSupportedGameInstallContext(serviceId, gameId)) {
+      throw new Error(
+        `Unsupported game install context: ${serviceId}/${gameId}`,
+      );
+    }
+
+    if (action !== "launcher-config-only" && action !== "sync-registry") {
+      throw new Error(`Unsupported game install conflict action: ${action}`);
+    }
+
+    return resolveGameInstallPathConflict(serviceId, gameId, action);
+  },
+);
 
 ipcMain.handle(
   "report:save",

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -17,6 +17,10 @@ import {
   GameLaunchContext,
   KakaoMaintenanceInfo,
   KakaoGameStarterMigrationRequest,
+  GameInstallPathConflictAction,
+  GameInstallPathConflictResolveResult,
+  GameInstallPathDiagnostics,
+  GameInstallPathSaveResult,
 } from "../shared/types";
 
 const logger = new PreloadLogger({ type: "PRELOAD", typeColor: "#8BE9FD" });
@@ -29,6 +33,33 @@ contextBridge.exposeInMainWorld("electronAPI", {
     logger.log("[Preload] Sending trigger-game-start to Main Process");
     ipcRenderer.send("trigger-game-start", context);
   },
+  getGameInstallPathDiagnostics: (
+    serviceId: AppConfig["serviceChannel"],
+    gameId: AppConfig["activeGame"],
+  ): Promise<GameInstallPathDiagnostics> =>
+    ipcRenderer.invoke("game-install-path:get-diagnostics", serviceId, gameId),
+  setGameInstallPath: (
+    serviceId: AppConfig["serviceChannel"],
+    gameId: AppConfig["activeGame"],
+    installPath: string,
+  ): Promise<GameInstallPathSaveResult> =>
+    ipcRenderer.invoke("game-install-path:set", serviceId, gameId, installPath),
+  pickGameInstallPath: (
+    serviceId: AppConfig["serviceChannel"],
+    gameId: AppConfig["activeGame"],
+  ): Promise<GameInstallPathSaveResult> =>
+    ipcRenderer.invoke("game-install-path:pick", serviceId, gameId),
+  resolveGameInstallPathConflict: (
+    serviceId: AppConfig["serviceChannel"],
+    gameId: AppConfig["activeGame"],
+    action: GameInstallPathConflictAction,
+  ): Promise<GameInstallPathConflictResolveResult> =>
+    ipcRenderer.invoke(
+      "game-install-path:resolve-conflict",
+      serviceId,
+      gameId,
+      action,
+    ),
   minimizeWindow: () => ipcRenderer.send("window-minimize"),
   closeWindow: () => ipcRenderer.send("window-close"),
   getConfig: (

--- a/src/main/tests/kakao-account-validation-dom.test.ts
+++ b/src/main/tests/kakao-account-validation-dom.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  findKakaoAccountValidationElements,
+  getElementText,
+} from "../kakao/account-validation-dom";
+
+describe("kakao account validation DOM", () => {
+  it("detects a logged-in user from the current kg-ggb header", () => {
+    document.body.innerHTML = `
+      <aside class="ggb kg-ggb">
+        <div class="kg-ggb__head">
+          <nav class="kg-ggb__head--nav">
+            <button class="kg-ggb__btn--my-info" type="button">
+              <span><em>nerdhead@kakao.c...</em>님</span>
+            </button>
+            <button class="kg-ggb__btn--logout" type="button">로그아웃</button>
+          </nav>
+        </div>
+      </aside>
+      <div id="statusBar">
+        <div class="row2 loggedOut">
+          <a class="statusItem" href="https://poe.kakaogames.com/login">로그인</a>
+        </div>
+      </div>
+    `;
+
+    const elements = findKakaoAccountValidationElements(document);
+
+    expect(getElementText(elements.ggbNickname)).toBe("nerdhead@kakao.c...");
+    expect(elements.ggbLoginBtn).toBeNull();
+    expect(getElementText(elements.statusBarLoginBtn)).toBe("로그인");
+  });
+
+  it("detects login-required state from the current kg-ggb login button", () => {
+    document.body.innerHTML = `
+      <aside class="ggb kg-ggb">
+        <div class="kg-ggb__head">
+          <nav class="kg-ggb__head--nav">
+            <button class="kg-ggb__btn--login" type="button">
+              <span>로그인</span>
+            </button>
+          </nav>
+        </div>
+      </aside>
+    `;
+
+    const elements = findKakaoAccountValidationElements(document);
+
+    expect(elements.ggbNickname).toBeNull();
+    expect(getElementText(elements.ggbLoginBtn)).toBe("로그인");
+  });
+
+  it("reads a synced POE account id from the status bar", () => {
+    document.body.innerHTML = `
+      <div id="statusBar">
+        <div class="statusItem loggedInStatus">
+          <span class="profile-link"><a>AccountName#1234</a></span>
+        </div>
+      </div>
+    `;
+
+    const elements = findKakaoAccountValidationElements(document);
+
+    expect(getElementText(elements.statusBarNickname)).toBe("AccountName#1234");
+    expect(elements.statusBarLoginBtn).toBeNull();
+  });
+
+  it("does not match the legacy GGB header selectors", () => {
+    document.body.innerHTML = `
+      <div class="ggb-user">
+        <span id="a_kg_ggb_nickname">old-user</span>
+        <a class="btn-login">로그인</a>
+      </div>
+    `;
+
+    const elements = findKakaoAccountValidationElements(document);
+
+    expect(elements.ggbNickname).toBeNull();
+    expect(elements.ggbLoginBtn).toBeNull();
+  });
+});

--- a/src/main/tests/registry-install-status.test.ts
+++ b/src/main/tests/registry-install-status.test.ts
@@ -1,6 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { getGameInstallationStatus, isGameInstalled } from "../utils/registry";
+import { DEFAULT_CONFIG } from "../../shared/config";
+import { ACTIVE_GAMES, SERVICE_CHANNELS } from "../../shared/types";
+import {
+  GAME_INSTALL_REGISTRY_MAP,
+  getGameInstallPath,
+  getGameInstallPathDiagnostics,
+  getGameInstallationStatus,
+  isGameInstalled,
+  resolveGameInstallPathConflict,
+  setGameInstallPath,
+} from "../utils/registry";
 
 import type { ChildProcess } from "node:child_process";
 
@@ -8,7 +18,10 @@ const mocks = vi.hoisted(() => ({
   execFile: vi.fn(),
   stat: vi.fn(),
   powershellExecute: vi.fn(),
+  loggerLog: vi.fn(),
   loggerWarn: vi.fn(),
+  contextProviderGet: vi.fn(),
+  setConfigWithEvent: vi.fn(),
 }));
 
 vi.mock("node:child_process", () => ({
@@ -33,9 +46,15 @@ vi.mock("electron", () => ({
 
 vi.mock("../utils/logger", () => ({
   logger: {
+    log: mocks.loggerLog,
     warn: mocks.loggerWarn,
     error: vi.fn(),
-    log: vi.fn(),
+  },
+}));
+
+vi.mock("../context-provider", () => ({
+  ContextProvider: {
+    get: mocks.contextProviderGet,
   },
 }));
 
@@ -45,6 +64,10 @@ vi.mock("../utils/powershell", () => ({
       execute: mocks.powershellExecute,
     }),
   },
+}));
+
+vi.mock("../utils/config-utils", () => ({
+  setConfigWithEvent: mocks.setConfigWithEvent,
 }));
 
 type RegQueryCallback = (
@@ -69,7 +92,11 @@ describe("registry install status", () => {
     mocks.execFile.mockReset();
     mocks.stat.mockReset();
     mocks.powershellExecute.mockReset();
+    mocks.loggerLog.mockClear();
     mocks.loggerWarn.mockClear();
+    mocks.contextProviderGet.mockReset();
+    mocks.setConfigWithEvent.mockReset();
+    mocks.contextProviderGet.mockReturnValue(null);
     mocks.powershellExecute.mockResolvedValue({
       stdout: "",
       stderr: "",
@@ -97,14 +124,14 @@ HKEY_CURRENT_USER\\Software\\DaumGames\\POE2
       );
       return {} as ChildProcess;
     });
-    mocks.stat.mockResolvedValue({ isDirectory: () => true });
+    mocks.stat.mockResolvedValue({ isFile: () => true });
 
     await expect(
       getGameInstallationStatus("Kakao Games", "POE2"),
     ).resolves.toBe("installed");
     await expect(isGameInstalled("Kakao Games", "POE2")).resolves.toBe(true);
 
-    expect(mocks.stat).toHaveBeenCalledWith(installPath);
+    expect(mocks.stat).toHaveBeenCalledWith(`${installPath}\\PathOfExile.exe`);
   });
 
   it("returns unknown instead of uninstalled when registry access fails", async () => {
@@ -125,13 +152,16 @@ HKEY_CURRENT_USER\\Software\\DaumGames\\POE2
 
     expect(mocks.stat).not.toHaveBeenCalled();
     expect(mocks.loggerWarn).toHaveBeenCalledWith(
-      expect.stringContaining("Could not determine installation status"),
+      expect.stringContaining("registry=read-failed"),
+    );
+    expect(mocks.loggerWarn).toHaveBeenCalledWith(
+      expect.stringContaining("error=PowerShell threw"),
     );
   });
 
   it("returns uninstalled when the registry value is absent", async () => {
     mocks.powershellExecute.mockResolvedValue({
-      stdout: "",
+      stdout: "__REG_VALUE_MISSING__",
       stderr: "",
       code: 0,
     });
@@ -142,5 +172,512 @@ HKEY_CURRENT_USER\\Software\\DaumGames\\POE2
 
     expect(mocks.execFile).not.toHaveBeenCalled();
     expect(mocks.stat).not.toHaveBeenCalled();
+    expect(mocks.loggerLog).toHaveBeenCalledWith(
+      expect.stringContaining("registry=value-missing"),
+    );
+  });
+
+  it("logs a key-missing diagnostic when the install registry key is absent", async () => {
+    mocks.powershellExecute.mockResolvedValue({
+      stdout: "__REG_KEY_MISSING__",
+      stderr: "",
+      code: 0,
+    });
+
+    await expect(
+      getGameInstallationStatus("Kakao Games", "POE2"),
+    ).resolves.toBe("uninstalled");
+
+    expect(mocks.loggerLog).toHaveBeenCalledWith(
+      expect.stringContaining("registry=key-missing"),
+    );
+  });
+
+  it("uses a configured install path before checking the registry", async () => {
+    const installPath = String.raw`C:\Games\Path of Exile 2`;
+    mocks.contextProviderGet.mockReturnValue(
+      createContext({
+        "Kakao Games": {
+          POE1: "",
+          POE2: installPath,
+        },
+        GGG: {
+          POE1: "",
+          POE2: "",
+        },
+      }),
+    );
+    mocks.stat.mockResolvedValue({ isFile: () => true });
+
+    await expect(getGameInstallPath("Kakao Games", "POE2")).resolves.toBe(
+      installPath,
+    );
+
+    expect(mocks.powershellExecute).not.toHaveBeenCalled();
+    expect(mocks.execFile).not.toHaveBeenCalled();
+    expect(mocks.setConfigWithEvent).not.toHaveBeenCalled();
+  });
+
+  it("falls back to registry and caches the path when the configured path is empty", async () => {
+    const registryPath = String.raw`D:\Games\Path of Exile 2`;
+    mocks.contextProviderGet.mockReturnValue(
+      createContext({
+        "Kakao Games": {
+          POE1: "",
+          POE2: "",
+        },
+        GGG: {
+          POE1: "",
+          POE2: "",
+        },
+      }),
+    );
+    mocks.stat.mockResolvedValue({ isFile: () => true });
+    mocks.powershellExecute.mockResolvedValue({
+      stdout: registryPath,
+      stderr: "",
+      code: 0,
+    });
+
+    await expect(getGameInstallPath("Kakao Games", "POE2")).resolves.toBe(
+      registryPath,
+    );
+
+    expect(mocks.setConfigWithEvent).toHaveBeenCalledWith("gameInstallPaths", {
+      "Kakao Games": {
+        POE1: "",
+        POE2: registryPath,
+      },
+      GGG: {
+        POE1: "",
+        POE2: "",
+      },
+    });
+  });
+
+  it("falls back to registry without overwriting when a configured path conflicts", async () => {
+    const stalePath = String.raw`C:\Old\Path of Exile 2`;
+    const registryPath = String.raw`D:\Games\Path of Exile 2`;
+    mocks.contextProviderGet.mockReturnValue(
+      createContext({
+        "Kakao Games": {
+          POE1: "",
+          POE2: stalePath,
+        },
+        GGG: {
+          POE1: "",
+          POE2: "",
+        },
+      }),
+    );
+    mocks.stat.mockImplementation(async (targetPath: string) => {
+      if (targetPath === `${stalePath}\\PathOfExile.exe`) {
+        throw Object.assign(new Error("missing"), { code: "ENOENT" });
+      }
+
+      return { isFile: () => true };
+    });
+    mocks.powershellExecute.mockResolvedValue({
+      stdout: registryPath,
+      stderr: "",
+      code: 0,
+    });
+
+    await expect(getGameInstallPath("Kakao Games", "POE2")).resolves.toBe(
+      registryPath,
+    );
+
+    expect(mocks.setConfigWithEvent).not.toHaveBeenCalled();
+  });
+
+  it("returns diagnostics for conflicting configured and registry paths", async () => {
+    const stalePath = String.raw`C:\Old\Path of Exile 2`;
+    const registryPath = String.raw`D:\Games\Path of Exile 2`;
+    mocks.contextProviderGet.mockReturnValue(
+      createContext({
+        "Kakao Games": {
+          POE1: "",
+          POE2: stalePath,
+        },
+        GGG: {
+          POE1: "",
+          POE2: "",
+        },
+      }),
+    );
+    mocks.stat.mockImplementation(async (targetPath: string) => {
+      if (targetPath === `${stalePath}\\PathOfExile.exe`) {
+        throw Object.assign(new Error("missing"), { code: "ENOENT" });
+      }
+
+      return { isFile: () => true };
+    });
+    mocks.powershellExecute.mockResolvedValue({
+      stdout: registryPath,
+      stderr: "",
+      code: 0,
+    });
+
+    const diagnostics = await getGameInstallPathDiagnostics(
+      "Kakao Games",
+      "POE2",
+    );
+
+    expect(diagnostics.hasPathConflict).toBe(true);
+    expect(diagnostics.recommendedSource).toBe("registry");
+    expect(diagnostics.executableName).toBe("PathOfExile.exe");
+    expect(diagnostics.config.path).toBe(stalePath);
+    expect(diagnostics.config.verification).toBe("missing");
+    expect(diagnostics.registry.path).toBe(registryPath);
+    expect(diagnostics.registry.verification).toBe("valid");
+    expect(diagnostics.registry.registryValueName).toBe("InstallPath");
+    expect(diagnostics.isPathConflictAcknowledged).toBe(false);
+  });
+
+  it("acknowledges a launcher-config-only conflict for the current path pair", async () => {
+    const configPath = String.raw`C:\Games\Path of Exile 2`;
+    const registryPath = String.raw`D:\Games\Path of Exile 2`;
+    mocks.contextProviderGet.mockReturnValue(
+      createContext({
+        "Kakao Games": {
+          POE1: "",
+          POE2: configPath,
+        },
+        GGG: {
+          POE1: "",
+          POE2: "",
+        },
+      }),
+    );
+    mocks.stat.mockResolvedValue({ isFile: () => true });
+    mocks.powershellExecute.mockResolvedValue({
+      stdout: registryPath,
+      stderr: "",
+      code: 0,
+    });
+
+    const result = await resolveGameInstallPathConflict(
+      "Kakao Games",
+      "POE2",
+      "launcher-config-only",
+    );
+
+    expect(result.ok).toBe(true);
+    expect(mocks.setConfigWithEvent).toHaveBeenCalledWith(
+      "gameInstallPathConflictResolutions",
+      {
+        "Kakao Games": {
+          POE1: null,
+          POE2: {
+            configPath,
+            registryPath,
+            resolvedAt: expect.any(Number),
+          },
+        },
+        GGG: {
+          POE1: null,
+          POE2: null,
+        },
+      },
+    );
+  });
+
+  it("marks diagnostics as acknowledged when the saved conflict pair matches", async () => {
+    const configPath = String.raw`C:\Games\Path of Exile 2`;
+    const registryPath = String.raw`D:\Games\Path of Exile 2`;
+    mocks.contextProviderGet.mockReturnValue(
+      createContext(
+        {
+          "Kakao Games": {
+            POE1: "",
+            POE2: configPath,
+          },
+          GGG: {
+            POE1: "",
+            POE2: "",
+          },
+        },
+        {
+          "Kakao Games": {
+            POE1: null,
+            POE2: {
+              configPath,
+              registryPath,
+              resolvedAt: 123,
+            },
+          },
+          GGG: {
+            POE1: null,
+            POE2: null,
+          },
+        },
+      ),
+    );
+    mocks.stat.mockResolvedValue({ isFile: () => true });
+    mocks.powershellExecute.mockResolvedValue({
+      stdout: registryPath,
+      stderr: "",
+      code: 0,
+    });
+
+    const diagnostics = await getGameInstallPathDiagnostics(
+      "Kakao Games",
+      "POE2",
+    );
+
+    expect(diagnostics.hasPathConflict).toBe(true);
+    expect(diagnostics.isPathConflictAcknowledged).toBe(true);
+  });
+
+  it("updates the registry install path from the launcher config path", async () => {
+    const configPath = String.raw`C:\Games\Path of Exile 2`;
+    const registryPath = String.raw`D:\Games\Path of Exile 2`;
+    mocks.contextProviderGet.mockReturnValue(
+      createContext({
+        "Kakao Games": {
+          POE1: "",
+          POE2: configPath,
+        },
+        GGG: {
+          POE1: "",
+          POE2: "",
+        },
+      }),
+    );
+    mocks.stat.mockResolvedValue({ isFile: () => true });
+    mocks.powershellExecute
+      .mockResolvedValueOnce({
+        stdout: registryPath,
+        stderr: "",
+        code: 0,
+      })
+      .mockResolvedValueOnce({
+        stdout: "",
+        stderr: "",
+        code: 0,
+      })
+      .mockResolvedValueOnce({
+        stdout: configPath,
+        stderr: "",
+        code: 0,
+      });
+
+    const result = await resolveGameInstallPathConflict(
+      "Kakao Games",
+      "POE2",
+      "sync-registry",
+    );
+
+    expect(result.ok).toBe(true);
+    expect(mocks.powershellExecute).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining("New-ItemProperty"),
+      false,
+    );
+    expect(mocks.powershellExecute).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining(configPath),
+      false,
+    );
+    expect(mocks.setConfigWithEvent).toHaveBeenCalledWith(
+      "gameInstallPathConflictResolutions",
+      {
+        "Kakao Games": {
+          POE1: null,
+          POE2: null,
+        },
+        GGG: {
+          POE1: null,
+          POE2: null,
+        },
+      },
+    );
+  });
+
+  it("saves a manually selected install path only after executable verification", async () => {
+    const installPath = String.raw`E:\Games\Path of Exile 2`;
+    mocks.contextProviderGet.mockReturnValue(
+      createContext({
+        "Kakao Games": {
+          POE1: "",
+          POE2: "",
+        },
+        GGG: {
+          POE1: "",
+          POE2: "",
+        },
+      }),
+    );
+    mocks.stat.mockResolvedValue({ isFile: () => true });
+    mocks.powershellExecute.mockResolvedValue({
+      stdout: "__REG_VALUE_MISSING__",
+      stderr: "",
+      code: 0,
+    });
+
+    const result = await setGameInstallPath("Kakao Games", "POE2", installPath);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      throw new Error("Expected install path save to succeed");
+    }
+
+    expect(result.path).toBe(installPath);
+    expect(mocks.setConfigWithEvent).toHaveBeenCalledWith("gameInstallPaths", {
+      "Kakao Games": {
+        POE1: "",
+        POE2: installPath,
+      },
+      GGG: {
+        POE1: "",
+        POE2: "",
+      },
+    });
+  });
+
+  it("rejects a manually selected folder without PathOfExile.exe", async () => {
+    const installPath = String.raw`E:\Games\Path of Exile 2`;
+    mocks.contextProviderGet.mockReturnValue(
+      createContext({
+        "Kakao Games": {
+          POE1: "",
+          POE2: "",
+        },
+        GGG: {
+          POE1: "",
+          POE2: "",
+        },
+      }),
+    );
+    mocks.stat.mockRejectedValue(
+      Object.assign(new Error("missing"), { code: "ENOENT" }),
+    );
+
+    const result = await setGameInstallPath("Kakao Games", "POE2", installPath);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error("Expected install path save to fail");
+    }
+
+    expect(result.verification).toBe("missing");
+    expect(mocks.setConfigWithEvent).not.toHaveBeenCalled();
+  });
+
+  it("logs both configured path and registry diagnostics when both fail", async () => {
+    const stalePath = String.raw`C:\Old\Path of Exile 2`;
+    mocks.contextProviderGet.mockReturnValue(
+      createContext({
+        "Kakao Games": {
+          POE1: "",
+          POE2: stalePath,
+        },
+        GGG: {
+          POE1: "",
+          POE2: "",
+        },
+      }),
+    );
+    mocks.stat.mockRejectedValue(
+      Object.assign(new Error("missing"), { code: "ENOENT" }),
+    );
+    mocks.powershellExecute.mockResolvedValue({
+      stdout: "__REG_VALUE_MISSING__",
+      stderr: "",
+      code: 0,
+    });
+
+    await expect(
+      getGameInstallationStatus("Kakao Games", "POE2"),
+    ).resolves.toBe("uninstalled");
+
+    expect(mocks.loggerLog).toHaveBeenCalledWith(
+      expect.stringContaining("config=path-invalid"),
+    );
+    expect(mocks.loggerLog).toHaveBeenCalledWith(
+      expect.stringContaining("registry=value-missing"),
+    );
+  });
+
+  it("returns uninstalled when a registry path does not contain PathOfExile.exe", async () => {
+    const installPath = String.raw`C:\Games\Path of Exile 2`;
+    mocks.powershellExecute.mockResolvedValue({
+      stdout: installPath,
+      stderr: "",
+      code: 0,
+    });
+    mocks.stat.mockRejectedValue(
+      Object.assign(new Error("missing"), { code: "ENOENT" }),
+    );
+
+    await expect(
+      getGameInstallationStatus("Kakao Games", "POE2"),
+    ).resolves.toBe("uninstalled");
+
+    expect(mocks.setConfigWithEvent).not.toHaveBeenCalled();
+    expect(mocks.loggerLog).toHaveBeenCalledWith(
+      expect.stringContaining("registry=path-invalid"),
+    );
+    expect(mocks.loggerLog).toHaveBeenCalledWith(
+      expect.stringContaining("PathOfExile.exe missing"),
+    );
+  });
+
+  it("defines registry and cached config slots for every supported service/game", () => {
+    expect(Object.keys(GAME_INSTALL_REGISTRY_MAP).sort()).toEqual(
+      [...SERVICE_CHANNELS].sort(),
+    );
+    expect(Object.keys(DEFAULT_CONFIG.gameInstallPaths).sort()).toEqual(
+      [...SERVICE_CHANNELS].sort(),
+    );
+    expect(
+      Object.keys(DEFAULT_CONFIG.gameInstallPathConflictResolutions).sort(),
+    ).toEqual([...SERVICE_CHANNELS].sort());
+
+    for (const serviceId of SERVICE_CHANNELS) {
+      expect(Object.keys(GAME_INSTALL_REGISTRY_MAP[serviceId]).sort()).toEqual(
+        [...ACTIVE_GAMES].sort(),
+      );
+      expect(
+        Object.keys(DEFAULT_CONFIG.gameInstallPaths[serviceId]).sort(),
+      ).toEqual([...ACTIVE_GAMES].sort());
+      expect(
+        Object.keys(
+          DEFAULT_CONFIG.gameInstallPathConflictResolutions[serviceId],
+        ).sort(),
+      ).toEqual([...ACTIVE_GAMES].sort());
+
+      for (const gameId of ACTIVE_GAMES) {
+        const registryInfo = GAME_INSTALL_REGISTRY_MAP[serviceId][gameId];
+
+        expect(
+          registryInfo.path,
+          `${serviceId}/${gameId} registry path is required`,
+        ).not.toBe("");
+        expect(
+          registryInfo.key,
+          `${serviceId}/${gameId} registry value name is required`,
+        ).not.toBe("");
+        expect(DEFAULT_CONFIG.gameInstallPaths[serviceId][gameId]).toBe("");
+        expect(
+          DEFAULT_CONFIG.gameInstallPathConflictResolutions[serviceId][gameId],
+        ).toBeNull();
+      }
+    }
   });
 });
+
+function createContext(
+  gameInstallPaths: {
+    "Kakao Games": { POE1: string; POE2: string };
+    GGG: { POE1: string; POE2: string };
+  },
+  gameInstallPathConflictResolutions = DEFAULT_CONFIG.gameInstallPathConflictResolutions,
+) {
+  return {
+    getConfig: () => ({
+      gameInstallPaths,
+      gameInstallPathConflictResolutions,
+    }),
+  };
+}

--- a/src/main/utils/registry.ts
+++ b/src/main/utils/registry.ts
@@ -5,14 +5,39 @@ import path from "node:path";
 import { app } from "electron";
 
 import { PowerShellManager } from "./powershell";
-import { AppConfig } from "../../shared/types";
+import { CONFIG_KEYS, DEFAULT_CONFIG } from "../../shared/config";
+import {
+  ActiveGame,
+  AppConfig,
+  GameInstallPathConflictAction,
+  GameInstallPathConflictResolution,
+  GameInstallPathConflictResolveResult,
+  GameInstallPathConflictResolutions,
+  GameInstallPathConfigDiagnostic,
+  GameInstallPathDiagnostics,
+  GameInstallPaths,
+  GameInstallPathRegistryDiagnostic,
+  GameInstallPathSaveResult,
+  GameInstallPathVerificationStatus,
+  ServiceChannel,
+} from "../../shared/types";
+import { ContextProvider } from "../context-provider";
+import { setConfigWithEvent } from "../utils/config-utils";
 import { logger } from "../utils/logger";
 
 type RegistryReadResult =
-  | { ok: true; value: string | null }
+  | {
+      ok: true;
+      value: string | null;
+      state: "found" | "key-missing" | "value-missing" | "value-empty";
+    }
   | { ok: false; error: string };
 
 export type GameInstallationStatus = "installed" | "uninstalled" | "unknown";
+type InstallPathVerificationStatus = Exclude<
+  GameInstallPathVerificationStatus,
+  "not-checked"
+>;
 
 type ExecFileError = Error & {
   code?: number | string;
@@ -20,13 +45,24 @@ type ExecFileError = Error & {
   stderr?: string | Buffer;
 };
 
+type InstallPathResolution = {
+  path: string | null;
+  source?: "config" | "registry";
+  error?: string;
+  verifyError?: string;
+  diagnostics: string[];
+};
+
+type ConfiguredInstallPathResult =
+  | { state: "found"; path: string }
+  | { state: "empty" | "context-unavailable"; path: null };
+
+const GAME_EXECUTABLE_NAME = "PathOfExile.exe";
+
 /**
  * Registry Mapping for Game Installation Paths
  */
-const REGISTRY_MAP: Record<
-  AppConfig["serviceChannel"],
-  Record<AppConfig["activeGame"], { path: string; key: string }>
-> = {
+export const GAME_INSTALL_REGISTRY_MAP = {
   "Kakao Games": {
     POE1: {
       path: "HKCU:\\Software\\DaumGames\\POE",
@@ -47,7 +83,10 @@ const REGISTRY_MAP: Record<
       key: "InstallLocation",
     },
   },
-};
+} as const satisfies Record<
+  ServiceChannel,
+  Record<ActiveGame, { path: string; key: string }>
+>;
 
 export const DAUM_STARTER_PROTOCOL_KEY =
   "Registry::HKEY_CLASSES_ROOT\\daumgamestarter\\shell\\open\\command";
@@ -100,6 +139,188 @@ const normalizePath = (rawPath: string): string => {
   return normalized;
 };
 
+const createDefaultGameInstallPaths = (): GameInstallPaths => ({
+  "Kakao Games": { ...DEFAULT_CONFIG.gameInstallPaths["Kakao Games"] },
+  GGG: { ...DEFAULT_CONFIG.gameInstallPaths.GGG },
+});
+
+const createDefaultGameInstallPathConflictResolutions =
+  (): GameInstallPathConflictResolutions => ({
+    "Kakao Games": {
+      ...DEFAULT_CONFIG.gameInstallPathConflictResolutions["Kakao Games"],
+    },
+    GGG: { ...DEFAULT_CONFIG.gameInstallPathConflictResolutions.GGG },
+  });
+
+const normalizeGameInstallPaths = (value: unknown): GameInstallPaths => {
+  const normalized = createDefaultGameInstallPaths();
+
+  if (!value || typeof value !== "object") return normalized;
+
+  const rawPaths = value as Partial<
+    Record<
+      AppConfig["serviceChannel"],
+      Partial<Record<AppConfig["activeGame"], unknown>>
+    >
+  >;
+
+  for (const serviceId of Object.keys(normalized) as Array<
+    AppConfig["serviceChannel"]
+  >) {
+    for (const gameId of Object.keys(normalized[serviceId]) as Array<
+      AppConfig["activeGame"]
+    >) {
+      const rawPath = rawPaths[serviceId]?.[gameId];
+      normalized[serviceId][gameId] =
+        typeof rawPath === "string" ? normalizePath(rawPath) : "";
+    }
+  }
+
+  return normalized;
+};
+
+const normalizeGameInstallPathConflictResolutions = (
+  value: unknown,
+): GameInstallPathConflictResolutions => {
+  const normalized = createDefaultGameInstallPathConflictResolutions();
+
+  if (!value || typeof value !== "object") return normalized;
+
+  const rawResolutions = value as Partial<
+    Record<
+      AppConfig["serviceChannel"],
+      Partial<Record<AppConfig["activeGame"], unknown>>
+    >
+  >;
+
+  for (const serviceId of Object.keys(normalized) as Array<
+    AppConfig["serviceChannel"]
+  >) {
+    for (const gameId of Object.keys(normalized[serviceId]) as Array<
+      AppConfig["activeGame"]
+    >) {
+      const rawResolution = rawResolutions[serviceId]?.[gameId];
+      if (!rawResolution || typeof rawResolution !== "object") {
+        normalized[serviceId][gameId] = null;
+        continue;
+      }
+
+      const resolution =
+        rawResolution as Partial<GameInstallPathConflictResolution>;
+      if (
+        typeof resolution.configPath !== "string" ||
+        typeof resolution.registryPath !== "string" ||
+        typeof resolution.resolvedAt !== "number"
+      ) {
+        normalized[serviceId][gameId] = null;
+        continue;
+      }
+
+      normalized[serviceId][gameId] = {
+        configPath: normalizePath(resolution.configPath),
+        registryPath: normalizePath(resolution.registryPath),
+        resolvedAt: resolution.resolvedAt,
+      };
+    }
+  }
+
+  return normalized;
+};
+
+const getConfiguredGameInstallPath = (
+  serviceId: AppConfig["serviceChannel"],
+  gameId: AppConfig["activeGame"],
+): ConfiguredInstallPathResult => {
+  const context = ContextProvider.get();
+  if (!context) return { state: "context-unavailable", path: null };
+
+  const config = context.getConfig() as AppConfig;
+  const gameInstallPaths = normalizeGameInstallPaths(config.gameInstallPaths);
+  const installPath = gameInstallPaths[serviceId]?.[gameId];
+
+  return installPath
+    ? { state: "found", path: installPath }
+    : { state: "empty", path: null };
+};
+
+const persistDiscoveredGameInstallPath = async (
+  serviceId: AppConfig["serviceChannel"],
+  gameId: AppConfig["activeGame"],
+  installPath: string,
+): Promise<boolean> => {
+  const context = ContextProvider.get();
+  if (!context) return false;
+
+  const config = context.getConfig() as AppConfig;
+  const currentPaths = normalizeGameInstallPaths(config.gameInstallPaths);
+
+  if (currentPaths[serviceId][gameId] === installPath) return true;
+
+  const nextValue: GameInstallPaths = {
+    ...currentPaths,
+    [serviceId]: {
+      ...currentPaths[serviceId],
+      [gameId]: installPath,
+    },
+  };
+
+  setConfigWithEvent(CONFIG_KEYS.GAME_INSTALL_PATHS, nextValue);
+  return true;
+};
+
+const persistGameInstallPathConflictResolution = async (
+  serviceId: AppConfig["serviceChannel"],
+  gameId: AppConfig["activeGame"],
+  resolution: GameInstallPathConflictResolution | null,
+): Promise<boolean> => {
+  const context = ContextProvider.get();
+  if (!context) return false;
+
+  const config = context.getConfig() as AppConfig;
+  const currentResolutions = normalizeGameInstallPathConflictResolutions(
+    config.gameInstallPathConflictResolutions,
+  );
+
+  const nextValue: GameInstallPathConflictResolutions = {
+    ...currentResolutions,
+    [serviceId]: {
+      ...currentResolutions[serviceId],
+      [gameId]: resolution,
+    },
+  };
+
+  setConfigWithEvent(
+    CONFIG_KEYS.GAME_INSTALL_PATH_CONFLICT_RESOLUTIONS,
+    nextValue,
+  );
+  return true;
+};
+
+const isGameInstallPathConflictAcknowledged = (
+  serviceId: AppConfig["serviceChannel"],
+  gameId: AppConfig["activeGame"],
+  configPath: string | null,
+  registryPath: string | null,
+) => {
+  if (!configPath || !registryPath) return false;
+
+  const context = ContextProvider.get();
+  if (!context) return false;
+
+  const config = context.getConfig() as AppConfig;
+  const resolutions = normalizeGameInstallPathConflictResolutions(
+    config.gameInstallPathConflictResolutions,
+  );
+  const resolution = resolutions[serviceId]?.[gameId];
+
+  if (!resolution) return false;
+
+  return (
+    areSameInstallPath(resolution.configPath, configPath) &&
+    areSameInstallPath(resolution.registryPath, registryPath)
+  );
+};
+
 /**
  * Executes a PowerShell command, optionally with Admin privileges (RunAs).
  */
@@ -124,6 +345,9 @@ const formatError = (error: unknown): string => {
   return String(error);
 };
 
+const escapePowerShellSingleQuotedString = (value: string): string =>
+  value.replace(/'/g, "''");
+
 const isMissingPathError = (error: unknown): boolean => {
   return (
     typeof error === "object" &&
@@ -134,7 +358,10 @@ const isMissingPathError = (error: unknown): boolean => {
   );
 };
 
-const parseRegQueryValue = (stdout: string, key: string): string | null => {
+const parseRegQueryValue = (
+  stdout: string,
+  key: string,
+): { found: boolean; value: string | null; state: "found" | "value-empty" } => {
   const lowerKey = key.toLowerCase();
 
   for (const line of stdout.split(/\r?\n/)) {
@@ -143,11 +370,51 @@ const parseRegQueryValue = (stdout: string, key: string): string | null => {
 
     if (match[1].trim().toLowerCase() === lowerKey) {
       const value = match[2].trim();
-      return value || null;
+      return {
+        found: true,
+        value: value || null,
+        state: value ? "found" : "value-empty",
+      };
     }
   }
 
-  return null;
+  return { found: false, value: null, state: "value-empty" };
+};
+
+const parsePowerShellRegistryOutput = (stdout: string): RegistryReadResult => {
+  const lines = stdout
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  const marker = lines[0];
+
+  if (marker === "__REG_KEY_MISSING__") {
+    return { ok: true, value: null, state: "key-missing" };
+  }
+
+  if (marker === "__REG_VALUE_MISSING__") {
+    return { ok: true, value: null, state: "value-missing" };
+  }
+
+  if (marker === "__REG_VALUE_EMPTY__") {
+    return { ok: true, value: null, state: "value-empty" };
+  }
+
+  if (marker === "__REG_VALUE_FOUND__") {
+    const value = lines.slice(1).join("\n").trim();
+    return {
+      ok: true,
+      value: value || null,
+      state: value ? "found" : "value-empty",
+    };
+  }
+
+  const value = stdout.trim();
+  return {
+    ok: true,
+    value: value || null,
+    state: value ? "found" : "value-missing",
+  };
 };
 
 const queryRegistryWithRegExe = async (
@@ -166,16 +433,39 @@ const queryRegistryWithRegExe = async (
       { windowsHide: true, timeout: 5000 },
       (error, stdout, stderr) => {
         if (!error) {
+          const parsed = parseRegQueryValue(toOutputString(stdout), key);
           resolve({
             ok: true,
-            value: parseRegQueryValue(toOutputString(stdout), key),
+            value: parsed.value,
+            state: parsed.found ? parsed.state : "value-missing",
           });
           return;
         }
 
         const execError = error as ExecFileError;
         if (execError.code === 1 || execError.code === "1") {
-          resolve({ ok: true, value: null });
+          execFile(
+            "reg.exe",
+            ["query", queryPath],
+            { windowsHide: true, timeout: 5000 },
+            (pathError) => {
+              if (!pathError) {
+                resolve({ ok: true, value: null, state: "value-missing" });
+                return;
+              }
+
+              const pathExecError = pathError as ExecFileError;
+              if (pathExecError.code === 1 || pathExecError.code === "1") {
+                resolve({ ok: true, value: null, state: "key-missing" });
+                return;
+              }
+
+              resolve({
+                ok: false,
+                error: formatError(pathExecError),
+              });
+            },
+          );
           return;
         }
 
@@ -197,10 +487,24 @@ const readRegistryValueDetailed = async (
 ): Promise<RegistryReadResult> => {
   const finalPath = standardizeRegPath(regPath);
   const psCommand = `
-      if (Test-Path "${finalPath}") {
-        $prop = Get-ItemProperty -Path "${finalPath}" -Name "${key}" -ErrorAction SilentlyContinue
-        if ($prop) {
-            $prop."${key}"
+      $path = "${finalPath}"
+      $name = "${key}"
+      if (-not (Test-Path -LiteralPath $path)) {
+        Write-Output "__REG_KEY_MISSING__"
+      } else {
+        $item = Get-Item -LiteralPath $path -ErrorAction Stop
+        if ($item.GetValueNames() -notcontains $name) {
+          Write-Output "__REG_VALUE_MISSING__"
+        } else {
+          $value = $item.GetValue($name, $null)
+          if ($null -eq $value) {
+            Write-Output "__REG_VALUE_MISSING__"
+          } elseif ([string]::IsNullOrWhiteSpace([string]$value)) {
+            Write-Output "__REG_VALUE_EMPTY__"
+          } else {
+            Write-Output "__REG_VALUE_FOUND__"
+            Write-Output $value
+          }
         }
       }
     `.trim();
@@ -209,8 +513,7 @@ const readRegistryValueDetailed = async (
     const { stdout, stderr, code } = await runPowerShell(psCommand);
 
     if (code === 0) {
-      const value = stdout.trim();
-      return { ok: true, value: value || null };
+      return parsePowerShellRegistryOutput(stdout);
     }
 
     const fallback = await queryRegistryWithRegExe(regPath, key);
@@ -253,14 +556,18 @@ export const writeRegistryValue = async (
 ): Promise<boolean> => {
   try {
     const finalPath = standardizeRegPath(regPath);
-    // Escape single quotes in value for PowerShell single-quoted string
-    const safeValue = value.replace(/'/g, "''");
+    const safePath = escapePowerShellSingleQuotedString(finalPath);
+    const safeKey = escapePowerShellSingleQuotedString(key);
+    const safeValue = escapePowerShellSingleQuotedString(value);
 
     const psCommand = `
-      if (-not (Test-Path "${finalPath}")) {
-        New-Item -Path "${finalPath}" -Force | Out-Null
+      $path = '${safePath}'
+      $name = '${safeKey}'
+      $value = '${safeValue}'
+      if (-not (Test-Path -Path $path)) {
+        New-Item -Path $path -Force | Out-Null
       }
-      Set-ItemProperty -Path "${finalPath}" -Name "${key}" -Value '${safeValue}' -Type String -Force
+      New-ItemProperty -Path $path -Name $name -Value $value -PropertyType String -Force | Out-Null
     `.trim();
 
     const { code } = await runPowerShell(psCommand, useAdmin);
@@ -270,18 +577,455 @@ export const writeRegistryValue = async (
   }
 };
 
+const getGameExecutablePath = (installPath: string) =>
+  path.join(installPath, GAME_EXECUTABLE_NAME);
+
+const verifyGameInstallPath = async (
+  installPath: string,
+): Promise<{
+  status: InstallPathVerificationStatus;
+  executablePath: string;
+  error?: string;
+}> => {
+  const executablePath = getGameExecutablePath(installPath);
+
+  try {
+    const stats = await fs.stat(executablePath);
+
+    return stats.isFile()
+      ? { status: "valid", executablePath }
+      : { status: "missing", executablePath };
+  } catch (error) {
+    if (isMissingPathError(error)) {
+      return { status: "missing", executablePath };
+    }
+
+    return { status: "unknown", executablePath, error: formatError(error) };
+  }
+};
+
+const readRegistryInstallPath = async (
+  serviceId: AppConfig["serviceChannel"],
+  gameId: AppConfig["activeGame"],
+): Promise<RegistryReadResult> => {
+  const registryInfo = GAME_INSTALL_REGISTRY_MAP[serviceId]?.[gameId];
+  if (!registryInfo) {
+    return {
+      ok: false,
+      error: `Unsupported game context: ${serviceId}/${gameId}`,
+    };
+  }
+
+  const registryResult = await readRegistryValueDetailed(
+    registryInfo.path,
+    registryInfo.key,
+  );
+
+  if (!registryResult.ok) return registryResult;
+
+  return {
+    ok: true,
+    value: registryResult.value ? normalizePath(registryResult.value) : null,
+    state: registryResult.state,
+  };
+};
+
+const writeRegistryInstallPath = async (
+  serviceId: AppConfig["serviceChannel"],
+  gameId: AppConfig["activeGame"],
+  installPath: string,
+): Promise<boolean> => {
+  const registryInfo = GAME_INSTALL_REGISTRY_MAP[serviceId]?.[gameId];
+  if (!registryInfo) return false;
+
+  return writeRegistryValue(registryInfo.path, registryInfo.key, installPath);
+};
+
+const getRegistryInstallPathLabel = (
+  serviceId: AppConfig["serviceChannel"],
+  gameId: AppConfig["activeGame"],
+) => {
+  const registryInfo = GAME_INSTALL_REGISTRY_MAP[serviceId]?.[gameId];
+
+  return registryInfo
+    ? `${registryInfo.path} / ${registryInfo.key}`
+    : `${serviceId}/${gameId}`;
+};
+
+const formatDiagnostics = (diagnostics: string[]) => {
+  return diagnostics.length > 0 ? diagnostics.join("; ") : "no details";
+};
+
+const formatPathCheckFailure = (
+  source: "config" | "registry",
+  installPath: string,
+  status: InstallPathVerificationStatus,
+  error?: string,
+) => {
+  const executablePath = getGameExecutablePath(installPath);
+
+  if (status === "missing") {
+    return `${source}=path-invalid (${GAME_EXECUTABLE_NAME} missing at ${executablePath})`;
+  }
+
+  return `${source}=path-check-blocked (${executablePath}: ${error || "unknown error"})`;
+};
+
+const logInstallPathResolutionFailure = (
+  serviceId: AppConfig["serviceChannel"],
+  gameId: AppConfig["activeGame"],
+  resolution: InstallPathResolution,
+) => {
+  const message = `[Registry] Install path unresolved for ${gameId} (${serviceId}): ${formatDiagnostics(resolution.diagnostics)}`;
+
+  if (resolution.error || resolution.verifyError) {
+    logger.warn(
+      `${message}${resolution.error ? `; error=${resolution.error}` : ""}${resolution.verifyError ? `; verifyError=${resolution.verifyError}` : ""}`,
+    );
+    return;
+  }
+
+  logger.log(message);
+};
+
+const resolveGameInstallPath = async (
+  serviceId: AppConfig["serviceChannel"],
+  gameId: AppConfig["activeGame"],
+): Promise<InstallPathResolution> => {
+  const diagnostics: string[] = [];
+  const configuredPath = getConfiguredGameInstallPath(serviceId, gameId);
+  let configuredVerifyError: string | undefined;
+
+  if (configuredPath.path !== null) {
+    const configuredInstallPath = configuredPath.path;
+    const configuredStatus = await verifyGameInstallPath(configuredInstallPath);
+
+    if (configuredStatus.status === "valid") {
+      return { path: configuredInstallPath, source: "config", diagnostics };
+    }
+
+    configuredVerifyError = configuredStatus.error;
+    diagnostics.push(
+      formatPathCheckFailure(
+        "config",
+        configuredInstallPath,
+        configuredStatus.status,
+        configuredStatus.error,
+      ),
+    );
+  } else if (configuredPath.state === "context-unavailable") {
+    diagnostics.push("config=context-unavailable");
+  } else {
+    diagnostics.push("config=empty");
+  }
+
+  const registryResult = await readRegistryInstallPath(serviceId, gameId);
+  const registryLabel = getRegistryInstallPathLabel(serviceId, gameId);
+
+  if (!registryResult.ok) {
+    diagnostics.push(`registry=read-failed (${registryLabel})`);
+    return { path: null, error: registryResult.error, diagnostics };
+  }
+
+  if (!registryResult.value) {
+    diagnostics.push(`registry=${registryResult.state} (${registryLabel})`);
+    return { path: null, verifyError: configuredVerifyError, diagnostics };
+  }
+
+  const registryStatus = await verifyGameInstallPath(registryResult.value);
+
+  if (registryStatus.status === "valid") {
+    if (configuredPath.state === "empty") {
+      await persistDiscoveredGameInstallPath(
+        serviceId,
+        gameId,
+        registryResult.value,
+      );
+    }
+
+    return { path: registryResult.value, source: "registry", diagnostics };
+  }
+
+  diagnostics.push(
+    formatPathCheckFailure(
+      "registry",
+      registryResult.value,
+      registryStatus.status,
+      registryStatus.error,
+    ),
+  );
+
+  return {
+    path: null,
+    verifyError: registryStatus.error ?? configuredVerifyError,
+    diagnostics,
+  };
+};
+
+const areSameInstallPath = (left: string | null, right: string | null) => {
+  if (!left || !right) return false;
+  return (
+    normalizePath(left).toLowerCase() === normalizePath(right).toLowerCase()
+  );
+};
+
+const getRecommendedInstallPathSource = (
+  configDiagnostic: GameInstallPathConfigDiagnostic,
+  registryDiagnostic: GameInstallPathRegistryDiagnostic,
+): "config" | "registry" | null => {
+  if (
+    configDiagnostic.verification === "valid" &&
+    registryDiagnostic.verification !== "valid"
+  ) {
+    return "config";
+  }
+
+  if (
+    registryDiagnostic.verification === "valid" &&
+    configDiagnostic.verification !== "valid"
+  ) {
+    return "registry";
+  }
+
+  return null;
+};
+
 /**
- * Identify the installation path of the game from Windows Registry
+ * Reads and verifies both saved config and registry paths without updating config.
+ */
+export const getGameInstallPathDiagnostics = async (
+  serviceId: AppConfig["serviceChannel"],
+  gameId: AppConfig["activeGame"],
+): Promise<GameInstallPathDiagnostics> => {
+  const configuredPath = getConfiguredGameInstallPath(serviceId, gameId);
+  const configDiagnostic: GameInstallPathConfigDiagnostic = {
+    source: "config",
+    path: configuredPath.path,
+    state: configuredPath.state,
+    verification: "not-checked",
+  };
+
+  if (configuredPath.path) {
+    const verification = await verifyGameInstallPath(configuredPath.path);
+    configDiagnostic.verification = verification.status;
+    configDiagnostic.executablePath = verification.executablePath;
+    configDiagnostic.error = verification.error;
+  }
+
+  const registryInfo = GAME_INSTALL_REGISTRY_MAP[serviceId][gameId];
+  const registryResult = await readRegistryInstallPath(serviceId, gameId);
+  const registryDiagnostic: GameInstallPathRegistryDiagnostic = {
+    source: "registry",
+    path: registryResult.ok ? registryResult.value : null,
+    state: registryResult.ok ? registryResult.state : "read-failed",
+    verification: "not-checked",
+    error: registryResult.ok ? undefined : registryResult.error,
+    registryPath: registryInfo.path,
+    registryValueName: registryInfo.key,
+  };
+
+  if (registryResult.ok && registryResult.value) {
+    const verification = await verifyGameInstallPath(registryResult.value);
+    registryDiagnostic.verification = verification.status;
+    registryDiagnostic.executablePath = verification.executablePath;
+    registryDiagnostic.error = verification.error;
+  }
+
+  const hasPathConflict =
+    Boolean(configDiagnostic.path && registryDiagnostic.path) &&
+    !areSameInstallPath(configDiagnostic.path, registryDiagnostic.path);
+
+  return {
+    serviceId,
+    gameId,
+    executableName: GAME_EXECUTABLE_NAME,
+    config: configDiagnostic,
+    registry: registryDiagnostic,
+    hasPathConflict,
+    isPathConflictAcknowledged:
+      hasPathConflict &&
+      isGameInstallPathConflictAcknowledged(
+        serviceId,
+        gameId,
+        configDiagnostic.path,
+        registryDiagnostic.path,
+      ),
+    recommendedSource: getRecommendedInstallPathSource(
+      configDiagnostic,
+      registryDiagnostic,
+    ),
+  };
+};
+
+export const setGameInstallPath = async (
+  serviceId: AppConfig["serviceChannel"],
+  gameId: AppConfig["activeGame"],
+  installPath: string,
+): Promise<GameInstallPathSaveResult> => {
+  const normalizedInstallPath = normalizePath(installPath);
+
+  if (!normalizedInstallPath) {
+    return {
+      ok: false,
+      verification: "not-checked",
+      error: "Install path is empty.",
+    };
+  }
+
+  const verification = await verifyGameInstallPath(normalizedInstallPath);
+  if (verification.status !== "valid") {
+    return {
+      ok: false,
+      path: normalizedInstallPath,
+      verification: verification.status,
+      error:
+        verification.error ||
+        `${GAME_EXECUTABLE_NAME} was not found in the selected folder.`,
+      diagnostics: await getGameInstallPathDiagnostics(serviceId, gameId),
+    };
+  }
+
+  const persisted = await persistDiscoveredGameInstallPath(
+    serviceId,
+    gameId,
+    normalizedInstallPath,
+  );
+
+  if (!persisted) {
+    return {
+      ok: false,
+      path: normalizedInstallPath,
+      verification: verification.status,
+      error: "App context is not available.",
+      diagnostics: await getGameInstallPathDiagnostics(serviceId, gameId),
+    };
+  }
+
+  return {
+    ok: true,
+    path: normalizedInstallPath,
+    diagnostics: await getGameInstallPathDiagnostics(serviceId, gameId),
+  };
+};
+
+export const resolveGameInstallPathConflict = async (
+  serviceId: AppConfig["serviceChannel"],
+  gameId: AppConfig["activeGame"],
+  action: GameInstallPathConflictAction,
+): Promise<GameInstallPathConflictResolveResult> => {
+  const diagnostics = await getGameInstallPathDiagnostics(serviceId, gameId);
+  const configPath = diagnostics.config.path;
+  const registryPath = diagnostics.registry.path;
+
+  if (!configPath) {
+    return {
+      ok: false,
+      action,
+      verification: "not-checked",
+      error: "Launcher config path is empty.",
+      diagnostics,
+    };
+  }
+
+  const verification = await verifyGameInstallPath(configPath);
+  if (verification.status !== "valid") {
+    return {
+      ok: false,
+      action,
+      path: configPath,
+      verification: verification.status,
+      error:
+        verification.error ||
+        `${GAME_EXECUTABLE_NAME} was not found in the launcher config path.`,
+      diagnostics,
+    };
+  }
+
+  if (action === "launcher-config-only") {
+    if (!registryPath) {
+      return {
+        ok: false,
+        action,
+        path: configPath,
+        verification: verification.status,
+        error: "Registry path is empty.",
+        diagnostics,
+      };
+    }
+
+    const persisted = await persistGameInstallPathConflictResolution(
+      serviceId,
+      gameId,
+      {
+        configPath,
+        registryPath,
+        resolvedAt: Date.now(),
+      },
+    );
+
+    if (!persisted) {
+      return {
+        ok: false,
+        action,
+        path: configPath,
+        verification: verification.status,
+        error: "App context is not available.",
+        diagnostics,
+      };
+    }
+
+    logger.log(
+      `[Registry] User kept launcher install path for ${gameId} (${serviceId}); registry path remains unchanged.`,
+    );
+
+    return {
+      ok: true,
+      action,
+      path: configPath,
+      diagnostics: await getGameInstallPathDiagnostics(serviceId, gameId),
+    };
+  }
+
+  const written = await writeRegistryInstallPath(serviceId, gameId, configPath);
+  if (!written) {
+    return {
+      ok: false,
+      action,
+      path: configPath,
+      verification: verification.status,
+      error: "Failed to update registry install path.",
+      diagnostics,
+    };
+  }
+
+  await persistGameInstallPathConflictResolution(serviceId, gameId, null);
+
+  logger.log(
+    `[Registry] Updated registry install path for ${gameId} (${serviceId}) from launcher config path.`,
+  );
+
+  return {
+    ok: true,
+    action,
+    path: configPath,
+    diagnostics: await getGameInstallPathDiagnostics(serviceId, gameId),
+  };
+};
+
+/**
+ * Identify the installation path of the game from saved config, then Registry.
  */
 export const getGameInstallPath = async (
   serviceId: AppConfig["serviceChannel"],
   gameId: AppConfig["activeGame"],
 ): Promise<string | null> => {
-  const registryInfo = REGISTRY_MAP[serviceId]?.[gameId];
-  if (!registryInfo) return null;
+  const resolution = await resolveGameInstallPath(serviceId, gameId);
 
-  const rawPath = await readRegistryValue(registryInfo.path, registryInfo.key);
-  return rawPath ? normalizePath(rawPath) : null;
+  if (!resolution.path) {
+    logInstallPathResolutionFailure(serviceId, gameId, resolution);
+  }
+
+  return resolution.path;
 };
 
 /**
@@ -340,44 +1084,28 @@ export const setDaumGameStarterCommand = async (
 };
 
 /**
- * Checks if the game is actually installed by verifying registry path and folder presence
+ * Checks if the game is installed by verifying PathOfExile.exe in the resolved folder.
  */
 export const getGameInstallationStatus = async (
   serviceId: AppConfig["serviceChannel"],
   gameId: AppConfig["activeGame"],
 ): Promise<GameInstallationStatus> => {
-  const registryInfo = REGISTRY_MAP[serviceId]?.[gameId];
-  if (!registryInfo) return "unknown";
+  const resolution = await resolveGameInstallPath(serviceId, gameId);
 
-  const registryResult = await readRegistryValueDetailed(
-    registryInfo.path,
-    registryInfo.key,
-  );
+  if (resolution.path) return "installed";
 
-  if (!registryResult.ok) {
-    logger.warn(
-      `[Registry] Could not determine installation status for ${gameId} (${serviceId}): ${registryResult.error}`,
-    );
+  if (resolution.error) {
+    logInstallPathResolutionFailure(serviceId, gameId, resolution);
     return "unknown";
   }
 
-  if (!registryResult.value) return "uninstalled";
-
-  const installPath = normalizePath(registryResult.value);
-  if (!installPath) return "uninstalled";
-
-  try {
-    // Check if directory exists
-    const stats = await fs.stat(installPath);
-    return stats.isDirectory() ? "installed" : "uninstalled";
-  } catch (error) {
-    if (isMissingPathError(error)) return "uninstalled";
-
-    logger.warn(
-      `[Registry] Could not verify installation path for ${gameId} (${serviceId}): ${formatError(error)}`,
-    );
+  if (resolution.verifyError) {
+    logInstallPathResolutionFailure(serviceId, gameId, resolution);
     return "unknown";
   }
+
+  logInstallPathResolutionFailure(serviceId, gameId, resolution);
+  return "uninstalled";
 };
 
 export const isGameInstalled = async (

--- a/src/renderer/App.css
+++ b/src/renderer/App.css
@@ -367,6 +367,27 @@ img {
   width: 100%;
 }
 
+.active-status-message.with-action {
+  gap: 8px;
+}
+
+.status-manual-path-button {
+  height: 18px;
+  padding: 0 7px;
+  border: 1px solid rgba(223, 207, 153, 0.36);
+  border-radius: 4px;
+  background: rgba(223, 207, 153, 0.1);
+  color: var(--theme-accent, #dfcf99);
+  font-size: 11px;
+  font-weight: 700;
+  line-height: 16px;
+  cursor: pointer;
+}
+
+.status-manual-path-button:hover {
+  background: rgba(223, 207, 153, 0.18);
+}
+
 .company-logos {
   display: flex;
   justify-content: center;

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -2030,6 +2030,9 @@ function App() {
                   onPatchReservationRequest={() =>
                     setIsPatchReservationOpen(true)
                   }
+                  onFontManagerSettingsRequest={() =>
+                    openSettingsWithFocus("openFontManagerBtn")
+                  }
                 />
               </div>
 

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -20,6 +20,7 @@ import {
   ThemeDefinition,
   KakaoMaintenanceInfo,
   KakaoGameStarterMigrationRequest,
+  GameInstallPathDiagnostics,
 } from "../shared/types";
 import { DOWNLOAD_URLS, SUPPORT_URLS } from "../shared/urls";
 
@@ -32,6 +33,7 @@ import GameSelector from "./components/GameSelector";
 import GameStartButton from "./components/GameStartButton";
 import ChangelogModal from "./components/modals/ChangelogModal";
 import FontCatalogModal from "./components/modals/FontCatalogModal";
+import GamePathDiagnosticModal from "./components/modals/GamePathDiagnosticModal";
 import FontManagerModal from "./components/modals/FontManagerModal";
 import FontMigrationModal from "./components/modals/FontMigrationModal";
 import { ForcedRepairModal } from "./components/modals/ForcedRepairModal";
@@ -68,6 +70,22 @@ type KakaoMaintenanceModalInfo = KakaoMaintenanceInfo & {
   gameId: AppConfig["activeGame"];
   serviceId: "Kakao Games";
 };
+
+type GamePathModalMode = "conflict" | "missing" | "diagnostic";
+
+type GamePathModalState = {
+  mode: GamePathModalMode;
+  gameId: AppConfig["activeGame"];
+  serviceId: AppConfig["serviceChannel"];
+  diagnostics: GameInstallPathDiagnostics | null;
+  busy: boolean;
+  errorMessage?: string;
+  highlightManual?: boolean;
+  showRegistrySyncConfirm?: boolean;
+  manualSaveToastId?: number;
+};
+
+type GamePathSource = "config" | "registry";
 
 // Status Message Mapping (Configuration)
 const STATUS_MESSAGES: Record<RunStatus, StatusMessageConfig> = {
@@ -119,6 +137,25 @@ const formatNewsRefreshTime = (lastUpdatedAt: number | null) => {
   });
 
   return `마지막 확인: ${time}`;
+};
+
+const formatUnknownError = (error: unknown) => {
+  return error instanceof Error ? error.message : String(error);
+};
+
+const getGamePathSaveErrorMessage = (
+  verification: string,
+  fallback?: string,
+) => {
+  if (verification === "missing") {
+    return "선택한 폴더에서 PathOfExile.exe를 찾을 수 없습니다.";
+  }
+
+  if (verification === "unknown") {
+    return "선택한 폴더의 실행 파일을 확인할 수 없습니다.";
+  }
+
+  return fallback || "게임 경로를 저장하지 못했습니다.";
 };
 
 const NEWS_OPEN_MODE_OPTIONS: Array<{
@@ -210,6 +247,9 @@ function App() {
   const [settingsFocusId, setSettingsFocusId] = useState<string | undefined>(
     undefined,
   );
+  const [gamePathModalState, setGamePathModalState] =
+    useState<GamePathModalState | null>(null);
+  const shownGamePathConflictKeysRef = useRef<Set<string>>(new Set());
 
   const [bgImage, setBgImage] = useState(bgPoe);
   const [bgOpacity, setBgOpacity] = useState(1);
@@ -252,6 +292,57 @@ function App() {
     syncGameState(config.activeGame, "Kakao Games");
     syncGameState(config.activeGame, "GGG");
   }, [config.activeGame, isFontMigrationOpen, syncGameState]);
+
+  useEffect(() => {
+    if (!isConfigLoaded || !window.electronAPI || gamePathModalState) return;
+
+    const serviceId = config.serviceChannel;
+    const gameId = config.activeGame;
+    const contextKey = `${serviceId}:${gameId}`;
+    if (shownGamePathConflictKeysRef.current.has(contextKey)) return;
+
+    let canceled = false;
+    window.electronAPI
+      .getGameInstallPathDiagnostics(serviceId, gameId)
+      .then((diagnostics) => {
+        if (canceled) return;
+
+        const hasUsablePath =
+          diagnostics.config.verification === "valid" ||
+          diagnostics.registry.verification === "valid";
+        if (
+          !diagnostics.hasPathConflict ||
+          diagnostics.isPathConflictAcknowledged ||
+          !hasUsablePath
+        ) {
+          return;
+        }
+
+        shownGamePathConflictKeysRef.current.add(contextKey);
+        setGamePathModalState({
+          mode: "conflict",
+          serviceId,
+          gameId,
+          diagnostics,
+          busy: false,
+        });
+      })
+      .catch((error) => {
+        logger.warn(
+          `[App] Failed to check game path conflict: ${formatUnknownError(error)}`,
+        );
+      });
+
+    return () => {
+      canceled = true;
+    };
+  }, [
+    isConfigLoaded,
+    config.activeGame,
+    config.serviceChannel,
+    config.gameInstallPaths,
+    gamePathModalState,
+  ]);
 
   // Active Status Message State
   const [activeMessage, setActiveMessage] = useState<string>("");
@@ -781,6 +872,26 @@ function App() {
     activeMessage,
   ]);
 
+  const shouldShowGamePathManualPrompt = useMemo(() => {
+    if (
+      activeGameStatus.gameId !== config.activeGame ||
+      activeGameStatus.serviceId !== config.serviceChannel
+    ) {
+      return false;
+    }
+
+    return (
+      activeGameStatus.status === "uninstalled" ||
+      activeGameStatus.status === "install_check_blocked"
+    );
+  }, [
+    activeGameStatus.gameId,
+    activeGameStatus.serviceId,
+    activeGameStatus.status,
+    config.activeGame,
+    config.serviceChannel,
+  ]);
+
   // Compute Button Disabled State
   const isButtonDisabled = useMemo(() => {
     // Context mismatch check
@@ -798,7 +909,7 @@ function App() {
     // ACTIVE: "Install" button should be ENABLED (not disabled)
     // allowing user to click and go to download page.
     if (s === "uninstalled") return false;
-    if (s === "install_check_blocked") return true;
+    if (s === "install_check_blocked") return false;
 
     // Running states -> Disabled
     if (
@@ -1028,6 +1139,403 @@ function App() {
     window.electronAPI?.setConfig(CONFIG_KEYS.SERVICE_CHANNEL, channel);
   };
 
+  const openDownloadPage = useCallback(
+    (
+      serviceId: AppConfig["serviceChannel"],
+      gameId: AppConfig["activeGame"],
+    ) => {
+      const downloadUrl = DOWNLOAD_URLS[serviceId][gameId];
+      if (downloadUrl) {
+        window.open(downloadUrl, "_blank");
+        return;
+      }
+
+      logger.error(`[App] No download URL found for ${gameId} / ${serviceId}`);
+    },
+    [],
+  );
+
+  const openGamePathModal = useCallback(
+    async (
+      mode: GamePathModalMode,
+      serviceId: AppConfig["serviceChannel"],
+      gameId: AppConfig["activeGame"],
+      options?: { highlightManual?: boolean },
+    ) => {
+      if (!window.electronAPI) {
+        logger.warn("Electron API not available");
+        return;
+      }
+
+      setGamePathModalState({
+        mode,
+        serviceId,
+        gameId,
+        diagnostics: null,
+        busy: true,
+        highlightManual: options?.highlightManual ?? false,
+        showRegistrySyncConfirm: false,
+      });
+
+      try {
+        const diagnostics =
+          await window.electronAPI.getGameInstallPathDiagnostics(
+            serviceId,
+            gameId,
+          );
+
+        setGamePathModalState((current) => {
+          if (
+            !current ||
+            current.mode !== mode ||
+            current.serviceId !== serviceId ||
+            current.gameId !== gameId
+          ) {
+            return current;
+          }
+
+          return {
+            ...current,
+            diagnostics,
+            busy: false,
+            errorMessage: undefined,
+          };
+        });
+      } catch (error) {
+        setGamePathModalState((current) => {
+          if (!current) return current;
+
+          return {
+            ...current,
+            busy: false,
+            errorMessage: `게임 경로를 확인하지 못했습니다. ${formatUnknownError(error)}`,
+          };
+        });
+      }
+    },
+    [],
+  );
+
+  const handleGamePathContextChange = useCallback(
+    async (
+      serviceId: AppConfig["serviceChannel"],
+      gameId: AppConfig["activeGame"],
+    ) => {
+      if (!window.electronAPI || !gamePathModalState) {
+        return;
+      }
+
+      if (
+        gamePathModalState.serviceId === serviceId &&
+        gamePathModalState.gameId === gameId
+      ) {
+        return;
+      }
+
+      setGamePathModalState((current) =>
+        current
+          ? {
+              ...current,
+              mode: "diagnostic",
+              serviceId,
+              gameId,
+              diagnostics: null,
+              busy: true,
+              errorMessage: undefined,
+              highlightManual: false,
+              showRegistrySyncConfirm: false,
+            }
+          : current,
+      );
+
+      try {
+        const diagnostics =
+          await window.electronAPI.getGameInstallPathDiagnostics(
+            serviceId,
+            gameId,
+          );
+
+        setGamePathModalState((current) => {
+          if (
+            !current ||
+            current.serviceId !== serviceId ||
+            current.gameId !== gameId
+          ) {
+            return current;
+          }
+
+          return {
+            ...current,
+            diagnostics,
+            busy: false,
+          };
+        });
+      } catch (error) {
+        setGamePathModalState((current) => {
+          if (
+            !current ||
+            current.serviceId !== serviceId ||
+            current.gameId !== gameId
+          ) {
+            return current;
+          }
+
+          return {
+            ...current,
+            busy: false,
+            errorMessage: `게임 경로를 확인하지 못했습니다. ${formatUnknownError(error)}`,
+          };
+        });
+      }
+    },
+    [gamePathModalState],
+  );
+
+  const handleGamePathModalClose = useCallback(() => {
+    setGamePathModalState(null);
+  }, []);
+
+  const handleUseGamePath = useCallback(
+    async (source: GamePathSource) => {
+      if (!window.electronAPI || !gamePathModalState?.diagnostics) return;
+
+      const { serviceId, gameId, diagnostics } = gamePathModalState;
+      const installPath = diagnostics[source].path;
+      if (!installPath) {
+        setGamePathModalState((current) =>
+          current
+            ? {
+                ...current,
+                errorMessage: "저장할 경로가 없습니다.",
+              }
+            : current,
+        );
+        return;
+      }
+
+      if (
+        source === "config" &&
+        diagnostics.hasPathConflict &&
+        diagnostics.registry.path
+      ) {
+        setGamePathModalState((current) =>
+          current
+            ? {
+                ...current,
+                showRegistrySyncConfirm: true,
+                errorMessage: undefined,
+              }
+            : current,
+        );
+        return;
+      }
+
+      setGamePathModalState((current) =>
+        current ? { ...current, busy: true, errorMessage: undefined } : current,
+      );
+
+      try {
+        const result = await window.electronAPI.setGameInstallPath(
+          serviceId,
+          gameId,
+          installPath,
+        );
+
+        if (result.ok) {
+          setGamePathModalState(null);
+          void syncGameState(gameId, serviceId);
+          return;
+        }
+
+        setGamePathModalState((current) =>
+          current
+            ? {
+                ...current,
+                diagnostics: result.diagnostics || current.diagnostics,
+                busy: false,
+                errorMessage: getGamePathSaveErrorMessage(
+                  result.verification,
+                  result.error,
+                ),
+              }
+            : current,
+        );
+      } catch (error) {
+        setGamePathModalState((current) =>
+          current
+            ? {
+                ...current,
+                busy: false,
+                errorMessage: `게임 경로를 저장하지 못했습니다. ${formatUnknownError(error)}`,
+              }
+            : current,
+        );
+      }
+    },
+    [gamePathModalState, syncGameState],
+  );
+
+  const handleManualGamePathSelect = useCallback(async () => {
+    if (!window.electronAPI || !gamePathModalState) return;
+
+    const { serviceId, gameId } = gamePathModalState;
+    setGamePathModalState((current) =>
+      current ? { ...current, busy: true, errorMessage: undefined } : current,
+    );
+
+    try {
+      const result = await window.electronAPI.pickGameInstallPath(
+        serviceId,
+        gameId,
+      );
+
+      if (result.ok) {
+        setGamePathModalState((current) =>
+          current
+            ? {
+                ...current,
+                mode: "diagnostic",
+                diagnostics: result.diagnostics,
+                busy: false,
+                errorMessage: undefined,
+                highlightManual: false,
+                showRegistrySyncConfirm: false,
+                manualSaveToastId: Date.now(),
+              }
+            : current,
+        );
+
+        void syncGameState(gameId, serviceId);
+        return;
+      }
+
+      setGamePathModalState((current) =>
+        current
+          ? {
+              ...current,
+              diagnostics: result.diagnostics || current.diagnostics,
+              busy: false,
+              errorMessage: result.canceled
+                ? undefined
+                : getGamePathSaveErrorMessage(
+                    result.verification,
+                    result.error,
+                  ),
+            }
+          : current,
+      );
+    } catch (error) {
+      setGamePathModalState((current) =>
+        current
+          ? {
+              ...current,
+              busy: false,
+              errorMessage: `수동 경로를 저장하지 못했습니다. ${formatUnknownError(error)}`,
+            }
+          : current,
+      );
+    }
+  }, [gamePathModalState, syncGameState]);
+
+  const handleGamePathConflictConfirmClose = useCallback(() => {
+    setGamePathModalState((current) =>
+      current ? { ...current, showRegistrySyncConfirm: false } : current,
+    );
+  }, []);
+
+  const handleResolveGamePathConflict = useCallback(
+    async (action: "launcher-config-only" | "sync-registry") => {
+      if (!window.electronAPI || !gamePathModalState) return;
+
+      const { serviceId, gameId } = gamePathModalState;
+      setGamePathModalState((current) =>
+        current
+          ? {
+              ...current,
+              busy: true,
+              errorMessage: undefined,
+              showRegistrySyncConfirm: false,
+            }
+          : current,
+      );
+
+      try {
+        const result = await window.electronAPI.resolveGameInstallPathConflict(
+          serviceId,
+          gameId,
+          action,
+        );
+
+        if (result.ok) {
+          setGamePathModalState(null);
+          void syncGameState(gameId, serviceId);
+          return;
+        }
+
+        setGamePathModalState((current) =>
+          current
+            ? {
+                ...current,
+                diagnostics: result.diagnostics || current.diagnostics,
+                busy: false,
+                errorMessage:
+                  result.verification === "valid" &&
+                  result.action === "sync-registry"
+                    ? "레지스트리 설치 경로를 업데이트하지 못했습니다."
+                    : result.verification === "valid" &&
+                        result.action === "launcher-config-only"
+                      ? "경로 충돌 확인 상태를 저장하지 못했습니다."
+                      : getGamePathSaveErrorMessage(
+                          result.verification,
+                          result.error,
+                        ),
+              }
+            : current,
+        );
+      } catch (error) {
+        setGamePathModalState((current) =>
+          current
+            ? {
+                ...current,
+                busy: false,
+                errorMessage: `게임 경로 충돌을 처리하지 못했습니다. ${formatUnknownError(error)}`,
+              }
+            : current,
+        );
+      }
+    },
+    [gamePathModalState, syncGameState],
+  );
+
+  const handleGamePathInstall = useCallback(() => {
+    if (!gamePathModalState) return;
+
+    openDownloadPage(gamePathModalState.serviceId, gamePathModalState.gameId);
+    setGamePathModalState(null);
+  }, [gamePathModalState, openDownloadPage]);
+
+  useEffect(() => {
+    const handleOpenGamePathModal = () => {
+      void openGamePathModal(
+        "diagnostic",
+        config.serviceChannel,
+        config.activeGame,
+      );
+    };
+
+    window.addEventListener(
+      "open-game-path-diagnostic-modal",
+      handleOpenGamePathModal,
+    );
+
+    return () => {
+      window.removeEventListener(
+        "open-game-path-diagnostic-modal",
+        handleOpenGamePathModal,
+      );
+    };
+  }, [config.activeGame, config.serviceChannel, openGamePathModal]);
+
   const handleGameStart = () => {
     if (!window.electronAPI) {
       logger.warn("Electron API not available");
@@ -1035,21 +1543,20 @@ function App() {
     }
 
     if (activeGameStatus.status === "uninstalled") {
-      // Open Download Page using centralized URL constants
-      const downloadUrl =
-        DOWNLOAD_URLS[config.serviceChannel][config.activeGame];
-      if (downloadUrl) {
-        window.open(downloadUrl, "_blank");
-      } else {
-        logger.error(
-          `[App] No download URL found for ${config.activeGame} / ${config.serviceChannel}`,
-        );
-      }
+      void openGamePathModal(
+        "missing",
+        config.serviceChannel,
+        config.activeGame,
+      );
       return;
     }
 
     if (activeGameStatus.status === "install_check_blocked") {
-      logger.warn("[App] Game start blocked because install check failed.");
+      void openGamePathModal(
+        "missing",
+        config.serviceChannel,
+        config.activeGame,
+      );
       return;
     }
 
@@ -1309,6 +1816,37 @@ function App() {
         onClose={handleUpdateDismiss}
       />
 
+      <GamePathDiagnosticModal
+        isOpen={gamePathModalState !== null}
+        mode={gamePathModalState?.mode ?? "missing"}
+        serviceId={gamePathModalState?.serviceId ?? config.serviceChannel}
+        gameId={gamePathModalState?.gameId ?? config.activeGame}
+        diagnostics={gamePathModalState?.diagnostics ?? null}
+        busy={gamePathModalState?.busy ?? false}
+        errorMessage={gamePathModalState?.errorMessage}
+        highlightManual={gamePathModalState?.highlightManual ?? false}
+        showRegistrySyncConfirm={
+          gamePathModalState?.showRegistrySyncConfirm ?? false
+        }
+        manualSaveToastId={gamePathModalState?.manualSaveToastId}
+        onClose={handleGamePathModalClose}
+        onContextChange={handleGamePathContextChange}
+        onUsePath={handleUseGamePath}
+        onManualSelect={handleManualGamePathSelect}
+        onRegistrySyncConfirmClose={handleGamePathConflictConfirmClose}
+        onKeepLauncherConfig={() =>
+          void handleResolveGamePathConflict("launcher-config-only")
+        }
+        onSyncRegistry={() =>
+          void handleResolveGamePathConflict("sync-registry")
+        }
+        onInstall={
+          gamePathModalState?.mode === "missing"
+            ? handleGamePathInstall
+            : undefined
+        }
+      />
+
       <SettingsModal
         isOpen={isSettingsOpen}
         onClose={closeSettings}
@@ -1529,6 +2067,11 @@ function App() {
 
                 {/* Progress Info Message */}
                 <div
+                  className={
+                    shouldShowGamePathManualPrompt
+                      ? "active-status-message with-action"
+                      : "active-status-message"
+                  }
                   style={{
                     height: "20px",
                     marginTop: "2px",
@@ -1544,7 +2087,27 @@ function App() {
                     transition: "opacity 0.3s ease-in-out",
                   }}
                 >
-                  {activeStatusMessage || " "}
+                  {shouldShowGamePathManualPrompt ? (
+                    <>
+                      <span>이미 게임이 설치되어 있나요?</span>
+                      <button
+                        type="button"
+                        className="status-manual-path-button"
+                        onClick={() =>
+                          void openGamePathModal(
+                            "missing",
+                            config.serviceChannel,
+                            config.activeGame,
+                            { highlightManual: true },
+                          )
+                        }
+                      >
+                        수동 설정
+                      </button>
+                    </>
+                  ) : (
+                    activeStatusMessage || " "
+                  )}
                 </div>
 
                 {/* Company Logos - Removed and moved to Service Channel Dropdown */}

--- a/src/renderer/components/ServiceChannelSelector.tsx
+++ b/src/renderer/components/ServiceChannelSelector.tsx
@@ -1,28 +1,10 @@
 import React, { useEffect, useRef, useState } from "react";
 
 import { AppConfig } from "../../shared/types";
-import imgGGG from "../assets/img-ci-ggg_150x67.png";
-import imgKakao from "../assets/img-ci-kakaogames_158x28.png";
+import { SERVICE_CHANNEL_ASSETS } from "../utils/service-channel-assets";
 import "./ServiceChannelSelector.css";
 
 type ServiceChannel = AppConfig["serviceChannel"];
-
-interface ServiceChannelInfo {
-  logo: string;
-  alt: string;
-}
-
-// Extensible Configuration Map
-const CHANNEL_CONFIG: Record<ServiceChannel, ServiceChannelInfo> = {
-  "Kakao Games": {
-    logo: imgKakao,
-    alt: "Kakao Games",
-  },
-  GGG: {
-    logo: imgGGG,
-    alt: "Grinding Gear Games",
-  },
-};
 
 interface ServiceChannelSelectorProps {
   channel: ServiceChannel;
@@ -55,7 +37,7 @@ const ServiceChannelSelector: React.FC<ServiceChannelSelectorProps> = ({
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, [isOpen]);
 
-  const activeInfo = CHANNEL_CONFIG[channel];
+  const activeInfo = SERVICE_CHANNEL_ASSETS[channel];
 
   return (
     <div className="service-channel-container" ref={containerRef}>
@@ -74,30 +56,33 @@ const ServiceChannelSelector: React.FC<ServiceChannelSelectorProps> = ({
             />
           </div>
 
-          {/* Dropdown List (Automatic based on CHANNEL_CONFIG) */}
+          {/* Dropdown List (Automatic based on shared channel assets) */}
           {isOpen && (
             <div className="custom-dropdown-list">
-              {(Object.keys(CHANNEL_CONFIG) as ServiceChannel[]).map((key) => {
-                const info = CHANNEL_CONFIG[key];
-                return (
-                  <div
-                    key={key}
-                    className={`custom-dropdown-item ${
-                      channel === key ? "selected" : ""
-                    }`}
-                    onClick={() => {
-                      onChannelChange(key);
-                      setIsOpen(false);
-                    }}
-                  >
-                    <img
-                      src={info.logo}
-                      alt={info.alt}
-                      className="channel-logo"
-                    />
-                  </div>
-                );
-              })}
+              {(Object.keys(SERVICE_CHANNEL_ASSETS) as ServiceChannel[]).map(
+                (key) => {
+                  const info = SERVICE_CHANNEL_ASSETS[key];
+
+                  return (
+                    <div
+                      key={key}
+                      className={`custom-dropdown-item ${
+                        channel === key ? "selected" : ""
+                      }`}
+                      onClick={() => {
+                        onChannelChange(key);
+                        setIsOpen(false);
+                      }}
+                    >
+                      <img
+                        src={info.logo}
+                        alt={info.alt}
+                        className="channel-logo"
+                      />
+                    </div>
+                  );
+                },
+              )}
             </div>
           )}
         </div>

--- a/src/renderer/components/SupportLinks.tsx
+++ b/src/renderer/components/SupportLinks.tsx
@@ -154,12 +154,14 @@ interface SupportLinksProps {
     timestamp: string | number;
   }) => void;
   onPatchReservationRequest?: () => void;
+  onFontManagerSettingsRequest?: () => void;
 }
 
 const SupportLinks: React.FC<SupportLinksProps> = ({
   remoteVersions,
   onForcedRepairRequest,
   onPatchReservationRequest,
+  onFontManagerSettingsRequest,
 }) => {
   // Define Links Configuration
   const linkDefinitions = useMemo<SupportLinkItemDef[]>(
@@ -172,6 +174,17 @@ const SupportLinks: React.FC<SupportLinksProps> = ({
         onClick: () => {
           if (onPatchReservationRequest) {
             onPatchReservationRequest();
+          }
+        },
+      },
+      {
+        id: "font_manager",
+        type: "link",
+        icon: "font_download",
+        defaultLabel: "커스텀 폰트 설정",
+        onClick: () => {
+          if (onFontManagerSettingsRequest) {
+            onFontManagerSettingsRequest();
           }
         },
       },
@@ -312,7 +325,12 @@ const SupportLinks: React.FC<SupportLinksProps> = ({
         },
       },
     ],
-    [onForcedRepairRequest, onPatchReservationRequest, remoteVersions],
+    [
+      onFontManagerSettingsRequest,
+      onForcedRepairRequest,
+      onPatchReservationRequest,
+      remoteVersions,
+    ],
   );
 
   return (

--- a/src/renderer/components/modals/FontManagerModal.tsx
+++ b/src/renderer/components/modals/FontManagerModal.tsx
@@ -321,7 +321,7 @@ const FontManagerModal: React.FC<FontManagerModalProps> = ({
         )}
 
         <div className="font-header">
-          <h2>커스텀 폰트 관리 (BETA)</h2>
+          <h2>커스텀 폰트 관리</h2>
           <div className="font-header-actions">
             <button
               onClick={() => setShowDetailSettings(true)}

--- a/src/renderer/components/modals/GamePathDiagnosticModal.css
+++ b/src/renderer/components/modals/GamePathDiagnosticModal.css
@@ -1,0 +1,674 @@
+.game-path-modal-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 12000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.74);
+  backdrop-filter: blur(4px);
+  animation: gamePathOverlayFadeIn 0.16s ease-out;
+}
+
+.game-path-modal {
+  position: relative;
+  width: min(960px, calc(100vw - 80px));
+  overflow: hidden;
+  border: 1px solid rgba(223, 207, 153, 0.22);
+  border-radius: 8px;
+  background: #151515;
+  box-shadow: 0 28px 64px rgba(0, 0, 0, 0.78);
+  transform: scale(var(--app-scale, 1));
+  transform-origin: center center;
+  animation: gamePathContentIn 0.18s ease-out;
+}
+
+.game-path-modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  min-height: 76px;
+  padding: 18px 22px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  background: linear-gradient(to right, #1c1c1c, #121212);
+}
+
+.game-path-title-group {
+  min-width: 0;
+}
+
+.game-path-title {
+  margin: 0;
+  color: var(--theme-accent, #dfcf99);
+  font-size: 18px;
+  font-weight: 700;
+  letter-spacing: 0;
+}
+
+.game-path-subtitle {
+  margin: 5px 0 0;
+  color: #9a9a9a;
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.game-path-context-controls {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.game-path-context-select {
+  position: relative;
+}
+
+.game-path-service-select {
+  width: 150px;
+}
+
+.game-path-game-select {
+  width: 86px;
+}
+
+.game-path-context-trigger,
+.game-path-context-item {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  border: 1px solid rgba(223, 207, 153, 0.2);
+  border-radius: 4px;
+  background: rgba(22, 22, 22, 0.96);
+  color: var(--theme-accent, #dfcf99);
+  cursor: pointer;
+}
+
+.game-path-context-trigger {
+  justify-content: space-between;
+  gap: 8px;
+  height: 32px;
+  padding: 0 8px 0 10px;
+}
+
+.game-path-context-trigger:hover:not(:disabled),
+.game-path-context-trigger.is-open {
+  border-color: rgba(223, 207, 153, 0.48);
+  background: rgba(35, 35, 35, 0.98);
+}
+
+.game-path-context-trigger:disabled {
+  cursor: wait;
+  opacity: 0.62;
+}
+
+.game-path-context-trigger .material-symbols-outlined {
+  flex: 0 0 auto;
+  color: #9a9a9a;
+  font-size: 18px;
+}
+
+.game-path-context-trigger.is-open .material-symbols-outlined {
+  color: var(--theme-accent, #dfcf99);
+  transform: rotate(180deg);
+}
+
+.game-path-context-menu {
+  position: absolute;
+  top: calc(100% + 5px);
+  right: 0;
+  z-index: 5;
+  width: 100%;
+  overflow: hidden;
+  border: 1px solid rgba(223, 207, 153, 0.42);
+  border-radius: 4px;
+  background: rgba(15, 15, 15, 0.98);
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.46);
+}
+
+.game-path-context-item {
+  justify-content: flex-start;
+  height: 34px;
+  padding: 0 10px;
+  border: 0;
+  border-radius: 0;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.game-path-context-item:last-child {
+  border-bottom: 0;
+}
+
+.game-path-context-item:hover {
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.game-path-context-item.is-selected {
+  background: rgba(223, 207, 153, 0.08);
+  box-shadow: inset 2px 0 0 var(--theme-accent, #dfcf99);
+}
+
+.game-path-channel-logo {
+  display: block;
+  width: auto;
+  max-width: 112px;
+  object-fit: contain;
+  filter: grayscale(0.15);
+}
+
+img.game-path-channel-logo[alt="Kakao Games"] {
+  height: 16px;
+}
+
+img.game-path-channel-logo[alt="Grinding Gear Games"] {
+  height: 27px;
+}
+
+.game-path-context-trigger:hover:not(:disabled) .game-path-channel-logo,
+.game-path-context-trigger.is-open .game-path-channel-logo,
+.game-path-context-item:hover .game-path-channel-logo {
+  filter: brightness(1.1);
+}
+
+.game-path-game-label {
+  overflow: hidden;
+  color: var(--theme-accent, #dfcf99);
+  font-size: 11px;
+  font-weight: 800;
+  line-height: 1;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.game-path-modal-body {
+  padding: 20px 22px 22px;
+  background: #151515;
+}
+
+.game-path-loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  min-height: 184px;
+  color: #bdbdbd;
+  font-size: 14px;
+}
+
+.game-path-loading .material-symbols-outlined {
+  color: var(--theme-accent, #dfcf99);
+}
+
+.game-path-options {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.game-path-option {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 210px;
+  padding: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.025);
+}
+
+.game-path-option.is-recommended {
+  border-color: rgba(223, 207, 153, 0.36);
+  background: rgba(223, 207, 153, 0.055);
+}
+
+.game-path-option.is-valid {
+  border-color: rgba(64, 192, 87, 0.52);
+  background:
+    linear-gradient(rgba(64, 192, 87, 0.055), rgba(64, 192, 87, 0.025)),
+    rgba(255, 255, 255, 0.025);
+}
+
+.game-path-option.is-valid.is-recommended {
+  border-color: rgba(64, 192, 87, 0.7);
+  box-shadow: 0 0 0 1px rgba(64, 192, 87, 0.08);
+}
+
+.game-path-option.is-invalid {
+  border-color: rgba(250, 82, 82, 0.62);
+  background:
+    linear-gradient(rgba(250, 82, 82, 0.075), rgba(250, 82, 82, 0.03)),
+    rgba(255, 255, 255, 0.02);
+}
+
+.game-path-option.is-empty,
+.game-path-option.is-unknown {
+  border-color: rgba(255, 171, 0, 0.58);
+  background:
+    linear-gradient(rgba(255, 171, 0, 0.065), rgba(255, 171, 0, 0.025)),
+    rgba(255, 255, 255, 0.02);
+}
+
+.game-path-option-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 10px;
+  min-height: 48px;
+}
+
+.game-path-option-title {
+  color: #e4e4e4;
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.game-path-option.is-valid .game-path-option-title {
+  color: #e9fff0;
+}
+
+.game-path-option.is-invalid .game-path-option-title {
+  color: #ffe3e3;
+}
+
+.game-path-option.is-empty .game-path-option-title,
+.game-path-option.is-unknown .game-path-option-title {
+  color: #fff3bf;
+}
+
+.game-path-option-meta {
+  width: 100%;
+  margin-top: 5px;
+  color: #777;
+  font-family: Consolas, "Courier New", monospace;
+  font-size: 10px;
+  line-height: 1.3;
+  overflow-wrap: anywhere;
+}
+
+.game-path-state {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  flex: 0 0 auto;
+  color: #999;
+  font-size: 12px;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.game-path-state .material-symbols-outlined {
+  font-size: 19px;
+}
+
+.game-path-state.is-valid {
+  color: #40c057;
+}
+
+.game-path-state.is-invalid {
+  color: #fa5252;
+}
+
+.game-path-state.is-unknown,
+.game-path-state.is-empty {
+  color: #ffab00;
+}
+
+.game-path-option-path {
+  display: flex;
+  align-items: center;
+  min-height: 54px;
+  margin: 14px 0 10px;
+  padding: 11px 12px;
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  border-radius: 6px;
+  background: rgba(0, 0, 0, 0.25);
+  color: #ddd;
+  font-family: Consolas, "Courier New", monospace;
+  font-size: 12px;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+  word-break: normal;
+  user-select: text;
+}
+
+.game-path-option-path.is-empty {
+  color: #777;
+  font-family: var(--launcher-font-family);
+}
+
+.game-path-option.is-valid .game-path-option-path {
+  border-color: rgba(64, 192, 87, 0.18);
+  background: rgba(0, 0, 0, 0.2);
+}
+
+.game-path-option.is-invalid .game-path-option-path {
+  border-color: rgba(250, 82, 82, 0.32);
+  background: rgba(250, 82, 82, 0.02);
+}
+
+.game-path-option.is-empty .game-path-option-path,
+.game-path-option.is-unknown .game-path-option-path {
+  border-color: rgba(255, 171, 0, 0.28);
+  background: rgba(255, 171, 0, 0.02);
+}
+
+.game-path-option-error {
+  margin-bottom: 10px;
+  color: #ff8787;
+  font-size: 11px;
+  line-height: 1.4;
+  overflow-wrap: anywhere;
+}
+
+.game-path-option .game-path-action {
+  margin-top: auto;
+}
+
+.game-path-manual-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-top: 16px;
+  padding: 12px 14px;
+  border: 1px solid rgba(223, 207, 153, 0.14);
+  border-radius: 8px;
+  background: rgba(223, 207, 153, 0.045);
+}
+
+.game-path-manual-row.is-highlighted {
+  border-color: rgba(223, 207, 153, 0.45);
+  box-shadow: 0 0 18px rgba(223, 207, 153, 0.18);
+  animation: gamePathManualHighlight 2s ease-out;
+}
+
+.game-path-manual-row strong {
+  display: block;
+  color: var(--theme-accent, #dfcf99);
+  font-size: 13px;
+}
+
+.game-path-manual-row span {
+  display: block;
+  margin-top: 3px;
+  color: #aaa;
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.game-path-error-banner {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  margin-top: 14px;
+  padding: 10px 12px;
+  border: 1px solid rgba(250, 82, 82, 0.28);
+  border-radius: 6px;
+  background: rgba(250, 82, 82, 0.08);
+  color: #ff8787;
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.game-path-error-banner .material-symbols-outlined {
+  flex: 0 0 auto;
+  font-size: 19px;
+}
+
+.game-path-modal-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  padding: 16px 22px 20px;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  background: #101010;
+}
+
+.game-path-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  min-height: 36px;
+  padding: 8px 15px;
+  border-radius: 4px;
+  border: 1px solid transparent;
+  font-size: 13px;
+  font-weight: 700;
+  line-height: 1;
+  cursor: pointer;
+  transition:
+    filter 0.16s ease,
+    background-color 0.16s ease,
+    border-color 0.16s ease,
+    color 0.16s ease;
+}
+
+.game-path-action .material-symbols-outlined {
+  font-size: 18px;
+}
+
+.game-path-action.primary {
+  border-color: rgba(223, 207, 153, 0.4);
+  background: var(--theme-accent, #dfcf99);
+  color: #111;
+}
+
+.game-path-action.danger {
+  border-color: rgba(250, 82, 82, 0.58);
+  background: #b93f3f;
+  color: #fff1f1;
+}
+
+.game-path-action.secondary,
+.game-path-action.ghost {
+  border-color: #444;
+  background: #2d2d2d;
+  color: #ddd;
+}
+
+.game-path-action.reselect {
+  border-color: rgba(250, 82, 82, 0.28);
+}
+
+.game-path-action.ghost {
+  background: transparent;
+}
+
+.game-path-action:hover:not(:disabled) {
+  filter: brightness(1.12);
+}
+
+.game-path-action:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+
+.game-path-confirm-overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 20;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 22px;
+  background: rgba(0, 0, 0, 0.58);
+  backdrop-filter: blur(3px);
+}
+
+.game-path-confirm-dialog {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 14px;
+  width: min(720px, 100%);
+  padding: 18px;
+  border: 1px solid rgba(255, 171, 0, 0.44);
+  border-radius: 8px;
+  background:
+    linear-gradient(rgba(255, 171, 0, 0.055), rgba(255, 171, 0, 0.02)),
+    #181818;
+  box-shadow: 0 24px 58px rgba(0, 0, 0, 0.72);
+}
+
+.game-path-confirm-icon {
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  color: #ffbf33;
+}
+
+.game-path-confirm-icon .material-symbols-outlined {
+  font-size: 28px;
+}
+
+.game-path-confirm-content {
+  min-width: 0;
+}
+
+.game-path-confirm-content h3 {
+  margin: 0 0 10px;
+  color: #f1dca4;
+  font-size: 16px;
+  font-weight: 700;
+  letter-spacing: 0;
+}
+
+.game-path-confirm-content p {
+  margin: 0 0 9px;
+  color: #c6c6c6;
+  font-size: 12px;
+  line-height: 1.55;
+}
+
+.game-path-confirm-paths {
+  display: grid;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.game-path-confirm-paths div {
+  min-width: 0;
+  padding: 9px 10px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 5px;
+  background: rgba(0, 0, 0, 0.22);
+}
+
+.game-path-confirm-paths span {
+  display: block;
+  margin-bottom: 4px;
+  color: #8e8e8e;
+  font-size: 10px;
+  font-weight: 700;
+}
+
+.game-path-confirm-paths strong {
+  display: block;
+  color: #ddd;
+  font-family: Consolas, "Courier New", monospace;
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+}
+
+.game-path-confirm-actions {
+  grid-column: 1 / -1;
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 4px;
+}
+
+.game-path-modal .shared-toast.visible {
+  animation: gamePathToastLifecycle 2.5s ease forwards;
+}
+
+@keyframes gamePathOverlayFadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes gamePathContentIn {
+  from {
+    opacity: 0;
+    transform: scale(calc(var(--app-scale, 1) * 0.96)) translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: scale(var(--app-scale, 1)) translateY(0);
+  }
+}
+
+@keyframes gamePathToastLifecycle {
+  0% {
+    opacity: 0;
+    transform: translateX(-50%) translateY(10px);
+  }
+  12%,
+  78% {
+    opacity: 1;
+    transform: translateX(-50%) translateY(0);
+  }
+  100% {
+    opacity: 0;
+    transform: translateX(-50%) translateY(10px);
+  }
+}
+
+@keyframes gamePathManualHighlight {
+  0% {
+    background: rgba(223, 207, 153, 0.22);
+    box-shadow: 0 0 28px rgba(223, 207, 153, 0.35);
+  }
+  35% {
+    background: rgba(223, 207, 153, 0.11);
+  }
+  100% {
+    background: rgba(223, 207, 153, 0.045);
+    box-shadow: 0 0 18px rgba(223, 207, 153, 0.18);
+  }
+}
+
+@media (max-width: 680px) {
+  .game-path-modal {
+    width: min(640px, 92vw);
+  }
+
+  .game-path-modal-header,
+  .game-path-manual-row {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .game-path-context-controls {
+    justify-content: flex-start;
+    width: 100%;
+  }
+
+  .game-path-service-select {
+    flex: 1 1 150px;
+  }
+
+  .game-path-options {
+    grid-template-columns: 1fr;
+  }
+
+  .game-path-modal-footer {
+    flex-wrap: wrap;
+  }
+
+  .game-path-confirm-dialog {
+    grid-template-columns: 1fr;
+  }
+
+  .game-path-confirm-actions {
+    justify-content: stretch;
+    flex-direction: column;
+  }
+}

--- a/src/renderer/components/modals/GamePathDiagnosticModal.tsx
+++ b/src/renderer/components/modals/GamePathDiagnosticModal.tsx
@@ -1,0 +1,561 @@
+import React from "react";
+
+import "./GamePathDiagnosticModal.css";
+import {
+  ACTIVE_GAMES,
+  SERVICE_CHANNELS,
+  type ActiveGame,
+  type GameInstallPathConfigDiagnostic,
+  type GameInstallPathDiagnostics,
+  type GameInstallPathRegistryDiagnostic,
+  type ServiceChannel,
+} from "../../../shared/types";
+import { SERVICE_CHANNEL_ASSETS } from "../../utils/service-channel-assets";
+import { Toast } from "../ui/Toast";
+
+type GamePathSource = "config" | "registry";
+type GamePathModalMode = "conflict" | "missing" | "diagnostic";
+type PathDiagnostic =
+  | GameInstallPathConfigDiagnostic
+  | GameInstallPathRegistryDiagnostic;
+
+interface GamePathDiagnosticModalProps {
+  isOpen: boolean;
+  mode: GamePathModalMode;
+  serviceId: ServiceChannel;
+  gameId: ActiveGame;
+  diagnostics: GameInstallPathDiagnostics | null;
+  busy?: boolean;
+  errorMessage?: string;
+  highlightManual?: boolean;
+  showRegistrySyncConfirm?: boolean;
+  manualSaveToastId?: number;
+  onClose: () => void;
+  onContextChange: (serviceId: ServiceChannel, gameId: ActiveGame) => void;
+  onUsePath: (source: GamePathSource) => void;
+  onManualSelect: () => void;
+  onRegistrySyncConfirmClose: () => void;
+  onKeepLauncherConfig: () => void;
+  onSyncRegistry: () => void;
+  onInstall?: () => void;
+}
+
+const getStatusIcon = (diagnostic: PathDiagnostic) => {
+  if (diagnostic.verification === "valid") return "check_circle";
+  if (diagnostic.verification === "missing") return "cancel";
+  if (
+    diagnostic.verification === "unknown" ||
+    diagnostic.state === "context-unavailable" ||
+    diagnostic.state === "read-failed"
+  ) {
+    return "warning";
+  }
+  return "help";
+};
+
+const getStatusClass = (diagnostic: PathDiagnostic) => {
+  if (diagnostic.verification === "valid") return "is-valid";
+  if (diagnostic.verification === "missing") return "is-invalid";
+  if (
+    diagnostic.verification === "unknown" ||
+    diagnostic.state === "context-unavailable" ||
+    diagnostic.state === "read-failed"
+  ) {
+    return "is-unknown";
+  }
+  return "is-empty";
+};
+
+const getStatusText = (diagnostic: PathDiagnostic) => {
+  if (diagnostic.verification === "valid") return "확인됨";
+  if (diagnostic.verification === "missing") return "실행 파일 없음";
+  if (diagnostic.verification === "unknown") return "확인 불가";
+
+  switch (diagnostic.state) {
+    case "empty":
+      return "미설정";
+    case "context-unavailable":
+      return "설정 확인 불가";
+    case "key-missing":
+      return "레지스트리 키 없음";
+    case "value-missing":
+      return "경로값 없음";
+    case "value-empty":
+      return "경로값 비어 있음";
+    case "read-failed":
+      return "레지스트리 확인 실패";
+    default:
+      return "확인 전";
+  }
+};
+
+const getEmptyPathText = (source: GamePathSource) => {
+  return source === "registry" ? "레지스트리 경로 없음" : "저장된 경로 없음";
+};
+
+const getActionText = (source: GamePathSource) => {
+  return source === "registry" ? "이 경로 사용" : "설정 경로 유지";
+};
+
+const GAME_LABELS: Record<ActiveGame, string> = {
+  POE1: "POE1",
+  POE2: "POE2",
+};
+
+const GamePathServiceSelect: React.FC<{
+  value: ServiceChannel;
+  disabled: boolean;
+  onChange: (value: ServiceChannel) => void;
+}> = ({ value, disabled, onChange }) => {
+  const [isOpen, setIsOpen] = React.useState(false);
+  const selectRef = React.useRef<HTMLDivElement>(null);
+  const activeInfo = SERVICE_CHANNEL_ASSETS[value];
+
+  React.useEffect(() => {
+    const handleOutsideClick = (event: MouseEvent) => {
+      if (!selectRef.current?.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+
+    if (isOpen) {
+      document.addEventListener("mousedown", handleOutsideClick);
+    }
+
+    return () => document.removeEventListener("mousedown", handleOutsideClick);
+  }, [isOpen]);
+
+  return (
+    <div
+      className="game-path-context-select game-path-service-select"
+      ref={selectRef}
+    >
+      <button
+        type="button"
+        className={`game-path-context-trigger ${isOpen ? "is-open" : ""}`}
+        disabled={disabled}
+        aria-label="서비스 선택"
+        onClick={() => setIsOpen((current) => !current)}
+      >
+        <img
+          src={activeInfo.logo}
+          alt={activeInfo.alt}
+          className="game-path-channel-logo"
+        />
+        <span className="material-symbols-outlined">expand_more</span>
+      </button>
+
+      {isOpen && (
+        <div className="game-path-context-menu">
+          {SERVICE_CHANNELS.map((service) => {
+            const info = SERVICE_CHANNEL_ASSETS[service];
+
+            return (
+              <button
+                key={service}
+                type="button"
+                className={`game-path-context-item ${
+                  value === service ? "is-selected" : ""
+                }`}
+                onClick={() => {
+                  onChange(service);
+                  setIsOpen(false);
+                }}
+              >
+                <img
+                  src={info.logo}
+                  alt={info.alt}
+                  className="game-path-channel-logo"
+                />
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+};
+
+const GamePathGameSelect: React.FC<{
+  value: ActiveGame;
+  disabled: boolean;
+  onChange: (value: ActiveGame) => void;
+}> = ({ value, disabled, onChange }) => {
+  const [isOpen, setIsOpen] = React.useState(false);
+  const selectRef = React.useRef<HTMLDivElement>(null);
+
+  React.useEffect(() => {
+    const handleOutsideClick = (event: MouseEvent) => {
+      if (!selectRef.current?.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+
+    if (isOpen) {
+      document.addEventListener("mousedown", handleOutsideClick);
+    }
+
+    return () => document.removeEventListener("mousedown", handleOutsideClick);
+  }, [isOpen]);
+
+  return (
+    <div
+      className="game-path-context-select game-path-game-select"
+      ref={selectRef}
+    >
+      <button
+        type="button"
+        className={`game-path-context-trigger ${isOpen ? "is-open" : ""}`}
+        disabled={disabled}
+        aria-label="게임 선택"
+        onClick={() => setIsOpen((current) => !current)}
+      >
+        <span className="game-path-game-label">{GAME_LABELS[value]}</span>
+        <span className="material-symbols-outlined">expand_more</span>
+      </button>
+
+      {isOpen && (
+        <div className="game-path-context-menu">
+          {ACTIVE_GAMES.map((game) => (
+            <button
+              key={game}
+              type="button"
+              className={`game-path-context-item ${
+                value === game ? "is-selected" : ""
+              }`}
+              onClick={() => {
+                onChange(game);
+                setIsOpen(false);
+              }}
+            >
+              <span className="game-path-game-label">{GAME_LABELS[game]}</span>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+const PathOptionCard: React.FC<{
+  title: string;
+  source: GamePathSource;
+  diagnostic: PathDiagnostic;
+  recommended: boolean;
+  busy: boolean;
+  onUsePath: (source: GamePathSource) => void;
+  onManualSelect: () => void;
+}> = ({
+  title,
+  source,
+  diagnostic,
+  recommended,
+  busy,
+  onUsePath,
+  onManualSelect,
+}) => {
+  const canUsePath = Boolean(
+    diagnostic.path && diagnostic.verification === "valid",
+  );
+  const canReselectConfigPath = Boolean(
+    source === "config" &&
+    diagnostic.path &&
+    diagnostic.verification === "missing",
+  );
+  const statusClass = getStatusClass(diagnostic);
+  const actionDisabled = (!canUsePath && !canReselectConfigPath) || busy;
+  const registryDetail =
+    diagnostic.source === "registry"
+      ? `${diagnostic.registryPath} / ${diagnostic.registryValueName}`
+      : null;
+
+  return (
+    <section
+      className={`game-path-option ${statusClass} ${
+        recommended ? "is-recommended" : ""
+      }`}
+    >
+      <div className="game-path-option-head">
+        <div>
+          <div className="game-path-option-title">{title}</div>
+          {registryDetail && (
+            <div className="game-path-option-meta">{registryDetail}</div>
+          )}
+        </div>
+        <div className={`game-path-state ${statusClass}`}>
+          <span className="material-symbols-outlined">
+            {getStatusIcon(diagnostic)}
+          </span>
+          {getStatusText(diagnostic)}
+        </div>
+      </div>
+
+      <div
+        className={`game-path-option-path ${diagnostic.path ? "" : "is-empty"}`}
+        title={diagnostic.path || getEmptyPathText(source)}
+      >
+        {diagnostic.path || getEmptyPathText(source)}
+      </div>
+
+      {diagnostic.error && (
+        <div className="game-path-option-error">{diagnostic.error}</div>
+      )}
+
+      <button
+        type="button"
+        className={`game-path-action ${
+          recommended ? "primary" : "secondary"
+        } ${canReselectConfigPath ? "reselect" : ""}`}
+        disabled={actionDisabled}
+        onClick={() =>
+          canReselectConfigPath ? onManualSelect() : onUsePath(source)
+        }
+      >
+        <span className="material-symbols-outlined">
+          {canReselectConfigPath
+            ? "folder_open"
+            : source === "registry"
+              ? "sync_alt"
+              : "check"}
+        </span>
+        {canReselectConfigPath ? "다시 선택" : getActionText(source)}
+      </button>
+    </section>
+  );
+};
+
+const GamePathDiagnosticModal: React.FC<GamePathDiagnosticModalProps> = ({
+  isOpen,
+  mode,
+  serviceId,
+  gameId,
+  diagnostics,
+  busy = false,
+  errorMessage,
+  highlightManual = false,
+  showRegistrySyncConfirm = false,
+  manualSaveToastId,
+  onClose,
+  onContextChange,
+  onUsePath,
+  onManualSelect,
+  onRegistrySyncConfirmClose,
+  onKeepLauncherConfig,
+  onSyncRegistry,
+  onInstall,
+}) => {
+  const manualRowRef = React.useRef<HTMLDivElement>(null);
+
+  React.useEffect(() => {
+    if (!isOpen || !diagnostics || !highlightManual) return;
+
+    const timer = window.setTimeout(() => {
+      manualRowRef.current?.scrollIntoView({
+        behavior: "smooth",
+        block: "nearest",
+      });
+    }, 250);
+
+    return () => window.clearTimeout(timer);
+  }, [diagnostics, highlightManual, isOpen]);
+
+  const subtitle =
+    mode === "missing"
+      ? "설치된 게임 경로를 찾지 못했습니다."
+      : mode === "conflict"
+        ? "설정 경로와 레지스트리 경로가 다릅니다."
+        : "서비스와 게임별 설치 경로를 확인합니다.";
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="game-path-modal-overlay" onClick={onClose}>
+      <div
+        className="game-path-modal"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <header className="game-path-modal-header">
+          <div className="game-path-title-group">
+            <h2 className="game-path-title">게임 경로 진단</h2>
+            <p className="game-path-subtitle">{subtitle}</p>
+          </div>
+          <div className="game-path-context-controls">
+            <GamePathServiceSelect
+              value={serviceId}
+              disabled={busy}
+              onChange={(nextServiceId) =>
+                onContextChange(nextServiceId, gameId)
+              }
+            />
+            <GamePathGameSelect
+              value={gameId}
+              disabled={busy}
+              onChange={(nextGameId) => onContextChange(serviceId, nextGameId)}
+            />
+          </div>
+        </header>
+
+        <div className="game-path-modal-body">
+          {!diagnostics ? (
+            <div className="game-path-loading">
+              <span className="material-symbols-outlined">sync</span>
+              경로를 확인하는 중...
+            </div>
+          ) : (
+            <>
+              <div className="game-path-options">
+                <PathOptionCard
+                  title="레지스트리"
+                  source="registry"
+                  diagnostic={diagnostics.registry}
+                  recommended={diagnostics.recommendedSource === "registry"}
+                  busy={busy}
+                  onUsePath={onUsePath}
+                  onManualSelect={onManualSelect}
+                />
+                <PathOptionCard
+                  title="런처 내 설정"
+                  source="config"
+                  diagnostic={diagnostics.config}
+                  recommended={diagnostics.recommendedSource === "config"}
+                  busy={busy}
+                  onUsePath={onUsePath}
+                  onManualSelect={onManualSelect}
+                />
+              </div>
+
+              <div
+                ref={manualRowRef}
+                className={`game-path-manual-row ${
+                  highlightManual ? "is-highlighted" : ""
+                }`}
+              >
+                <div>
+                  <strong>수동 설정</strong>
+                  <span>
+                    선택한 폴더 안에 {diagnostics.executableName}가 있어야
+                    합니다.
+                  </span>
+                </div>
+                <button
+                  type="button"
+                  className="game-path-action secondary"
+                  disabled={busy}
+                  onClick={onManualSelect}
+                >
+                  <span className="material-symbols-outlined">folder_open</span>
+                  폴더 선택
+                </button>
+              </div>
+            </>
+          )}
+
+          {errorMessage && (
+            <div className="game-path-error-banner">
+              <span className="material-symbols-outlined">error</span>
+              {errorMessage}
+            </div>
+          )}
+        </div>
+
+        <footer className="game-path-modal-footer">
+          <button
+            type="button"
+            className="game-path-action ghost"
+            disabled={busy}
+            onClick={onClose}
+          >
+            닫기
+          </button>
+          {onInstall && (
+            <button
+              type="button"
+              className="game-path-action primary"
+              disabled={busy}
+              onClick={onInstall}
+            >
+              <span className="material-symbols-outlined">download</span>
+              설치하기
+            </button>
+          )}
+        </footer>
+
+        {showRegistrySyncConfirm &&
+          diagnostics?.config.path &&
+          diagnostics?.registry.path && (
+            <div className="game-path-confirm-overlay">
+              <div
+                className="game-path-confirm-dialog"
+                onClick={(event) => event.stopPropagation()}
+              >
+                <div className="game-path-confirm-icon">
+                  <span className="material-symbols-outlined">warning</span>
+                </div>
+                <div className="game-path-confirm-content">
+                  <h3>레지스트리 설치 경로를 변경할까요?</h3>
+                  <p>
+                    레지스트리는 게임이 설치될 때 게임 쪽에서 자동으로 추가하는
+                    값입니다. 현재 값이 왜 손상되었거나 달라졌는지는 런처에서 알
+                    수 없습니다.
+                  </p>
+                  <p>
+                    이 값은 런처 외부의 게임 실행/패치 프로그램에서도 사용될 수
+                    있습니다. 잘못된 경로로 변경하면 일반적인 실행 환경에서도
+                    게임을 찾지 못할 수 있습니다.
+                  </p>
+                  <div className="game-path-confirm-paths">
+                    <div>
+                      <span>변경 전</span>
+                      <strong>{diagnostics.registry.path}</strong>
+                    </div>
+                    <div>
+                      <span>변경 후</span>
+                      <strong>{diagnostics.config.path}</strong>
+                    </div>
+                  </div>
+                </div>
+                <div className="game-path-confirm-actions">
+                  <button
+                    type="button"
+                    className="game-path-action ghost"
+                    disabled={busy}
+                    onClick={onRegistrySyncConfirmClose}
+                  >
+                    취소
+                  </button>
+                  <button
+                    type="button"
+                    className="game-path-action secondary"
+                    disabled={busy}
+                    onClick={onKeepLauncherConfig}
+                  >
+                    런처 내 설정만 사용
+                  </button>
+                  <button
+                    type="button"
+                    className="game-path-action danger"
+                    disabled={busy}
+                    onClick={onSyncRegistry}
+                  >
+                    <span className="material-symbols-outlined">warning</span>
+                    레지스트리에 반영
+                  </button>
+                </div>
+              </div>
+            </div>
+          )}
+
+        {manualSaveToastId && (
+          <Toast
+            key={manualSaveToastId}
+            message="게임 경로가 저장되었습니다."
+            visible
+            variant="success"
+          />
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default GamePathDiagnosticModal;

--- a/src/renderer/settings/settings-config.ts
+++ b/src/renderer/settings/settings-config.ts
@@ -806,7 +806,7 @@ export const SETTINGS_CONFIG: SettingsCategory[] = [
           {
             id: "openFontManagerBtn",
             type: "button",
-            label: "커스텀 폰트 관리 (BETA)",
+            label: "커스텀 폰트 관리",
             buttonText: "열기",
             variant: "primary",
             description: "게임 내 폰트를 교체하거나 원본으로 복구합니다.",

--- a/src/renderer/settings/settings-config.ts
+++ b/src/renderer/settings/settings-config.ts
@@ -722,6 +722,28 @@ export const SETTINGS_CONFIG: SettingsCategory[] = [
     icon: "sports_esports",
     sections: [
       {
+        id: "install_path",
+        title: "설치 경로",
+        items: [
+          {
+            id: "openGamePathDiagnosticBtn",
+            type: "button",
+            defaultValue: false,
+            label: "게임 경로 진단",
+            buttonText: "열기",
+            variant: "primary",
+            description:
+              "서비스와 게임별 설치 경로를 확인하거나 직접 지정합니다.",
+            icon: "folder_open",
+            onClickListener: () => {
+              window.dispatchEvent(
+                new CustomEvent("open-game-path-diagnostic-modal"),
+              );
+            },
+          },
+        ],
+      },
+      {
         id: "adv_process",
         title: "프로세스 관리",
         items: [

--- a/src/renderer/settings/settings-config.ts
+++ b/src/renderer/settings/settings-config.ts
@@ -832,7 +832,7 @@ export const SETTINGS_CONFIG: SettingsCategory[] = [
           {
             id: "aggressivePatchMode",
             type: "check",
-            label: "한국인 모드 (BETA)",
+            label: "한국인 모드",
             description:
               "단 한번이라도 다운로드에 실패하면 지체없이 강제 종료 후 복구합니다.",
             icon: "offline_bolt",

--- a/src/renderer/settings/types.ts
+++ b/src/renderer/settings/types.ts
@@ -273,6 +273,11 @@ export interface SettingText extends BaseSettingItem {
  */
 export interface SettingButton extends BaseSettingItem {
   type: "button";
+  /**
+   * 이 값이 존재하면 Electron Store를 사용하지 않고, UI 상태로만 관리됩니다.
+   * (액션 버튼은 보통 false를 사용합니다.)
+   */
+  defaultValue?: boolean;
   /** 버튼에 표시될 텍스트 */
   buttonText: string;
   /** 버튼 스타일 변형 (default, primary, danger 등) */

--- a/src/renderer/utils/service-channel-assets.ts
+++ b/src/renderer/utils/service-channel-assets.ts
@@ -1,0 +1,23 @@
+import imgGGG from "../assets/img-ci-ggg_150x67.png";
+import imgKakao from "../assets/img-ci-kakaogames_158x28.png";
+
+import type { ServiceChannel } from "../../shared/types";
+
+interface ServiceChannelAsset {
+  logo: string;
+  alt: string;
+}
+
+export const SERVICE_CHANNEL_ASSETS: Record<
+  ServiceChannel,
+  ServiceChannelAsset
+> = {
+  "Kakao Games": {
+    logo: imgKakao,
+    alt: "Kakao Games",
+  },
+  GGG: {
+    logo: imgGGG,
+    alt: "Grinding Gear Games",
+  },
+};

--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -160,6 +160,20 @@ export const CONFIG_METADATA: Record<string, ConfigDefinition> = {
     description:
       "각 게임 및 서비스별 마지막으로 감지된 버전과 WebRoot 정보를 저장합니다. (자동 관리)",
   },
+  GAME_INSTALL_PATHS: {
+    key: "gameInstallPaths",
+    name: "Game Install Paths",
+    category: "Game",
+    description:
+      "각 게임 및 서비스별 설치 경로를 저장합니다. 레지스트리에서 확인된 경로는 자동으로 캐싱됩니다.",
+  },
+  GAME_INSTALL_PATH_CONFLICT_RESOLUTIONS: {
+    key: "gameInstallPathConflictResolutions",
+    name: "Game Install Path Conflict Resolutions",
+    category: "Game",
+    description:
+      "사용자가 런처 설정 경로를 유지하기로 확인한 레지스트리/설정 경로 충돌을 저장합니다. (자동 관리)",
+  },
   REMOTE_THEME_SETTINGS: {
     key: "remoteThemeSettings",
     name: "Remote Theme Settings",
@@ -241,6 +255,9 @@ export const CONFIG_KEYS = {
   KAKAO_ACCOUNT_ID: CONFIG_METADATA.KAKAO_ACCOUNT_ID.key,
   GGG_ACCOUNT_ID: CONFIG_METADATA.GGG_ACCOUNT_ID.key,
   KNOWN_GAME_VERSIONS: CONFIG_METADATA.KNOWN_GAME_VERSIONS.key,
+  GAME_INSTALL_PATHS: CONFIG_METADATA.GAME_INSTALL_PATHS.key,
+  GAME_INSTALL_PATH_CONFLICT_RESOLUTIONS:
+    CONFIG_METADATA.GAME_INSTALL_PATH_CONFLICT_RESOLUTIONS.key,
   REMOTE_THEME_SETTINGS: CONFIG_METADATA.REMOTE_THEME_SETTINGS.key,
   PATCH_RESERVATIONS: CONFIG_METADATA.PATCH_RESERVATIONS.key,
   SILENT_PATCH_NOTIFICATION: CONFIG_METADATA.SILENT_PATCH_NOTIFICATION.key,
@@ -272,6 +289,26 @@ export const DEFAULT_CONFIG: AppConfig = {
   autoResolution: true,
   resolutionMode: "1440x960",
   knownGameVersions: {},
+  gameInstallPaths: {
+    "Kakao Games": {
+      POE1: "",
+      POE2: "",
+    },
+    GGG: {
+      POE1: "",
+      POE2: "",
+    },
+  },
+  gameInstallPathConflictResolutions: {
+    "Kakao Games": {
+      POE1: null,
+      POE2: null,
+    },
+    GGG: {
+      POE1: null,
+      POE2: null,
+    },
+  },
   remoteThemeSettings: {
     autoApply: true,
     selectedThemes: {

--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -120,7 +120,7 @@ export const CONFIG_METADATA: Record<string, ConfigDefinition> = {
     name: "Aggressive Patch Mode",
     category: "Patch",
     description:
-      "한국인 모드 (BETA): 패치 오류 발생 시 재시도 대기를 생략하고 즉시 대응합니다. 오류 탐지 시 프로세스를 강제 종료하여 즉각적인 자동 복구 단계를 시작합니다.",
+      "한국인 모드: 패치 오류 발생 시 재시도 대기를 생략하고 즉시 대응합니다. 오류 탐지 시 프로세스를 강제 종료하여 즉각적인 자동 복구 단계를 시작합니다.",
   },
   SKIP_DAUM_GAME_STARTER_UAC: {
     key: "skipDaumGameStarterUac",

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -19,11 +19,30 @@ export interface ConfigDefinition {
 }
 
 export type NewsOpenMode = "inline" | "modal";
+export const SERVICE_CHANNELS = ["Kakao Games", "GGG"] as const;
+export type ServiceChannel = (typeof SERVICE_CHANNELS)[number];
+export const ACTIVE_GAMES = ["POE1", "POE2"] as const;
+export type ActiveGame = (typeof ACTIVE_GAMES)[number];
+export type GameInstallPaths = Record<
+  ServiceChannel,
+  Record<ActiveGame, string>
+>;
+
+export interface GameInstallPathConflictResolution {
+  configPath: string;
+  registryPath: string;
+  resolvedAt: number;
+}
+
+export type GameInstallPathConflictResolutions = Record<
+  ServiceChannel,
+  Record<ActiveGame, GameInstallPathConflictResolution | null>
+>;
 
 export interface AppConfig {
   [key: string]: unknown;
-  serviceChannel: "Kakao Games" | "GGG";
-  activeGame: "POE1" | "POE2";
+  serviceChannel: ServiceChannel;
+  activeGame: ActiveGame;
   dev_mode: boolean;
   debug_console: boolean;
   themeCache: Partial<
@@ -68,6 +87,10 @@ export interface AppConfig {
     { version: string; webRoot: string; timestamp: number }
   >;
 
+  // Game installation paths cached by service/game after registry discovery.
+  gameInstallPaths: GameInstallPaths;
+  gameInstallPathConflictResolutions: GameInstallPathConflictResolutions;
+
   // Remote Theme Settings
   remoteThemeSettings: {
     autoApply: boolean;
@@ -102,6 +125,90 @@ export interface GameLaunchContext {
   gameId: AppConfig["activeGame"];
   serviceId: AppConfig["serviceChannel"];
 }
+
+export type GameInstallPathVerificationStatus =
+  | "valid"
+  | "missing"
+  | "unknown"
+  | "not-checked";
+
+export type GameInstallPathRegistryState =
+  | "found"
+  | "key-missing"
+  | "value-missing"
+  | "value-empty"
+  | "read-failed";
+
+export type GameInstallPathConfigState =
+  | "found"
+  | "empty"
+  | "context-unavailable";
+
+export interface GameInstallPathConfigDiagnostic {
+  source: "config";
+  path: string | null;
+  state: GameInstallPathConfigState;
+  verification: GameInstallPathVerificationStatus;
+  executablePath?: string;
+  error?: string;
+}
+
+export interface GameInstallPathRegistryDiagnostic {
+  source: "registry";
+  path: string | null;
+  state: GameInstallPathRegistryState;
+  verification: GameInstallPathVerificationStatus;
+  executablePath?: string;
+  error?: string;
+  registryPath: string;
+  registryValueName: string;
+}
+
+export interface GameInstallPathDiagnostics {
+  serviceId: AppConfig["serviceChannel"];
+  gameId: AppConfig["activeGame"];
+  executableName: string;
+  config: GameInstallPathConfigDiagnostic;
+  registry: GameInstallPathRegistryDiagnostic;
+  hasPathConflict: boolean;
+  isPathConflictAcknowledged: boolean;
+  recommendedSource: "config" | "registry" | null;
+}
+
+export type GameInstallPathConflictAction =
+  | "launcher-config-only"
+  | "sync-registry";
+
+export type GameInstallPathSaveResult =
+  | {
+      ok: true;
+      path: string;
+      diagnostics: GameInstallPathDiagnostics;
+    }
+  | {
+      ok: false;
+      canceled?: boolean;
+      path?: string;
+      verification: GameInstallPathVerificationStatus;
+      error?: string;
+      diagnostics?: GameInstallPathDiagnostics;
+    };
+
+export type GameInstallPathConflictResolveResult =
+  | {
+      ok: true;
+      action: GameInstallPathConflictAction;
+      path: string;
+      diagnostics: GameInstallPathDiagnostics;
+    }
+  | {
+      ok: false;
+      action: GameInstallPathConflictAction;
+      path?: string;
+      verification: GameInstallPathVerificationStatus;
+      error?: string;
+      diagnostics?: GameInstallPathDiagnostics;
+    };
 
 export interface PatchReservation {
   id: string; // 고유 ID (UUID 또는 timestamp)
@@ -320,6 +427,24 @@ export interface ElectronAPI {
   ) => () => void;
 
   triggerGameStart: (context: GameLaunchContext) => void;
+  getGameInstallPathDiagnostics: (
+    serviceId: AppConfig["serviceChannel"],
+    gameId: AppConfig["activeGame"],
+  ) => Promise<GameInstallPathDiagnostics>;
+  setGameInstallPath: (
+    serviceId: AppConfig["serviceChannel"],
+    gameId: AppConfig["activeGame"],
+    installPath: string,
+  ) => Promise<GameInstallPathSaveResult>;
+  pickGameInstallPath: (
+    serviceId: AppConfig["serviceChannel"],
+    gameId: AppConfig["activeGame"],
+  ) => Promise<GameInstallPathSaveResult>;
+  resolveGameInstallPathConflict: (
+    serviceId: AppConfig["serviceChannel"],
+    gameId: AppConfig["activeGame"],
+    action: GameInstallPathConflictAction,
+  ) => Promise<GameInstallPathConflictResolveResult>;
   minimizeWindow: () => void;
   closeWindow: () => void;
   getConfig: (


### PR DESCRIPTION
## Summary

- 게임 설치 경로 탐색 우선순위를 런처 설정값과 레지스트리 fallback 기준으로 정리하고, 수동 경로 지정 및 진단 모달을 추가했습니다.
- 런처 설정 경로와 레지스트리 경로가 다를 때 비교, 선택, 레지스트리 반영 여부를 확인하는 흐름을 추가했습니다.
- 커스텀 폰트 설정 접근성을 개선하고 커스텀 폰트 관리 및 한국인 모드의 베타 표기를 제거했습니다.
- 카카오게임즈 페이지 구조 변경에 맞춰 설정 계정의 로그인 확인 DOM 판별을 갱신했습니다.

## Motivation

게임이 설치되어 있어도 런처가 경로를 감지하지 못하거나, 외부 요인으로 레지스트리와 런처 설정이 어긋나는 상황에서 사용자가 경로를 직접 진단하고 복구할 수 있게 하기 위함입니다. 또한 카카오게임즈 페이지 구조 변경 이후 설정 계정의 로그인 확인이 멈추는 문제를 해소합니다.
