### PR TITLE
게임 경로 수동 설정 반영 및 경로 삭제 개선

### DIFF
--- a/src/main/events/handlers/GameInstallCheckHandler.ts
+++ b/src/main/events/handlers/GameInstallCheckHandler.ts
@@ -1,13 +1,13 @@
-import { AppConfig } from "../../../shared/types";
-import { logger } from "../../utils/logger";
-import { getGameInstallationStatus } from "../../utils/registry";
-import { eventBus } from "../EventBus";
+import {
+  getGameInstallStatusContextsForConfigChange,
+  reconcileGameInstallStatus,
+  shouldReconcileGameInstallStatusOnConfigChange,
+} from "../../game/GameInstallStatusReconciler";
 import {
   AppContext,
   EventHandler,
-  EventType,
-  GameStatusChangeEvent,
   ConfigChangeEvent,
+  EventType,
 } from "../types";
 
 /**
@@ -17,94 +17,15 @@ export const GameInstallCheckHandler: EventHandler<ConfigChangeEvent> = {
   id: "GameInstallCheckHandler",
   targetEvent: EventType.CONFIG_CHANGE,
 
-  condition: (event) => {
-    return (
-      event.payload.key === "activeGame" ||
-      event.payload.key === "serviceChannel"
-    );
-  },
+  condition: (event) => shouldReconcileGameInstallStatusOnConfigChange(event),
 
-  handle: async (_event, context: AppContext) => {
-    const config = context.getConfig() as AppConfig;
-    const { activeGame, serviceChannel } = config;
+  handle: async (event, context: AppContext) => {
+    const targets = getGameInstallStatusContextsForConfigChange(event, context);
 
-    logger.log(
-      `[GameInstallCheckHandler] Checking installation for ${activeGame} (${serviceChannel})...`,
-    );
-
-    const installationStatus = await getGameInstallationStatus(
-      serviceChannel,
-      activeGame,
-    );
-
-    // [Fix] Check if the game is already RUNNING before resetting to 'idle'
-    // This prevents status flickering or resetting when switching tabs while game is open.
-    // [Refactor] Use explicit process mapping for accurate status detection
-    // This prevents POE1 activity from falsely reporting POE2 as running (and vice versa).
-    // Previously, we relied on generic 'GameServiceProfiles' which mapped both to 'PathOfExile_KG.exe', causing cross-talk.
-
-    let targetProcessName: string;
-    let criteria:
-      | ((info: { pid: number; path: string }) => boolean)
-      | undefined;
-
-    if (serviceChannel === "Kakao Games") {
-      // Use specific Launcher names for Kakao to distinguish games
-      targetProcessName =
-        activeGame === "POE2" ? "POE2_Launcher.exe" : "POE_Launcher.exe";
-    } else {
-      // GGG uses the same process name but different paths
-      targetProcessName = "PathOfExile.exe";
-      criteria = (info) => {
-        const lowerPath = info.path.toLowerCase();
-        if (activeGame === "POE2") {
-          return lowerPath.includes("path of exile 2");
-        } else {
-          // POE1: Must include "path of exile" but NOT "path of exile 2"
-          return (
-            lowerPath.includes("path of exile") &&
-            !lowerPath.includes("path of exile 2")
-          );
-        }
-      };
+    for (const { serviceId, gameId } of targets) {
+      await reconcileGameInstallStatus(context, serviceId, gameId, {
+        reason: `config-change:${event.payload.key}`,
+      });
     }
-
-    const isRunning =
-      targetProcessName &&
-      context.processWatcher?.isProcessRunning(targetProcessName, criteria);
-
-    if (isRunning) {
-      logger.log(
-        `[GameInstallCheckHandler] Game ${activeGame} (${serviceChannel}) is currently RUNNING. Emitting 'running' status.`,
-      );
-      eventBus.emit<GameStatusChangeEvent>(
-        EventType.GAME_STATUS_CHANGE,
-        context,
-        {
-          gameId: activeGame,
-          serviceId: serviceChannel,
-          status: "running",
-        },
-      );
-      return;
-    }
-
-    eventBus.emit<GameStatusChangeEvent>(
-      EventType.GAME_STATUS_CHANGE,
-      context,
-      {
-        gameId: activeGame,
-        serviceId: serviceChannel,
-        status:
-          installationStatus === "uninstalled"
-            ? "uninstalled"
-            : installationStatus === "unknown"
-              ? "install_check_blocked"
-              : "idle",
-        ...(installationStatus === "unknown"
-          ? { errorCode: "INSTALL_CHECK_UNKNOWN" }
-          : {}),
-      },
-    );
   },
 };

--- a/src/main/game/GameInstallStatusReconciler.ts
+++ b/src/main/game/GameInstallStatusReconciler.ts
@@ -1,0 +1,206 @@
+import { CONFIG_KEYS } from "../../shared/config";
+import {
+  ACTIVE_GAMES,
+  AppConfig,
+  GameInstallPaths,
+  SERVICE_CHANNELS,
+} from "../../shared/types";
+import { eventBus } from "../events/EventBus";
+import {
+  AppContext,
+  ConfigChangeEvent,
+  EventType,
+  GameStatusChangeEvent,
+} from "../events/types";
+import {
+  getGameStatus,
+  shouldPreserveRuntimeGameStatus,
+} from "../state/GameStatusStore";
+import { logger } from "../utils/logger";
+import {
+  GameInstallationStatus,
+  getGameInstallationStatus,
+} from "../utils/registry";
+
+export interface GameInstallStatusContext {
+  gameId: AppConfig["activeGame"];
+  serviceId: AppConfig["serviceChannel"];
+}
+
+type ProcessCriteria = NonNullable<
+  AppContext["processWatcher"]
+>["isProcessRunning"] extends (
+  name: string,
+  criteria?: infer Criteria,
+) => boolean
+  ? Criteria
+  : never;
+
+export const GAME_INSTALL_STATUS_CONTEXTS: readonly GameInstallStatusContext[] =
+  SERVICE_CHANNELS.flatMap((serviceId) =>
+    ACTIVE_GAMES.map((gameId) => ({ gameId, serviceId })),
+  );
+
+export const shouldReconcileGameInstallStatusOnConfigChange = (
+  event: ConfigChangeEvent,
+) =>
+  event.payload.key === CONFIG_KEYS.ACTIVE_GAME ||
+  event.payload.key === CONFIG_KEYS.SERVICE_CHANNEL ||
+  event.payload.key === CONFIG_KEYS.GAME_INSTALL_PATHS;
+
+const getPathValue = (
+  value: unknown,
+  serviceId: AppConfig["serviceChannel"],
+  gameId: AppConfig["activeGame"],
+) => {
+  if (!value || typeof value !== "object") return "";
+
+  const servicePaths = (value as Partial<GameInstallPaths>)[serviceId];
+  if (!servicePaths || typeof servicePaths !== "object") return "";
+
+  const installPath = servicePaths[gameId];
+  return typeof installPath === "string" ? installPath : "";
+};
+
+const getChangedGameInstallPathContexts = (
+  oldValue: unknown,
+  newValue: unknown,
+): GameInstallStatusContext[] =>
+  GAME_INSTALL_STATUS_CONTEXTS.filter(
+    ({ serviceId, gameId }) =>
+      getPathValue(oldValue, serviceId, gameId) !==
+      getPathValue(newValue, serviceId, gameId),
+  );
+
+export const getGameInstallStatusContextsForConfigChange = (
+  event: ConfigChangeEvent,
+  context: AppContext,
+): GameInstallStatusContext[] => {
+  if (event.payload.key === CONFIG_KEYS.GAME_INSTALL_PATHS) {
+    return getChangedGameInstallPathContexts(
+      event.payload.oldValue,
+      event.payload.newValue,
+    );
+  }
+
+  if (
+    event.payload.key === CONFIG_KEYS.ACTIVE_GAME ||
+    event.payload.key === CONFIG_KEYS.SERVICE_CHANNEL
+  ) {
+    const config = context.getConfig() as AppConfig;
+    return [{ gameId: config.activeGame, serviceId: config.serviceChannel }];
+  }
+
+  return [];
+};
+
+const mapInstallationStatusToRunStatus = (
+  installationStatus: GameInstallationStatus,
+) =>
+  installationStatus === "uninstalled"
+    ? "uninstalled"
+    : installationStatus === "unknown"
+      ? "install_check_blocked"
+      : "idle";
+
+const getInstallCheckErrorPayload = (
+  installationStatus: GameInstallationStatus,
+) =>
+  installationStatus === "unknown"
+    ? { errorCode: "INSTALL_CHECK_UNKNOWN" }
+    : {};
+
+const getProcessCheck = (
+  serviceId: AppConfig["serviceChannel"],
+  gameId: AppConfig["activeGame"],
+): { name: string; criteria?: ProcessCriteria } => {
+  if (serviceId === "Kakao Games") {
+    return {
+      name: gameId === "POE2" ? "POE2_Launcher.exe" : "POE_Launcher.exe",
+    };
+  }
+
+  return {
+    name: "PathOfExile.exe",
+    criteria: (info) => {
+      const lowerPath = info.path.toLowerCase();
+      if (gameId === "POE2") {
+        return lowerPath.includes("path of exile 2");
+      }
+
+      return (
+        lowerPath.includes("path of exile") &&
+        !lowerPath.includes("path of exile 2")
+      );
+    },
+  };
+};
+
+const isGameProcessRunning = (
+  context: AppContext,
+  serviceId: AppConfig["serviceChannel"],
+  gameId: AppConfig["activeGame"],
+) => {
+  const processCheck = getProcessCheck(serviceId, gameId);
+  return context.processWatcher?.isProcessRunning(
+    processCheck.name,
+    processCheck.criteria,
+  );
+};
+
+const emitGameStatus = async (
+  context: AppContext,
+  payload: GameStatusChangeEvent["payload"],
+) => {
+  await eventBus.emit<GameStatusChangeEvent>(
+    EventType.GAME_STATUS_CHANGE,
+    context,
+    payload,
+  );
+};
+
+export const reconcileGameInstallStatus = async (
+  context: AppContext,
+  serviceId: AppConfig["serviceChannel"],
+  gameId: AppConfig["activeGame"],
+  options: { reason?: string } = {},
+) => {
+  const label = `${gameId} (${serviceId})`;
+  const reason = options.reason ? `; reason=${options.reason}` : "";
+
+  const currentStatus = getGameStatus(gameId, serviceId);
+  if (shouldPreserveRuntimeGameStatus(currentStatus)) {
+    logger.log(
+      `[GameInstallStatus] Preserving active runtime status for ${label}: ${currentStatus.status}${reason}`,
+    );
+    return;
+  }
+
+  if (isGameProcessRunning(context, serviceId, gameId)) {
+    logger.log(
+      `[GameInstallStatus] Game ${label} is currently running. Emitting running status${reason}.`,
+    );
+    await emitGameStatus(context, { gameId, serviceId, status: "running" });
+    return;
+  }
+
+  logger.log(
+    `[GameInstallStatus] Checking installation for ${label}${reason}.`,
+  );
+  const installationStatus = await getGameInstallationStatus(serviceId, gameId);
+
+  const latestStatus = getGameStatus(gameId, serviceId);
+  if (shouldPreserveRuntimeGameStatus(latestStatus)) {
+    logger.log(
+      `[GameInstallStatus] Preserving active runtime status after install check for ${label}: ${latestStatus.status}${reason}`,
+    );
+    return;
+  }
+
+  await emitGameStatus(context, {
+    gameId,
+    serviceId,
+    status: mapInstallationStatusToRunStatus(installationStatus),
+    ...getInstallCheckErrorPayload(installationStatus),
+  });
+};

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -107,6 +107,7 @@ import { PowerShellManager } from "./utils/powershell";
 import {
   getGameInstallPath,
   getGameInstallPathDiagnostics,
+  clearGameInstallPath,
   resolveGameInstallPathConflict,
   setGameInstallPath,
   syncInstallLocation,
@@ -790,6 +791,36 @@ ipcMain.handle(
     }
 
     return resolveGameInstallPathConflict(serviceId, gameId, action);
+  },
+);
+
+ipcMain.handle(
+  "game-install-path:clear",
+  async (
+    _event,
+    serviceId: AppConfig["serviceChannel"],
+    gameId: AppConfig["activeGame"],
+    source: "config" | "registry",
+  ) => {
+    if (!isSupportedGameInstallContext(serviceId, gameId)) {
+      throw new Error(
+        `Unsupported game install context: ${serviceId}/${gameId}`,
+      );
+    }
+
+    if (source !== "config" && source !== "registry") {
+      throw new Error(`Unsupported game install path clear source: ${source}`);
+    }
+
+    const result = await clearGameInstallPath(serviceId, gameId, source);
+
+    if (result.ok && source === "registry") {
+      await reconcileGameInstallStatus(appContext, serviceId, gameId, {
+        reason: "manual-registry-path-clear",
+      });
+    }
+
+    return result;
   },
 );
 

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -59,6 +59,10 @@ import {
   IServiceManager,
   UIEvent,
 } from "./events/types";
+import {
+  GAME_INSTALL_STATUS_CONTEXTS,
+  reconcileGameInstallStatus,
+} from "./game/GameInstallStatusReconciler";
 import { GameSessionTracker, SessionContext } from "./game/GameSessionTracker";
 import { registerGameStatusIpc } from "./ipc/game-status-ipc";
 import {
@@ -85,10 +89,6 @@ import {
 } from "./services/register-services";
 import { serviceManager } from "./services/ServiceManager";
 import { themeCacheManager } from "./services/ThemeCacheManager";
-import {
-  getGameStatus,
-  shouldPreserveRuntimeGameStatus,
-} from "./state/GameStatusStore";
 import { getConfig, setupStoreObservers, default as store } from "./store";
 import {
   isAdmin,
@@ -107,7 +107,6 @@ import { PowerShellManager } from "./utils/powershell";
 import {
   getGameInstallPath,
   getGameInstallPathDiagnostics,
-  getGameInstallationStatus,
   resolveGameInstallPathConflict,
   setGameInstallPath,
   syncInstallLocation,
@@ -2216,56 +2215,13 @@ async function createWindow() {
   );
 
   // Perform initial installation check for ALL contexts
-  // const initialConfig = getConfig() as AppConfig; (Removed: unused)
   const checkAllGameStatuses = async () => {
-    const combinations = [
-      { game: "POE1", service: "Kakao Games" },
-      { game: "POE2", service: "Kakao Games" },
-      { game: "POE1", service: "GGG" },
-      { game: "POE2", service: "GGG" },
-    ] as const;
-
     logger.log("[Main] Checking initial status for all game contexts...");
 
-    for (const combo of combinations) {
-      const currentStatus = getGameStatus(combo.game, combo.service);
-      if (shouldPreserveRuntimeGameStatus(currentStatus)) {
-        logger.log(
-          `[Main] Preserving active runtime status for ${combo.game} (${combo.service}): ${currentStatus.status}`,
-        );
-        continue;
-      }
-
-      const installationStatus = await getGameInstallationStatus(
-        combo.service as AppConfig["serviceChannel"],
-        combo.game as AppConfig["activeGame"],
-      );
-
-      const latestStatus = getGameStatus(combo.game, combo.service);
-      if (shouldPreserveRuntimeGameStatus(latestStatus)) {
-        logger.log(
-          `[Main] Preserving active runtime status after install check for ${combo.game} (${combo.service}): ${latestStatus.status}`,
-        );
-        continue;
-      }
-
-      await eventBus.emit<GameStatusChangeEvent>(
-        EventType.GAME_STATUS_CHANGE,
-        appContext,
-        {
-          gameId: combo.game as AppConfig["activeGame"],
-          serviceId: combo.service as AppConfig["serviceChannel"],
-          status:
-            installationStatus === "uninstalled"
-              ? "uninstalled"
-              : installationStatus === "unknown"
-                ? "install_check_blocked"
-                : "idle",
-          ...(installationStatus === "unknown"
-            ? { errorCode: "INSTALL_CHECK_UNKNOWN" }
-            : {}),
-        },
-      );
+    for (const { serviceId, gameId } of GAME_INSTALL_STATUS_CONTEXTS) {
+      await reconcileGameInstallStatus(appContext, serviceId, gameId, {
+        reason: "initial-status-check",
+      });
     }
   };
 

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -19,6 +19,8 @@ import {
   KakaoGameStarterMigrationRequest,
   GameInstallPathConflictAction,
   GameInstallPathConflictResolveResult,
+  GameInstallPathClearResult,
+  GameInstallPathClearSource,
   GameInstallPathDiagnostics,
   GameInstallPathSaveResult,
 } from "../shared/types";
@@ -60,6 +62,12 @@ contextBridge.exposeInMainWorld("electronAPI", {
       gameId,
       action,
     ),
+  clearGameInstallPath: (
+    serviceId: AppConfig["serviceChannel"],
+    gameId: AppConfig["activeGame"],
+    source: GameInstallPathClearSource,
+  ): Promise<GameInstallPathClearResult> =>
+    ipcRenderer.invoke("game-install-path:clear", serviceId, gameId, source),
   minimizeWindow: () => ipcRenderer.send("window-minimize"),
   closeWindow: () => ipcRenderer.send("window-close"),
   getConfig: (

--- a/src/main/tests/GameInstallCheckHandler.test.ts
+++ b/src/main/tests/GameInstallCheckHandler.test.ts
@@ -1,26 +1,24 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { eventBus } from "../events/EventBus";
 import { GameInstallCheckHandler } from "../events/handlers/GameInstallCheckHandler";
 import {
   EventType,
   type AppContext,
   type ConfigChangeEvent,
 } from "../events/types";
-import { getGameInstallationStatus } from "../utils/registry";
 
 const mocks = vi.hoisted(() => ({
-  getGameInstallationStatus: vi.fn(),
+  getGameInstallStatusContextsForConfigChange: vi.fn(),
+  reconcileGameInstallStatus: vi.fn(),
+  shouldReconcileGameInstallStatusOnConfigChange: vi.fn(),
 }));
 
-vi.mock("../events/EventBus", () => ({
-  eventBus: {
-    emit: vi.fn(),
-  },
-}));
-
-vi.mock("../utils/registry", () => ({
-  getGameInstallationStatus: mocks.getGameInstallationStatus,
+vi.mock("../game/GameInstallStatusReconciler", () => ({
+  getGameInstallStatusContextsForConfigChange:
+    mocks.getGameInstallStatusContextsForConfigChange,
+  reconcileGameInstallStatus: mocks.reconcileGameInstallStatus,
+  shouldReconcileGameInstallStatusOnConfigChange:
+    mocks.shouldReconcileGameInstallStatusOnConfigChange,
 }));
 
 const configChangeEvent: ConfigChangeEvent = {
@@ -37,30 +35,45 @@ describe("GameInstallCheckHandler", () => {
     vi.clearAllMocks();
   });
 
-  it("emits a blocked install-check status when installation status is unknown", async () => {
-    vi.mocked(getGameInstallationStatus).mockResolvedValue("unknown");
+  it("delegates config-change filtering to the install status reconciler", () => {
+    mocks.shouldReconcileGameInstallStatusOnConfigChange.mockReturnValue(true);
+
+    expect(
+      GameInstallCheckHandler.condition?.(configChangeEvent, {} as AppContext),
+    ).toBe(true);
+    expect(
+      mocks.shouldReconcileGameInstallStatusOnConfigChange,
+    ).toHaveBeenCalledWith(configChangeEvent);
+  });
+
+  it("reconciles every install status context affected by the config change", async () => {
+    mocks.getGameInstallStatusContextsForConfigChange.mockReturnValue([
+      { gameId: "POE2", serviceId: "Kakao Games" },
+      { gameId: "POE1", serviceId: "GGG" },
+    ]);
 
     const context = {
       getConfig: vi.fn(() => ({
         activeGame: "POE2",
         serviceChannel: "Kakao Games",
       })),
-      processWatcher: {
-        isProcessRunning: vi.fn(() => false),
-      },
     } as unknown as AppContext;
 
     await GameInstallCheckHandler.handle(configChangeEvent, context);
 
-    expect(eventBus.emit).toHaveBeenCalledWith(
-      EventType.GAME_STATUS_CHANGE,
+    expect(mocks.reconcileGameInstallStatus).toHaveBeenNthCalledWith(
+      1,
       context,
-      {
-        gameId: "POE2",
-        serviceId: "Kakao Games",
-        status: "install_check_blocked",
-        errorCode: "INSTALL_CHECK_UNKNOWN",
-      },
+      "Kakao Games",
+      "POE2",
+      { reason: "config-change:activeGame" },
+    );
+    expect(mocks.reconcileGameInstallStatus).toHaveBeenNthCalledWith(
+      2,
+      context,
+      "GGG",
+      "POE1",
+      { reason: "config-change:activeGame" },
     );
   });
 });

--- a/src/main/tests/GameInstallStatusReconciler.test.ts
+++ b/src/main/tests/GameInstallStatusReconciler.test.ts
@@ -1,0 +1,147 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { DEFAULT_CONFIG, CONFIG_KEYS } from "../../shared/config";
+import { eventBus } from "../events/EventBus";
+import {
+  EventType,
+  type AppContext,
+  type ConfigChangeEvent,
+} from "../events/types";
+import {
+  getGameInstallStatusContextsForConfigChange,
+  reconcileGameInstallStatus,
+} from "../game/GameInstallStatusReconciler";
+import {
+  resetGameStatusCacheForTests,
+  updateGameStatusCache,
+} from "../state/GameStatusStore";
+import { getGameInstallationStatus } from "../utils/registry";
+
+const mocks = vi.hoisted(() => ({
+  eventBusEmit: vi.fn(),
+  getGameInstallationStatus: vi.fn(),
+  loggerLog: vi.fn(),
+}));
+
+vi.mock("../events/EventBus", () => ({
+  eventBus: {
+    emit: mocks.eventBusEmit,
+  },
+}));
+
+vi.mock("../utils/logger", () => ({
+  logger: {
+    log: mocks.loggerLog,
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("../utils/registry", () => ({
+  getGameInstallationStatus: mocks.getGameInstallationStatus,
+}));
+
+const createContext = (processRunning = false) =>
+  ({
+    getConfig: vi.fn(() => ({
+      activeGame: "POE2",
+      serviceChannel: "Kakao Games",
+    })),
+    processWatcher: {
+      isProcessRunning: vi.fn(() => processRunning),
+    },
+  }) as unknown as AppContext;
+
+describe("GameInstallStatusReconciler", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetGameStatusCacheForTests();
+  });
+
+  it("emits idle when the install path is valid", async () => {
+    vi.mocked(getGameInstallationStatus).mockResolvedValue("installed");
+    const context = createContext();
+
+    await reconcileGameInstallStatus(context, "Kakao Games", "POE2");
+
+    expect(eventBus.emit).toHaveBeenCalledWith(
+      EventType.GAME_STATUS_CHANGE,
+      context,
+      {
+        gameId: "POE2",
+        serviceId: "Kakao Games",
+        status: "idle",
+      },
+    );
+  });
+
+  it("emits install_check_blocked when install status cannot be verified", async () => {
+    vi.mocked(getGameInstallationStatus).mockResolvedValue("unknown");
+    const context = createContext();
+
+    await reconcileGameInstallStatus(context, "Kakao Games", "POE2");
+
+    expect(eventBus.emit).toHaveBeenCalledWith(
+      EventType.GAME_STATUS_CHANGE,
+      context,
+      {
+        gameId: "POE2",
+        serviceId: "Kakao Games",
+        status: "install_check_blocked",
+        errorCode: "INSTALL_CHECK_UNKNOWN",
+      },
+    );
+  });
+
+  it("does not downgrade an active runtime status", async () => {
+    updateGameStatusCache({
+      gameId: "POE2",
+      serviceId: "Kakao Games",
+      status: "running",
+    });
+
+    await reconcileGameInstallStatus(createContext(), "Kakao Games", "POE2");
+
+    expect(getGameInstallationStatus).not.toHaveBeenCalled();
+    expect(eventBus.emit).not.toHaveBeenCalled();
+  });
+
+  it("keeps a detected running process stronger than install status", async () => {
+    const context = createContext(true);
+
+    await reconcileGameInstallStatus(context, "Kakao Games", "POE2");
+
+    expect(getGameInstallationStatus).not.toHaveBeenCalled();
+    expect(eventBus.emit).toHaveBeenCalledWith(
+      EventType.GAME_STATUS_CHANGE,
+      context,
+      {
+        gameId: "POE2",
+        serviceId: "Kakao Games",
+        status: "running",
+      },
+    );
+  });
+
+  it("targets only service/game pairs whose saved install path changed", () => {
+    const nextPaths = {
+      ...DEFAULT_CONFIG.gameInstallPaths,
+      "Kakao Games": {
+        ...DEFAULT_CONFIG.gameInstallPaths["Kakao Games"],
+        POE2: String.raw`D:\Games\Path of Exile 2`,
+      },
+    };
+    const event: ConfigChangeEvent = {
+      type: EventType.CONFIG_CHANGE,
+      payload: {
+        key: CONFIG_KEYS.GAME_INSTALL_PATHS,
+        oldValue: DEFAULT_CONFIG.gameInstallPaths,
+        newValue: nextPaths,
+      },
+    };
+
+    expect(
+      getGameInstallStatusContextsForConfigChange(event, createContext()),
+    ).toEqual([{ serviceId: "Kakao Games", gameId: "POE2" }]);
+  });
+});

--- a/src/main/tests/registry-install-status.test.ts
+++ b/src/main/tests/registry-install-status.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { DEFAULT_CONFIG } from "../../shared/config";
 import { ACTIVE_GAMES, SERVICE_CHANNELS } from "../../shared/types";
 import {
+  clearGameInstallPath,
   GAME_INSTALL_REGISTRY_MAP,
   getGameInstallPath,
   getGameInstallPathDiagnostics,
@@ -580,6 +581,80 @@ HKEY_CURRENT_USER\\Software\\DaumGames\\POE2
 
     expect(result.verification).toBe("missing");
     expect(mocks.setConfigWithEvent).not.toHaveBeenCalled();
+  });
+
+  it("clears a saved launcher install path for a service/game pair", async () => {
+    const installPath = String.raw`E:\Games\Path of Exile 2`;
+    mocks.contextProviderGet.mockReturnValue(
+      createContext({
+        "Kakao Games": {
+          POE1: "",
+          POE2: installPath,
+        },
+        GGG: {
+          POE1: "",
+          POE2: "",
+        },
+      }),
+    );
+    mocks.powershellExecute.mockResolvedValue({
+      stdout: "__REG_VALUE_MISSING__",
+      stderr: "",
+      code: 0,
+    });
+
+    const result = await clearGameInstallPath("Kakao Games", "POE2", "config");
+
+    expect(result.ok).toBe(true);
+    expect(mocks.setConfigWithEvent).toHaveBeenCalledWith("gameInstallPaths", {
+      "Kakao Games": {
+        POE1: "",
+        POE2: "",
+      },
+      GGG: {
+        POE1: "",
+        POE2: "",
+      },
+    });
+  });
+
+  it("deletes a registry install path value", async () => {
+    const installPath = String.raw`E:\Games\Path of Exile 2`;
+    mocks.contextProviderGet.mockReturnValue(
+      createContext({
+        "Kakao Games": {
+          POE1: "",
+          POE2: installPath,
+        },
+        GGG: {
+          POE1: "",
+          POE2: "",
+        },
+      }),
+    );
+    mocks.powershellExecute
+      .mockResolvedValueOnce({
+        stdout: "",
+        stderr: "",
+        code: 0,
+      })
+      .mockResolvedValue({
+        stdout: "__REG_VALUE_MISSING__",
+        stderr: "",
+        code: 0,
+      });
+
+    const result = await clearGameInstallPath(
+      "Kakao Games",
+      "POE2",
+      "registry",
+    );
+
+    expect(result.ok).toBe(true);
+    expect(mocks.powershellExecute).toHaveBeenCalledWith(
+      expect.stringContaining("Remove-ItemProperty"),
+      false,
+    );
   });
 
   it("logs both configured path and registry diagnostics when both fail", async () => {

--- a/src/main/utils/registry.ts
+++ b/src/main/utils/registry.ts
@@ -13,6 +13,8 @@ import {
   GameInstallPathConflictResolution,
   GameInstallPathConflictResolveResult,
   GameInstallPathConflictResolutions,
+  GameInstallPathClearResult,
+  GameInstallPathClearSource,
   GameInstallPathConfigDiagnostic,
   GameInstallPathDiagnostics,
   GameInstallPaths,
@@ -583,6 +585,34 @@ export const writeRegistryValue = async (
   }
 };
 
+export const deleteRegistryValue = async (
+  regPath: string,
+  key: string,
+  useAdmin: boolean = false,
+): Promise<boolean> => {
+  try {
+    const finalPath = standardizeRegPath(regPath);
+    const safePath = escapePowerShellSingleQuotedString(finalPath);
+    const safeKey = escapePowerShellSingleQuotedString(key);
+
+    const psCommand = `
+      $path = '${safePath}'
+      $name = '${safeKey}'
+      if (Test-Path -LiteralPath $path) {
+        $item = Get-Item -LiteralPath $path -ErrorAction Stop
+        if ($item.GetValueNames() -contains $name) {
+          Remove-ItemProperty -LiteralPath $path -Name $name -ErrorAction Stop
+        }
+      }
+    `.trim();
+
+    const { code } = await runPowerShell(psCommand, useAdmin);
+    return code === 0;
+  } catch (_e) {
+    return false;
+  }
+};
+
 const getGameExecutablePath = (
   serviceId: AppConfig["serviceChannel"],
   installPath: string,
@@ -648,6 +678,16 @@ const writeRegistryInstallPath = async (
   if (!registryInfo) return false;
 
   return writeRegistryValue(registryInfo.path, registryInfo.key, installPath);
+};
+
+const deleteRegistryInstallPath = async (
+  serviceId: AppConfig["serviceChannel"],
+  gameId: AppConfig["activeGame"],
+): Promise<boolean> => {
+  const registryInfo = GAME_INSTALL_REGISTRY_MAP[serviceId]?.[gameId];
+  if (!registryInfo) return false;
+
+  return deleteRegistryValue(registryInfo.path, registryInfo.key);
 };
 
 const getRegistryInstallPathLabel = (
@@ -932,6 +972,58 @@ export const setGameInstallPath = async (
   return {
     ok: true,
     path: normalizedInstallPath,
+    diagnostics: await getGameInstallPathDiagnostics(serviceId, gameId),
+  };
+};
+
+export const clearGameInstallPath = async (
+  serviceId: AppConfig["serviceChannel"],
+  gameId: AppConfig["activeGame"],
+  source: GameInstallPathClearSource,
+): Promise<GameInstallPathClearResult> => {
+  if (source === "config") {
+    const context = ContextProvider.get();
+    if (!context) {
+      return {
+        ok: false,
+        source,
+        error: "App context is not available.",
+        diagnostics: await getGameInstallPathDiagnostics(serviceId, gameId),
+      };
+    }
+
+    const config = context.getConfig() as AppConfig;
+    const currentPaths = normalizeGameInstallPaths(config.gameInstallPaths);
+    const nextValue: GameInstallPaths = {
+      ...currentPaths,
+      [serviceId]: {
+        ...currentPaths[serviceId],
+        [gameId]: "",
+      },
+    };
+
+    setConfigWithEvent(CONFIG_KEYS.GAME_INSTALL_PATHS, nextValue);
+
+    return {
+      ok: true,
+      source,
+      diagnostics: await getGameInstallPathDiagnostics(serviceId, gameId),
+    };
+  }
+
+  const deleted = await deleteRegistryInstallPath(serviceId, gameId);
+  if (!deleted) {
+    return {
+      ok: false,
+      source,
+      error: "Failed to delete registry install path.",
+      diagnostics: await getGameInstallPathDiagnostics(serviceId, gameId),
+    };
+  }
+
+  return {
+    ok: true,
+    source,
     diagnostics: await getGameInstallPathDiagnostics(serviceId, gameId),
   };
 };

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -82,6 +82,7 @@ type GamePathModalState = {
   errorMessage?: string;
   highlightManual?: boolean;
   showRegistrySyncConfirm?: boolean;
+  showRegistryClearConfirm?: boolean;
   manualSaveToastId?: number;
 };
 
@@ -1175,6 +1176,7 @@ function App() {
         busy: true,
         highlightManual: options?.highlightManual ?? false,
         showRegistrySyncConfirm: false,
+        showRegistryClearConfirm: false,
       });
 
       try {
@@ -1244,6 +1246,7 @@ function App() {
               errorMessage: undefined,
               highlightManual: false,
               showRegistrySyncConfirm: false,
+              showRegistryClearConfirm: false,
             }
           : current,
       );
@@ -1323,6 +1326,7 @@ function App() {
             ? {
                 ...current,
                 showRegistrySyncConfirm: true,
+                showRegistryClearConfirm: false,
                 errorMessage: undefined,
               }
             : current,
@@ -1400,6 +1404,7 @@ function App() {
                 errorMessage: undefined,
                 highlightManual: false,
                 showRegistrySyncConfirm: false,
+                showRegistryClearConfirm: false,
                 manualSaveToastId: Date.now(),
               }
             : current,
@@ -1443,6 +1448,96 @@ function App() {
     );
   }, []);
 
+  const handleGamePathRegistryClearConfirmClose = useCallback(() => {
+    setGamePathModalState((current) =>
+      current ? { ...current, showRegistryClearConfirm: false } : current,
+    );
+  }, []);
+
+  const handleClearGamePath = useCallback(
+    async (source: GamePathSource, confirmed = false) => {
+      if (!window.electronAPI || !gamePathModalState) return;
+
+      if (source === "registry" && !confirmed) {
+        setGamePathModalState((current) =>
+          current
+            ? {
+                ...current,
+                showRegistryClearConfirm: true,
+                showRegistrySyncConfirm: false,
+                errorMessage: undefined,
+              }
+            : current,
+        );
+        return;
+      }
+
+      const { serviceId, gameId } = gamePathModalState;
+      setGamePathModalState((current) =>
+        current
+          ? {
+              ...current,
+              busy: true,
+              errorMessage: undefined,
+              showRegistryClearConfirm: false,
+            }
+          : current,
+      );
+
+      try {
+        const result = await window.electronAPI.clearGameInstallPath(
+          serviceId,
+          gameId,
+          source,
+        );
+
+        if (result.ok) {
+          setGamePathModalState((current) =>
+            current
+              ? {
+                  ...current,
+                  mode: "diagnostic",
+                  diagnostics: result.diagnostics,
+                  busy: false,
+                  errorMessage: undefined,
+                  showRegistrySyncConfirm: false,
+                  showRegistryClearConfirm: false,
+                }
+              : current,
+          );
+          void syncGameState(gameId, serviceId);
+          return;
+        }
+
+        setGamePathModalState((current) =>
+          current
+            ? {
+                ...current,
+                diagnostics: result.diagnostics || current.diagnostics,
+                busy: false,
+                errorMessage:
+                  result.error ||
+                  (source === "registry"
+                    ? "레지스트리 설치 경로를 삭제하지 못했습니다."
+                    : "저장된 게임 경로를 삭제하지 못했습니다."),
+              }
+            : current,
+        );
+      } catch (error) {
+        setGamePathModalState((current) =>
+          current
+            ? {
+                ...current,
+                busy: false,
+                errorMessage: `게임 경로를 삭제하지 못했습니다. ${formatUnknownError(error)}`,
+              }
+            : current,
+        );
+      }
+    },
+    [gamePathModalState, syncGameState],
+  );
+
   const handleResolveGamePathConflict = useCallback(
     async (action: "launcher-config-only" | "sync-registry") => {
       if (!window.electronAPI || !gamePathModalState) return;
@@ -1455,6 +1550,7 @@ function App() {
               busy: true,
               errorMessage: undefined,
               showRegistrySyncConfirm: false,
+              showRegistryClearConfirm: false,
             }
           : current,
       );
@@ -1828,17 +1924,25 @@ function App() {
         showRegistrySyncConfirm={
           gamePathModalState?.showRegistrySyncConfirm ?? false
         }
+        showRegistryClearConfirm={
+          gamePathModalState?.showRegistryClearConfirm ?? false
+        }
         manualSaveToastId={gamePathModalState?.manualSaveToastId}
         onClose={handleGamePathModalClose}
         onContextChange={handleGamePathContextChange}
         onUsePath={handleUseGamePath}
+        onClearPath={(source) => void handleClearGamePath(source)}
         onManualSelect={handleManualGamePathSelect}
         onRegistrySyncConfirmClose={handleGamePathConflictConfirmClose}
+        onRegistryClearConfirmClose={handleGamePathRegistryClearConfirmClose}
         onKeepLauncherConfig={() =>
           void handleResolveGamePathConflict("launcher-config-only")
         }
         onSyncRegistry={() =>
           void handleResolveGamePathConflict("sync-registry")
+        }
+        onConfirmClearRegistry={() =>
+          void handleClearGamePath("registry", true)
         }
         onInstall={
           gamePathModalState?.mode === "missing"

--- a/src/renderer/components/modals/GamePathDiagnosticModal.css
+++ b/src/renderer/components/modals/GamePathDiagnosticModal.css
@@ -361,8 +361,22 @@ img.game-path-channel-logo[alt="Grinding Gear Games"] {
   overflow-wrap: anywhere;
 }
 
-.game-path-option .game-path-action {
+.game-path-option-actions {
+  display: flex;
+  gap: 8px;
   margin-top: auto;
+}
+
+.game-path-option-actions .game-path-action {
+  flex: 1 1 0;
+  min-width: 0;
+  margin-top: 0;
+}
+
+.game-path-action.path-clear {
+  flex: 0 1 auto;
+  padding-right: 12px;
+  padding-left: 12px;
 }
 
 .game-path-manual-row {
@@ -511,11 +525,23 @@ img.game-path-channel-logo[alt="Grinding Gear Games"] {
   box-shadow: 0 24px 58px rgba(0, 0, 0, 0.72);
 }
 
+.game-path-confirm-dialog.is-danger {
+  border-color: rgba(250, 82, 82, 0.52);
+  background:
+    linear-gradient(rgba(250, 82, 82, 0.06), rgba(250, 82, 82, 0.02)),
+    #181818;
+}
+
 .game-path-confirm-icon {
   display: flex;
   align-items: flex-start;
   justify-content: center;
   color: #ffbf33;
+}
+
+.game-path-confirm-dialog.is-danger .game-path-confirm-icon,
+.game-path-confirm-dialog.is-danger .game-path-confirm-content h3 {
+  color: #ff8787;
 }
 
 .game-path-confirm-icon .material-symbols-outlined {

--- a/src/renderer/components/modals/GamePathDiagnosticModal.tsx
+++ b/src/renderer/components/modals/GamePathDiagnosticModal.tsx
@@ -29,14 +29,18 @@ interface GamePathDiagnosticModalProps {
   errorMessage?: string;
   highlightManual?: boolean;
   showRegistrySyncConfirm?: boolean;
+  showRegistryClearConfirm?: boolean;
   manualSaveToastId?: number;
   onClose: () => void;
   onContextChange: (serviceId: ServiceChannel, gameId: ActiveGame) => void;
   onUsePath: (source: GamePathSource) => void;
+  onClearPath: (source: GamePathSource) => void;
   onManualSelect: () => void;
   onRegistrySyncConfirmClose: () => void;
+  onRegistryClearConfirmClose: () => void;
   onKeepLauncherConfig: () => void;
   onSyncRegistry: () => void;
+  onConfirmClearRegistry: () => void;
   onInstall?: () => void;
 }
 
@@ -95,6 +99,10 @@ const getEmptyPathText = (source: GamePathSource) => {
 
 const getActionText = (source: GamePathSource) => {
   return source === "registry" ? "이 경로 사용" : "설정 경로 유지";
+};
+
+const getClearActionText = (source: GamePathSource) => {
+  return source === "registry" ? "레지스트리 값 삭제" : "저장된 경로 삭제";
 };
 
 const GAME_LABELS: Record<ActiveGame, string> = {
@@ -244,6 +252,7 @@ const PathOptionCard: React.FC<{
   recommended: boolean;
   busy: boolean;
   onUsePath: (source: GamePathSource) => void;
+  onClearPath: (source: GamePathSource) => void;
   onManualSelect: () => void;
 }> = ({
   title,
@@ -252,11 +261,13 @@ const PathOptionCard: React.FC<{
   recommended,
   busy,
   onUsePath,
+  onClearPath,
   onManualSelect,
 }) => {
   const canUsePath = Boolean(
     diagnostic.path && diagnostic.verification === "valid",
   );
+  const canClearPath = Boolean(diagnostic.path);
   const canReselectConfigPath = Boolean(
     source === "config" &&
     diagnostic.path &&
@@ -301,25 +312,41 @@ const PathOptionCard: React.FC<{
         <div className="game-path-option-error">{diagnostic.error}</div>
       )}
 
-      <button
-        type="button"
-        className={`game-path-action ${
-          recommended ? "primary" : "secondary"
-        } ${canReselectConfigPath ? "reselect" : ""}`}
-        disabled={actionDisabled}
-        onClick={() =>
-          canReselectConfigPath ? onManualSelect() : onUsePath(source)
-        }
-      >
-        <span className="material-symbols-outlined">
-          {canReselectConfigPath
-            ? "folder_open"
-            : source === "registry"
-              ? "sync_alt"
-              : "check"}
-        </span>
-        {canReselectConfigPath ? "다시 선택" : getActionText(source)}
-      </button>
+      <div className="game-path-option-actions">
+        <button
+          type="button"
+          className={`game-path-action ${
+            recommended ? "primary" : "secondary"
+          } ${canReselectConfigPath ? "reselect" : ""}`}
+          disabled={actionDisabled}
+          onClick={() =>
+            canReselectConfigPath ? onManualSelect() : onUsePath(source)
+          }
+        >
+          <span className="material-symbols-outlined">
+            {canReselectConfigPath
+              ? "folder_open"
+              : source === "registry"
+                ? "sync_alt"
+                : "check"}
+          </span>
+          {canReselectConfigPath ? "다시 선택" : getActionText(source)}
+        </button>
+
+        {canClearPath && (
+          <button
+            type="button"
+            className={`game-path-action path-clear ${
+              source === "registry" ? "danger" : "secondary"
+            }`}
+            disabled={busy}
+            onClick={() => onClearPath(source)}
+          >
+            <span className="material-symbols-outlined">delete</span>
+            {getClearActionText(source)}
+          </button>
+        )}
+      </div>
     </section>
   );
 };
@@ -334,14 +361,18 @@ const GamePathDiagnosticModal: React.FC<GamePathDiagnosticModalProps> = ({
   errorMessage,
   highlightManual = false,
   showRegistrySyncConfirm = false,
+  showRegistryClearConfirm = false,
   manualSaveToastId,
   onClose,
   onContextChange,
   onUsePath,
+  onClearPath,
   onManualSelect,
   onRegistrySyncConfirmClose,
+  onRegistryClearConfirmClose,
   onKeepLauncherConfig,
   onSyncRegistry,
+  onConfirmClearRegistry,
   onInstall,
 }) => {
   const manualRowRef = React.useRef<HTMLDivElement>(null);
@@ -411,6 +442,7 @@ const GamePathDiagnosticModal: React.FC<GamePathDiagnosticModalProps> = ({
                   recommended={diagnostics.recommendedSource === "registry"}
                   busy={busy}
                   onUsePath={onUsePath}
+                  onClearPath={onClearPath}
                   onManualSelect={onManualSelect}
                 />
                 <PathOptionCard
@@ -420,6 +452,7 @@ const GamePathDiagnosticModal: React.FC<GamePathDiagnosticModalProps> = ({
                   recommended={diagnostics.recommendedSource === "config"}
                   busy={busy}
                   onUsePath={onUsePath}
+                  onClearPath={onClearPath}
                   onManualSelect={onManualSelect}
                 />
               </div>
@@ -544,6 +577,56 @@ const GamePathDiagnosticModal: React.FC<GamePathDiagnosticModalProps> = ({
               </div>
             </div>
           )}
+
+        {showRegistryClearConfirm && diagnostics?.registry.path && (
+          <div className="game-path-confirm-overlay">
+            <div
+              className="game-path-confirm-dialog is-danger"
+              onClick={(event) => event.stopPropagation()}
+            >
+              <div className="game-path-confirm-icon">
+                <span className="material-symbols-outlined">warning</span>
+              </div>
+              <div className="game-path-confirm-content">
+                <h3>레지스트리 설치 경로를 삭제할까요?</h3>
+                <p>
+                  레지스트리는 게임이 설치될 때 게임 쪽에서 자동으로 추가하는
+                  값입니다. 현재 값이 왜 손상되었거나 달라졌는지는 런처에서 알
+                  수 없습니다.
+                </p>
+                <p>
+                  삭제하면 런처 외부의 게임 실행/패치 프로그램에서 게임 경로를
+                  찾지 못할 수 있습니다.
+                </p>
+                <div className="game-path-confirm-paths">
+                  <div>
+                    <span>삭제 대상</span>
+                    <strong>{diagnostics.registry.path}</strong>
+                  </div>
+                </div>
+              </div>
+              <div className="game-path-confirm-actions">
+                <button
+                  type="button"
+                  className="game-path-action ghost"
+                  disabled={busy}
+                  onClick={onRegistryClearConfirmClose}
+                >
+                  취소
+                </button>
+                <button
+                  type="button"
+                  className="game-path-action danger"
+                  disabled={busy}
+                  onClick={onConfirmClearRegistry}
+                >
+                  <span className="material-symbols-outlined">delete</span>
+                  레지스트리 값 삭제
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
 
         {manualSaveToastId && (
           <Toast

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -179,6 +179,8 @@ export type GameInstallPathConflictAction =
   | "launcher-config-only"
   | "sync-registry";
 
+export type GameInstallPathClearSource = "config" | "registry";
+
 export type GameInstallPathSaveResult =
   | {
       ok: true;
@@ -190,6 +192,19 @@ export type GameInstallPathSaveResult =
       canceled?: boolean;
       path?: string;
       verification: GameInstallPathVerificationStatus;
+      error?: string;
+      diagnostics?: GameInstallPathDiagnostics;
+    };
+
+export type GameInstallPathClearResult =
+  | {
+      ok: true;
+      source: GameInstallPathClearSource;
+      diagnostics: GameInstallPathDiagnostics;
+    }
+  | {
+      ok: false;
+      source: GameInstallPathClearSource;
       error?: string;
       diagnostics?: GameInstallPathDiagnostics;
     };
@@ -445,6 +460,11 @@ export interface ElectronAPI {
     gameId: AppConfig["activeGame"],
     action: GameInstallPathConflictAction,
   ) => Promise<GameInstallPathConflictResolveResult>;
+  clearGameInstallPath: (
+    serviceId: AppConfig["serviceChannel"],
+    gameId: AppConfig["activeGame"],
+    source: GameInstallPathClearSource,
+  ) => Promise<GameInstallPathClearResult>;
   minimizeWindow: () => void;
   closeWindow: () => void;
   getConfig: (


### PR DESCRIPTION
## 요약

- 수동 게임 경로 설정 후 설치 상태가 즉시 갱신되도록 설치 상태 재확인 흐름을 정리했습니다.
- 게임 경로 진단 모달에서 런처 설정 경로와 레지스트리 경로를 삭제할 수 있도록 개선했습니다.
- 레지스트리 삭제는 외부 실행/패치 프로그램 영향 가능성을 안내하는 확인 절차를 거치도록 했습니다.

## 배경

수동 경로 저장은 성공해도 기존 게임 상태 캐시가 바로 갱신되지 않아 버튼이 계속 설치하기로 남을 수 있었습니다. 또한 잘못 저장된 런처 설정 경로나 손상된 레지스트리 경로를 사용자가 진단 화면에서 직접 정리할 수 없어, 잘못된 감지 상태를 해소하기 어려웠습니다.