### PR TITLE
opentype.js v2 후속: 폰트 자산 스크립트 fix + v2 계약 테스트

### DIFF
--- a/AGENTS-ROADMAP.md
+++ b/AGENTS-ROADMAP.md
@@ -22,3 +22,12 @@
       `npm test` `[Windows-pwsh]`.
 - [ ] FontManager `generateFontThumbnail`의 `replace('fill="black"', …)` dead code
       정리(opentype v2 `toSVG`는 기본 fill 속성을 생략). — 다음 폰트 작업 시.
+- [ ] `scripts/generate-font-assets.ts`의 `RemoteFontItem` 인터페이스가
+      `displayNames`를 선언하나 코드는 `fullNames`/`familyNames`를 출력(배포
+      스키마와 일치하는 쪽은 코드). tsx는 타입을 벗겨 무해하나 향후 `scripts/`
+      타입체크 도입 시 즉시 에러 — 인터페이스를 실출력에 맞추거나 scripts를
+      tsconfig에 편입. (2026-07 Fable5 후속 리뷰)
+- [ ] opentype.js ESM footgun: 순수 Node ESM `import('opentype.js')`에서 `parse`가
+      undefined(UMD main + exports map 부재). `automate-font-list` 러너를 ESM(예:
+      `node --experimental-strip-types`)으로 바꾸면 조용히 파손 — 현 tsx CJS 경로는
+      무관. 러너 변경 시 명시 검증. (위 opentype 정리 항목 연관)

--- a/AGENTS-ROADMAP.md
+++ b/AGENTS-ROADMAP.md
@@ -12,3 +12,13 @@
       — DoD: WSL에서 `git commit`이 `--no-verify` 없이 통과 / 검증: WSL 실커밋
       1회 `[WSL]` + Windows 커밋 회귀 없음 `[Windows-pwsh]`.
       의사코드: `docs/archive/2026-05-20-residual-work.md` §2.5.
+- [ ] opentype.js v2 정리: v2 자체 타입 번들 여부 확인 → 번들 시
+      `@types/opentype.js@^1.3.3` 제거(현재 잔존; v1 타입이 `opentype.load`를 유효해
+      보이게 만들어 v2 no-op 스텁을 가림). 미번들이면 유지. — DoD: `build:check`
+      green 유지 / 검증: `[Windows-pwsh]`. (2026-07 renovate 배치 F2)
+- [ ] FontManager 폰트명 추출(`pickFontName`)을 순수 함수로 추출 + 우선순위 엣지
+      단위 테스트(macintosh-only ko, fontFamily 폴백, names 부재 등). 현재는 실폰트
+      계약 테스트(`opentype-v2-contract.integration.test.ts`)만 존재. — 검증:
+      `npm test` `[Windows-pwsh]`.
+- [ ] FontManager `generateFontThumbnail`의 `replace('fill="black"', …)` dead code
+      정리(opentype v2 `toSVG`는 기본 fill 속성을 생략). — 다음 폰트 작업 시.

