### PR TITLE
fix: 카카오게임즈 설치 감지에서 PathOfExile_KG.exe를 확인하도록 수정

### DIFF
--- a/src/main/tests/registry-install-status.test.ts
+++ b/src/main/tests/registry-install-status.test.ts
@@ -131,6 +131,24 @@ HKEY_CURRENT_USER\\Software\\DaumGames\\POE2
     ).resolves.toBe("installed");
     await expect(isGameInstalled("Kakao Games", "POE2")).resolves.toBe(true);
 
+    expect(mocks.stat).toHaveBeenCalledWith(
+      `${installPath}\\PathOfExile_KG.exe`,
+    );
+  });
+
+  it("keeps GGG install verification on PathOfExile.exe", async () => {
+    const installPath = String.raw`C:\Games\Path of Exile 2`;
+    mocks.powershellExecute.mockResolvedValue({
+      stdout: installPath,
+      stderr: "",
+      code: 0,
+    });
+    mocks.stat.mockResolvedValue({ isFile: () => true });
+
+    await expect(getGameInstallationStatus("GGG", "POE2")).resolves.toBe(
+      "installed",
+    );
+
     expect(mocks.stat).toHaveBeenCalledWith(`${installPath}\\PathOfExile.exe`);
   });
 
@@ -271,7 +289,7 @@ HKEY_CURRENT_USER\\Software\\DaumGames\\POE2
       }),
     );
     mocks.stat.mockImplementation(async (targetPath: string) => {
-      if (targetPath === `${stalePath}\\PathOfExile.exe`) {
+      if (targetPath === `${stalePath}\\PathOfExile_KG.exe`) {
         throw Object.assign(new Error("missing"), { code: "ENOENT" });
       }
 
@@ -306,7 +324,7 @@ HKEY_CURRENT_USER\\Software\\DaumGames\\POE2
       }),
     );
     mocks.stat.mockImplementation(async (targetPath: string) => {
-      if (targetPath === `${stalePath}\\PathOfExile.exe`) {
+      if (targetPath === `${stalePath}\\PathOfExile_KG.exe`) {
         throw Object.assign(new Error("missing"), { code: "ENOENT" });
       }
 
@@ -325,7 +343,7 @@ HKEY_CURRENT_USER\\Software\\DaumGames\\POE2
 
     expect(diagnostics.hasPathConflict).toBe(true);
     expect(diagnostics.recommendedSource).toBe("registry");
-    expect(diagnostics.executableName).toBe("PathOfExile.exe");
+    expect(diagnostics.executableName).toBe("PathOfExile_KG.exe");
     expect(diagnostics.config.path).toBe(stalePath);
     expect(diagnostics.config.verification).toBe("missing");
     expect(diagnostics.registry.path).toBe(registryPath);
@@ -535,7 +553,7 @@ HKEY_CURRENT_USER\\Software\\DaumGames\\POE2
     });
   });
 