--- a/docs/archive/2026-07-08-renovate-deps-master.md
+++ b/docs/archive/2026-07-08-renovate-deps-master.md
@@ -1,0 +1,158 @@
+# 2026-07-08 — renovate 의존성 PR 일괄 반영 (10건)
+
+## 목표
+
+오픈 renovate `chore(deps)` PR 10건을 **위험 오름차순**으로 master에 반영한다.
+#182(opentype.js v2)는 CI 실패 상태라 **FontManager 코드 마이그레이션**까지 포함.
+설계·리뷰: architect(=Fable5, VSCode 폴백). 구현: 세션.
+
+## 결정 (2026-07-08 사용자 확인)
+
+1. **릴리스 분리 안 함** — master에 쭉 병합하면 release-please가 #236을 자동
+   갱신. 기존 개발분 + 의존성 업데이트를 **함께 통합 릴리스**할 예정(타이밍은
+   추후). 배치 병합 시점부터 1.4.3에 Electron 43 등이 포함된 상태가 된다.
+2. **#182 배치 포함** — opentype.js v2 코드 마이그레이션까지 이번 작업 범위.
+3. **저위험→고위험 순서, 한 세션 연속** — 단 `[사용자]` 실검증 게이트는 세션
+   중 대기(electron·폰트).
+
+## 공통 수칙 (모든 PR)
+
+- **병합 방식**: 서버사이드 **squash** (`gh pr merge N --squash`) — 관례
+  (#227/#230/#233)와 일치, commitlint/husky/WSL 마찰 없음, release-please가
+  chore로 파싱해 #236이 1.4.3 유지.
+- **병합 원자 루프** (PR마다, 생략 불가):
+  1. renovate 재베이스 트리거 (PR 체크박스 / Dependency Dashboard)
+  2. 새 merge-ref에서 pr-check green (`gh pr checks N --watch`) — required
+     check 없으니 규율로 강제
+  3. `gh pr merge N --squash`
+  4. 병합 push 후 release-please 런 성공 + **#236 open·"release 1.4.3"·
+     CHANGELOG 불변** 확인
+  5. 다음 PR (lock 충돌 시 renovate 자동 재베이스 대기)
+- **lock**: renovate 환경에서만 재생성시켜 로컬 npm 11.6.x 버그를 원천 회피
+  ([[npm-lockfile-emnapi-bug]]). CI가 EUSAGE로 실패하면 폴백: 해당 절차대로
+  `@emnapi` 항목 복원 후 renovate 브랜치에 수정 push.
+- **테스트**: pr-check에는 vitest 없음 → "테스트 통과"는 Windows pwsh
+  `npm test`로 별도 확인.
+
+## 마일스톤 + DoD
+
+### M0. 기준선 확립
+
+- ① 로컬 git fetch + master를 `cc1f1cb`로 동기화 `[WSL]`
+- ② Windows pwsh `npm ci` 성공 + `npm test` 전체 green (귀속 기준선) `[Windows-pwsh]`
+- ③ gh 토큰 · #236(open/1.4.3) 확인 `[WSL]`
+- **DoD**: 세 항목 관찰 확인.
+
+### M1. 안전 툴링 (#228 → #231 → #181)
+
+lint&format 그룹 / @types/chrome / lint-staged 17. 런타임 무관. #228은 lock
+전용이라 첫 타자로 재베이스→lock 정합 파이프라인을 검증.
+
+- **DoD**: 3건 머지드 + 각 병합 전 fresh pr-check green + 매 병합 후 #236
+  불변 `[CI/gh]`. lint-staged 17 실동작은 M7 커밋 시 자연 검증 `[Windows-pwsh]`.
+
+### M2. CI 인프라 (#229 → #232)
+
+actions/checkout v7 / actions/cache v6. lock 무관.
+
+- **DoD**: 2건 머지드 + 이후 워크플로 런 green `[CI]`. cache v6은 릴리스
+  빌드에서만 실행 → "다음 릴리스 빌드에서 확인"으로 이월 기록.
+
+### M3. 빌드 체인 (#179 → #194)
+
+esbuild 0.28 → vite-plugin-electron v1. #179 green 후 #194 진행. #194는 major
+(codeSplitting 전환), vite.config.mts의 5엔트리 + startup/reload API에 결합.
+
+- **DoD**: CI green + `npm ci`·`npm test` green + `npm run dev` 기동/핫리로드
+  스모크 + `npm run build:check` + `dist-electron/` 산출물 구조가
+  electron-builder.json5와 정합 `[Windows-pwsh]` + 런처 부팅 1회 `[사용자]`.
+  빌드 통과만으로 종결 불가.
+
+### M4. Electron v43 (#234 단독)
+
+electron 40→43 (Chromium 150 / Node 24). BrowserView 미사용 확인, breaking은
+Linux 전용뿐이나 기동·카카오 임베디드 웹·폰트 렌더 잠재 영향.
+
+- **DoD**: 병합 후 `npm ci`(바이너리 교체)+`npm test`+dev `[Windows-pwsh]`,
+  이어 **`[사용자]` 실검증**: 런처 부팅, 메인 UI/폰트 렌더, 커스텀 폰트 적용·
+  미리보기, 카카오 자동 로그인·SecurityCenter, 게임 실행, 업데이트 체크
+  (electron-updater). **이 게이트 통과 전 M5 진행 금지.**
+
+### M5. opentype.js v2 마이그레이션 (#182 = dep 번프 + 코드)
+
+CI 실패 원인 = `FontManager.ts:221` `opentype.load(path, cb)`(v2 제거) + v2
+`font.names` 구조 재편(플랫폼별)으로 `names.fullName?.ko` 접근 파손 +
+`@types/opentype.js@1.x` 충돌. **코드 마이그레이션 필요** → renovate #182와
+별개로 브랜치에서 dep 번프 + 코드 수정을 함께 처리(구현=세션, 리뷰=Fable5).
+
+- 작업: `opentype.load`→버퍼 `readFile`+`opentype.parse`, v2 names 구조 대응
+  (L131·L221 경로), `@types/opentype.js` 정리, `kakao-automation`/폰트 스킬
+  준수.
+- **DoD**: `npm run build:check` green + `npm test` green `[Windows-pwsh]` +
+  **`[사용자]` 커스텀 폰트 파싱·적용·미리보기 인게임 실검증** + Fable5 리뷰
+  통과. 빌드 통과만으로 종결 불가.
+
+### M6. 릴리스 엔진 (#183 마지막)
+
+release-please-action v4→v5. breaking = node24 런타임뿐. 9건 병합 동안 릴리스
+엔진을 v4로 안정 유지하고 최후에 단독 변경. **사용자 명시 승인 후 병합**
+(stop-and-ask #2). 병합 push가 v5 첫 런 → #236 재생성 즉시 관찰. 문제 시
+워크플로 1파일 revert로 복구(코드 영향 0).
+
+- **DoD**: v5 런 성공 + #236 open·1.4.3·CHANGELOG 불변 + 중복 릴리스 PR 없음 `[CI/gh]`.
+
+### M7. 종합 검증 · 리뷰 · 보고 · 마무리
+
+- ① 최종 `npm ci --dry-run` 클린 + `npm test` green + lint green `[Windows-pwsh]`
+  - 런처 최종 스모크 `[사용자]`
+- ② **Fable5 리뷰 루프** — 게이트 준수 감사 + #236 무결 + 잔여 리스크 판정
+  (라운드별 work 문서 기록)
+- ③ **사용자 보고** — 병합 이력, #236 릴리스 질의
+- ④ 마무리 — 위키 raw 노트 + 이 문서 `docs/archive/` 이동
+- **DoD**: 리뷰 `통과/조건부 통과` + 사용자 보고 완료.
+
+## 호환성 / stop-and-ask
+
+- **stop-and-ask #3 (major deps)**: #234/#194/#182/#181/#183/#229/#232 →
+  이 계획 승인 = 일괄 승인. 단 M4(electron)·M6(release 엔진) 진입 시 개별 재확인.
+- **stop-and-ask #2 (릴리스 플로)**: #183 → 최후순위 + 단독 관찰 + 사용자 승인.
+- **기존 사용자 blast radius**: config 스키마·폰트/UAC 마이그레이션·카카오
+  셀렉터 변경 없음. 실질 영향 = 다음 통합 릴리스로 자동 업데이트되는 **Electron
+  43 런타임**(Chromium 150/Node 24 — 카카오 임베디드 웹·폰트·기동) + **빌드
+  산출물 구조(#194)** + **폰트 파싱(#182)**. M3/M4/M5의 `[사용자]` DoD가 커버.
+- **#236 상호작용**: chore hidden → 버전·CHANGELOG 불변, rebase만. 교란 없음.
+
+## 리뷰 (라운드별 누적)
+
+### 병합 로그 (master, squash)
+
+`cc1f1cb`(M0 기준선) → `e0d5491`(#228) → `e4d3adc`(#231) → `8c4fb50`(#181) →
+`85e2974`(#229) → `b01cc92`(#232) → `38136bd`(#179) → `39bf1ab`(#194) →
+`69d434c`(#234) → `b74cf0d`(#182) → `e13a232`(#183). 10건 전부 단일부모 squash,
+`chore(deps): … (#NNN)`. #236은 내내 OPEN·1.4.3·changelog 불변.
+
+### M5 리뷰 — Fable5 라운드 1 (opentype v2 + FontManager): 조건부 통과
+
+- 실폰트(malgun/arial) 전수 실행 검증. 핵심: v2 `load`는 제거가 아니라 **무동작
+  스텁**(console.error만) → 구 코드 유지 시 폰트 추가 무한 행 → 마이그레이션 필수.
+- namespace import·`pickFontName`(플랫폼 순회, v1 우선순위 보존)·buffer→parse·
+  미변경 `generateFontThumbnail`(getPath/tables/toSVG)까지 전부 v2 정상 검증.
+- 필수 수정 1건(파싱 catch가 원본 오류 폐기) → `cause`+로깅으로 반영(`bfbc265`).
+
+### M7 최종 감사 — Fable5: 조건부 통과
+
+- 게이트: 10건 클린 squash, release-please 런 전부 success(v5 첫 런 포함), master
+  FontManager = 리뷰 통과본과 바이트 동일.
+- #236 무결: 단독 OPEN·1.4.3·changelog는 fix 1건뿐(chore 10건 0 유출), 태그 오발행 없음.
+- 신규 2건: **F1** `scripts/generate-font-assets.ts`의 `opentype.load` 잔존(CI
+  스크립트, 자동화 파손) / **F2** `@types/opentype.js@1` 잔존.
+- CI 미포착 TOP 리스크 + 통합 `[사용자]` 체크리스트 18항 제시(패키징 부팅·업데이터·
+  카카오·게임·폰트).
+
+### 후속 (branch `chore/opentype-v2-followup`)
+
+- **F1 수정**(Fable5 위임): `generate-font-assets.ts`를 v2 buffer parse로 마이그레이션 → `fix` 커밋.
+- **테스트 추가**: `opentype-v2-contract.integration.test.ts`(실 GmarketSans로 v2
+  계약 회귀 가드, 6건) → `chore` 커밋. opentype 커버리지 0 부분 해소.
+- **F2 + 잔여** → `AGENTS-ROADMAP.md` 이관.
+- Fable5 전체 변경 최종 리뷰(문제 없을 때까지 루프) 후 PR·보고.

--- a/scripts/generate-font-assets.ts
+++ b/scripts/generate-font-assets.ts
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 
 import { createCanvas } from "canvas";
-import opentype from "opentype.js";
+import * as opentype from "opentype.js";
 
 /**
  * 폰트 원격 저장소 자동화 스크립트 (NORMALIZED VERSION)
@@ -46,22 +46,41 @@ function calculateHash(filePath: string): string {
   return crypto.createHash("sha256").update(buffer).digest("hex");
 }
 
-const getAllNames = (
-  nameObj: { [lang: string]: string | undefined } | undefined,
-) => {
-  if (!nameObj) return {};
-  const names: { [lang: string]: string } = {};
-  // 가용한 모든 언어 필드 수집
-  Object.keys(nameObj).forEach((lang) => {
-    const val = nameObj[lang];
-    if (typeof val === "string") names[lang] = val;
-  });
-  return names;
+// [v2] opentype.js v2의 names는 플랫폼별 구조({unicode,macintosh,windows})로
+// 변경됨. 세 플랫폼을 병합해 언어별 이름을 수집한다(우선순위: windows >
+// macintosh > unicode). @types/opentype.js가 아직 v1이라 unknown으로 받는다.
+type NameTable = Record<string, Record<string, string | undefined> | undefined>;
+
+const getAllNames = (names: unknown, prop: string) => {
+  const n = names as {
+    unicode?: NameTable;
+    macintosh?: NameTable;
+    windows?: NameTable;
+  };
+  const result: { [lang: string]: string } = {};
+  // 낮은 우선순위 플랫폼부터 채워, 높은 우선순위가 같은 언어를 덮어쓴다
+  for (const platform of [n.unicode, n.macintosh, n.windows]) {
+    const nameObj = platform?.[prop];
+    if (!nameObj) continue;
+    // 가용한 모든 언어 필드 수집
+    Object.keys(nameObj).forEach((lang) => {
+      const val = nameObj[lang];
+      if (typeof val === "string") result[lang] = val;
+    });
+  }
+  return result;
 };
 
 async function generatePreview(fontPath: string, destPath: string) {
   try {
-    const font = await opentype.load(fontPath);
+    // [v2] opentype.js v2는 load(path)를 제거 → 버퍼를 읽어 parse.
+    const buffer = await fs.promises.readFile(fontPath);
+    const font = opentype.parse(
+      buffer.buffer.slice(
+        buffer.byteOffset,
+        buffer.byteOffset + buffer.byteLength,
+      ),
+    );
     const text = "Path of Exile 2 - 한글 테스트";
     const fontSize = 48;
     const canvas = createCanvas(800, 120);
@@ -122,16 +141,25 @@ async function main() {
     const fullPreviewPath = path.join(PREVIEW_DIR, `${id}.png`);
 
     try {
-      const font = await opentype.load(filePath);
-      const names = font.names;
+      // [v2] opentype.js v2는 load(path)를 제거 → 버퍼를 읽어 parse.
+      const fileBuffer = await fs.promises.readFile(filePath);
+      const font = opentype.parse(
+        fileBuffer.buffer.slice(
+          fileBuffer.byteOffset,
+          fileBuffer.byteOffset + fileBuffer.byteLength,
+        ),
+      );
+      const names: unknown = font.names;
 
-      const fullNames = getAllNames(names.fullName);
-      const familyNames = getAllNames(names.fontFamily);
-      const license = getAllNames(names.license);
-      const licenseUrl = (names.licenseURL?.en ||
-        names.licenseURL?.ko ||
-        Object.values(names.licenseURL || {})[0] ||
-        "") as string;
+      const fullNames = getAllNames(names, "fullName");
+      const familyNames = getAllNames(names, "fontFamily");
+      const license = getAllNames(names, "license");
+      const licenseUrlNames = getAllNames(names, "licenseURL");
+      const licenseUrl =
+        licenseUrlNames.en ||
+        licenseUrlNames.ko ||
+        Object.values(licenseUrlNames)[0] ||
+        "";
 
       // Smart Merge: 기존 데이터 매핑 (파일명 또는 이전 해시 기반)
       const existing = existingList.find(

--- a/src/main/tests/opentype-v2-contract.integration.test.ts
+++ b/src/main/tests/opentype-v2-contract.integration.test.ts
@@ -1,0 +1,66 @@
+// src/main/tests/opentype-v2-contract.integration.test.ts
+import fs from "node:fs";
+import path from "node:path";
+
+import * as opentype from "opentype.js";
+import { describe, it, expect } from "vitest";
+
+/**
+ * opentype.js v2 계약 회귀 가드 (#182 마이그레이션).
+ *
+ * FontManager(커스텀 폰트 파싱·이름추출·썸네일)는 electron 런타임 의존이라 vitest로
+ * 직접 못 띄우지만, 그 코드가 기대는 opentype v2 API 표면은 여기서 저장소 내장 실폰트
+ * (GmarketSansTTFBold.ttf — 한글 fullName·글리프 보유)로 CI에 고정한다. v1→v2에서
+ * 깨졌던 지점(default export 없음, load 제거, names 플랫폼별 재편)을 명시적으로 검증한다.
+ */
+const FONT_PATH = path.resolve(
+  __dirname,
+  "../../renderer/assets/fonts/GmarketSansTTFBold.ttf",
+);
+
+function parseFont(): opentype.Font {
+  const buf = fs.readFileSync(FONT_PATH);
+  return opentype.parse(
+    buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength),
+  );
+}
+
+describe("opentype.js v2 계약 (FontManager 의존 표면)", () => {
+  it("namespace import로 parse가 함수다 (v2는 default export 없음)", () => {
+    expect(typeof opentype.parse).toBe("function");
+  });
+
+  it("실 TTF를 parse한다 (load 제거 → buffer parse 경로)", () => {
+    const font = parseFont();
+    expect(font).toBeTruthy();
+    expect(typeof font.charToGlyph).toBe("function");
+  });
+
+  it("names는 v2 플랫폼별 구조 — windows.fullName에서 ko/en을 얻는다", () => {
+    const names = parseFont().names as unknown as {
+      windows?: { fullName?: Record<string, string | undefined> };
+    };
+    expect(names.windows?.fullName?.ko).toBe("G마켓 산스 TTF Bold");
+    expect(names.windows?.fullName?.en).toBe("Gmarket Sans TTF Bold");
+  });
+
+  it("v1식 평탄 names 접근은 v2에서 undefined (마이그레이션이 필요했던 이유)", () => {
+    const flat = parseFont().names as unknown as { fullName?: unknown };
+    expect(flat.fullName).toBeUndefined();
+  });
+
+  it("한글 글리프 판정: charToGlyph('가')가 유효 unicode를 준다", () => {
+    const g = parseFont().charToGlyph("가");
+    expect(g?.unicode).toBe(44032);
+  });
+
+  it("썸네일 생성 표면: getAdvanceWidth/getPath/toSVG/tables.os2가 동작한다", () => {
+    const font = parseFont();
+    expect(font.getAdvanceWidth("가", 32)).toBeGreaterThan(0);
+    const svg = font.getPath("가", 0, 0, 32).toSVG(2);
+    expect(typeof svg).toBe("string");
+    expect(svg.length).toBeGreaterThan(0);
+    const os2 = font.tables.os2 as { sTypoAscender?: unknown };
+    expect(typeof os2.sTypoAscender).toBe("number");
+  });
+});


### PR DESCRIPTION
## Summary

renovate 배치(10 PR, master 반영 완료)의 **opentype.js v2 후속**:

- **fix: 폰트 목록 자동화 스크립트를 opentype.js v2로 마이그레이션** (`ff21510`)
  `scripts/generate-font-assets.ts`가 v2에서 무동작 스텁이 된 `opentype.load`를 써서
  `automate-font-list` 워크플로가 파손(모든 폰트 실패 → `list.json` 빈 배열 덮어쓰기)되던
  것을 해소. namespace import + `readFile`+`parse` + names 플랫폼별 추출(FontManager와 동일).
  CI 스크립트라 런처 런타임과는 무관.
- **chore: opentype v2 계약 테스트 + 후속 문서** (`1859fa6`)
  `opentype-v2-contract.integration.test.ts` — 저장소 내장 실폰트(GmarketSans)로 v2 API
  계약(파싱·플랫폼별 `names`·글리프·`getPath`/`toSVG`)을 CI 회귀 가드(6건). 그간 0이던
  opentype 커버리지 부분 해소. `@types/opentype.js` 정리 등 잔여는 `AGENTS-ROADMAP.md`
  이관, 배치 work 문서는 `docs/archive/`로 완료 이관(M5·M7 리뷰 기록 포함).

## 배경

opentype.js를 v2로 올린 배치(#182)가 FontManager는 마이그레이션했지만, 동일 API를 쓰는
CI 스크립트와 테스트 커버리지가 남아 있었다. 이 PR이 그 후속을 닫는다. 릴리스(#236, 1.4.3)와
독립적이며, `fix`는 다음 릴리스 Bug Fixes에 실린다.