-  it("rejects a manually selected folder without PathOfExile.exe", async () => {
+  it("rejects a manually selected Kakao folder without PathOfExile_KG.exe", async () => {
     const installPath = String.raw`E:\Games\Path of Exile 2`;
     mocks.contextProviderGet.mockReturnValue(
       createContext({
@@ -599,7 +617,7 @@ HKEY_CURRENT_USER\\Software\\DaumGames\\POE2
     );
   });
 
-  it("returns uninstalled when a registry path does not contain PathOfExile.exe", async () => {
+  it("returns uninstalled when a Kakao registry path does not contain PathOfExile_KG.exe", async () => {
     const installPath = String.raw`C:\Games\Path of Exile 2`;
     mocks.powershellExecute.mockResolvedValue({
       stdout: installPath,
@@ -619,7 +637,7 @@ HKEY_CURRENT_USER\\Software\\DaumGames\\POE2
       expect.stringContaining("registry=path-invalid"),
     );
     expect(mocks.loggerLog).toHaveBeenCalledWith(
-      expect.stringContaining("PathOfExile.exe missing"),
+      expect.stringContaining("PathOfExile_KG.exe missing"),
     );
   });
 

--- a/src/main/utils/registry.ts
+++ b/src/main/utils/registry.ts
@@ -57,7 +57,13 @@ type ConfiguredInstallPathResult =
   | { state: "found"; path: string }
   | { state: "empty" | "context-unavailable"; path: null };
 
-const GAME_EXECUTABLE_NAME = "PathOfExile.exe";
+const GAME_EXECUTABLE_NAMES = {
+  "Kakao Games": "PathOfExile_KG.exe",
+  GGG: "PathOfExile.exe",
+} as const satisfies Record<ServiceChannel, string>;
+
+const getGameExecutableName = (serviceId: AppConfig["serviceChannel"]) =>
+  GAME_EXECUTABLE_NAMES[serviceId];
 
 /**
  * Registry Mapping for Game Installation Paths
@@ -577,17 +583,20 @@ export const writeRegistryValue = async (
   }
 };
 
-const getGameExecutablePath = (installPath: string) =>
-  path.join(installPath, GAME_EXECUTABLE_NAME);
+const getGameExecutablePath = (
+  serviceId: AppConfig["serviceChannel"],
+  installPath: string,
+) => path.join(installPath, getGameExecutableName(serviceId));
 
 const verifyGameInstallPath = async (
+  serviceId: AppConfig["serviceChannel"],
   installPath: string,
 ): Promise<{
   status: InstallPathVerificationStatus;
   executablePath: string;
   error?: string;
 }> => {
-  const executablePath = getGameExecutablePath(installPath);
+  const executablePath = getGameExecutablePath(serviceId, installPath);
 
   try {
     const stats = await fs.stat(executablePath);
@@ -657,15 +666,17 @@ const formatDiagnostics = (diagnostics: string[]) => {
 };
 
 const formatPathCheckFailure = (
+  serviceId: AppConfig["serviceChannel"],
   source: "config" | "registry",
   installPath: string,
   status: InstallPathVerificationStatus,
   error?: string,
 ) => {
-  const executablePath = getGameExecutablePath(installPath);
+  const executableName = getGameExecutableName(serviceId);
+  const executablePath = getGameExecutablePath(serviceId, installPath);
 
   if (status === "missing") {
-    return `${source}=path-invalid (${GAME_EXECUTABLE_NAME} missing at ${executablePath})`;
+    return `${source}=path-invalid (${executableName} missing at ${executablePath})`;
   }
 
   return `${source}=path-check-blocked (${executablePath}: ${error || "unknown error"})`;
@@ -698,7 +709,10 @@ const resolveGameInstallPath = async (
 
   if (configuredPath.path !== null) {
     const configuredInstallPath = configuredPath.path;
-    const configuredStatus = await verifyGameInstallPath(configuredInstallPath);
+    const configuredStatus = await verifyGameInstallPath(
+      serviceId,
+      configuredInstallPath,
+    );
 
     if (configuredStatus.status === "valid") {
       return { path: configuredInstallPath, source: "config", diagnostics };
@@ -707,6 +721,7 @@ const resolveGameInstallPath = async (
     configuredVerifyError = configuredStatus.error;
     diagnostics.push(
       formatPathCheckFailure(
+        serviceId,
         "config",
         configuredInstallPath,
         configuredStatus.status,
@@ -732,7 +747,10 @@ const resolveGameInstallPath = async (
     return { path: null, verifyError: configuredVerifyError, diagnostics };
   }
 
-  const registryStatus = await verifyGameInstallPath(registryResult.value);
+  const registryStatus = await verifyGameInstallPath(
+    serviceId,
+    registryResult.value,
+  );
 
   if (registryStatus.status === "valid") {
     if (configuredPath.state === "empty") {
@@ -748,6 +766,7 @@ const resolveGameInstallPath = async (
 
   diagnostics.push(
     formatPathCheckFailure(
+      serviceId,
       "registry",
       registryResult.value,
       registryStatus.status,
@@ -806,7 +825,10 @@ export const getGameInstallPathDiagnostics = async (
   };
 
   if (configuredPath.path) {
-    const verification = await verifyGameInstallPath(configuredPath.path);
+    const verification = await verifyGameInstallPath(
+      serviceId,
+      configuredPath.path,
+    );
     configDiagnostic.verification = verification.status;
     configDiagnostic.executablePath = verification.executablePath;
     configDiagnostic.error = verification.error;
@@ -825,7 +847,10 @@ export const getGameInstallPathDiagnostics = async (
   };
 
   if (registryResult.ok && registryResult.value) {
-    const verification = await verifyGameInstallPath(registryResult.value);
+    const verification = await verifyGameInstallPath(
+      serviceId,
+      registryResult.value,
+    );
     registryDiagnostic.verification = verification.status;
     registryDiagnostic.executablePath = verification.executablePath;
     registryDiagnostic.error = verification.error;
@@ -838,7 +863,7 @@ export const getGameInstallPathDiagnostics = async (
   return {
     serviceId,
     gameId,
-    executableName: GAME_EXECUTABLE_NAME,
+    executableName: getGameExecutableName(serviceId),
     config: configDiagnostic,
     registry: registryDiagnostic,
     hasPathConflict,
@@ -872,7 +897,10 @@ export const setGameInstallPath = async (
     };
   }
 
-  const verification = await verifyGameInstallPath(normalizedInstallPath);
+  const verification = await verifyGameInstallPath(
+    serviceId,
+    normalizedInstallPath,
+  );
   if (verification.status !== "valid") {
     return {
       ok: false,
@@ -880,7 +908,7 @@ export const setGameInstallPath = async (
       verification: verification.status,
       error:
         verification.error ||
-        `${GAME_EXECUTABLE_NAME} was not found in the selected folder.`,
+        `${getGameExecutableName(serviceId)}를 선택한 폴더에서 찾을 수 없습니다.`,
       diagnostics: await getGameInstallPathDiagnostics(serviceId, gameId),
     };
   }
@@ -927,7 +955,7 @@ export const resolveGameInstallPathConflict = async (
     };
   }
 
-  const verification = await verifyGameInstallPath(configPath);
+  const verification = await verifyGameInstallPath(serviceId, configPath);
   if (verification.status !== "valid") {
     return {
       ok: false,
@@ -936,7 +964,7 @@ export const resolveGameInstallPathConflict = async (
       verification: verification.status,
       error:
         verification.error ||
-        `${GAME_EXECUTABLE_NAME} was not found in the launcher config path.`,
+        `런처 설정 경로에서 ${getGameExecutableName(serviceId)}를 찾을 수 없습니다.`,
       diagnostics,
     };
   }
@@ -1084,7 +1112,7 @@ export const setDaumGameStarterCommand = async (
 };
 
 /**
- * Checks if the game is installed by verifying PathOfExile.exe in the resolved folder.
+ * Checks if the game is installed by verifying the service-specific executable in the resolved folder.
  */
 export const getGameInstallationStatus = async (
   serviceId: AppConfig["serviceChannel"],

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -148,7 +148,7 @@ const getGamePathSaveErrorMessage = (
   fallback?: string,
 ) => {
   if (verification === "missing") {
-    return "선택한 폴더에서 PathOfExile.exe를 찾을 수 없습니다.";
+    return fallback || "선택한 폴더에서 게임 실행 파일을 찾을 수 없습니다.";
   }
 
   if (verification === "unknown") {


### PR DESCRIPTION
## 요약

- 카카오게임즈 설치 경로 검증 시 `PathOfExile_KG.exe`를 확인하도록 수정했습니다.
- GGG 채널은 기존처럼 `PathOfExile.exe` 기준을 유지합니다.
- 수동 경로 지정 실패 메시지가 서비스별 실행 파일명에 맞게 표시되도록 정리했습니다.

## 배경

1.4.0에서 설치 감지를 폴더 존재 여부가 아니라 실행 파일 존재 여부로 강화하면서 모든 서비스에 `PathOfExile.exe` 기준이 적용되었습니다. 카카오게임즈 설치본은 실행 파일명이 `PathOfExile_KG.exe`라서 정상 설치 상태에서도 런처가 설치를 감지하지 못할 수 있었습니다.