### PR TITLE
chore: 폰트 스크립트 타입 정합 + opentype ESM 로드 가드

### DIFF
--- a/AGENTS-ROADMAP.md
+++ b/AGENTS-ROADMAP.md
@@ -22,12 +22,3 @@
       `npm test` `[Windows-pwsh]`.
 - [ ] FontManager `generateFontThumbnail`의 `replace('fill="black"', …)` dead code
       정리(opentype v2 `toSVG`는 기본 fill 속성을 생략). — 다음 폰트 작업 시.
-- [ ] `scripts/generate-font-assets.ts`의 `RemoteFontItem` 인터페이스가
-      `displayNames`를 선언하나 코드는 `fullNames`/`familyNames`를 출력(배포
-      스키마와 일치하는 쪽은 코드). tsx는 타입을 벗겨 무해하나 향후 `scripts/`
-      타입체크 도입 시 즉시 에러 — 인터페이스를 실출력에 맞추거나 scripts를
-      tsconfig에 편입. (2026-07 Fable5 후속 리뷰)
-- [ ] opentype.js ESM footgun: 순수 Node ESM `import('opentype.js')`에서 `parse`가
-      undefined(UMD main + exports map 부재). `automate-font-list` 러너를 ESM(예:
-      `node --experimental-strip-types`)으로 바꾸면 조용히 파손 — 현 tsx CJS 경로는
-      무관. 러너 변경 시 명시 검증. (위 opentype 정리 항목 연관)

--- a/scripts/generate-font-assets.ts
+++ b/scripts/generate-font-assets.ts
@@ -19,7 +19,7 @@ if (typeof opentype.parse !== "function") {
  *
  * 변경 사항:
  * 1. id: 파일 바이너리 SHA-256 해시로 고정
- * 2. displayNames: 다국어 이름 객체로 확장 ({ ko, en, ... })
+ * 2. fullNames/familyNames: 다국어 이름 객체로 확장 ({ ko, en, ... })
  * 3. license: 다국어 라이선스 객체로 확장
  * 4. previewPath: preview/${id}.png 규칙 강제
  */

--- a/scripts/generate-font-assets.ts
+++ b/scripts/generate-font-assets.ts
@@ -5,6 +5,15 @@ import path from "node:path";
 import { createCanvas } from "canvas";
 import * as opentype from "opentype.js";
 
+// opentype.js v2는 CJS(require) 전제로 로드된다(워크플로는 tsx=CJS). 러너를 순수
+// ESM으로 바꾸면 named export가 유실돼 parse가 undefined가 되고 이후 조용히 깨지므로,
+// 즉시 명확한 에러로 실패시킨다.
+if (typeof opentype.parse !== "function") {
+  throw new Error(
+    "opentype.parse를 찾을 수 없습니다 — opentype.js가 CJS가 아닌 ESM으로 로드된 것으로 보입니다. 이 스크립트는 tsx(CJS) 실행 전제입니다.",
+  );
+}
+
 /**
  * 폰트 원격 저장소 자동화 스크립트 (NORMALIZED VERSION)
  *
@@ -18,7 +27,8 @@ import * as opentype from "opentype.js";
 interface RemoteFontItem {
   id: string;
   fileName: string;
-  displayNames: { [lang: string]: string };
+  fullNames: { [lang: string]: string };
+  familyNames: { [lang: string]: string };
   previewPath: string;
   fileSize: number;
   license: { [lang: string]: string };


### PR DESCRIPTION
## Summary

Fable5 후속 리뷰의 non-blocking 노트 2건을 로드맵 이관 대신 **실제로 수정**:

- **① RemoteFontItem 타입 정합** — `scripts/generate-font-assets.ts`의 로컬 인터페이스가
  `displayNames`를 선언했으나 코드는 배포 스키마대로 `fullNames`/`familyNames`를 출력.
  tsx가 타입을 벗겨 런타임은 무해했으나 향후 `scripts/` 타입체크 도입 시 에러날 지뢰 →
  인터페이스를 실출력에 맞춤. (`@types/node`·`canvas` 있는 CI 기준 tsc는 canvas 외 오류 0)
- **② opentype ESM 로드 가드** — opentype.js는 CJS(require) 전제(워크플로는 tsx=CJS).
  러너를 순수 ESM으로 바꾸면 named export가 유실돼 `parse`가 조용히 undefined → 이후
  "undefined is not a function"으로 혼란스럽게 파손. 로드 시 `parse` 유무를 확인해 **즉시
  명확한 에러**로 실패시키는 가드 추가(silent→loud). 근본은 패키지/러너 한계라 제거 불가.

AGENTS-ROADMAP에서 위 2건 제거(완료 처리).

## 검증

- 스크립트 standalone tsc(`--types node`): **canvas TS2307(CI에서만 설치되는 env) 외 오류 0** — ① 완전 해소.
- `npm run build:check` green, `npm test` **185/185** — 회귀 없음. (② 가드는 tsx=CJS 런타임에선 발화 안 함)

## 배경

런처 런타임과 무관한 CI 자동화 스크립트(gh-pages `list.json` 생성). 앱 소스는 아니지만 그
산출물을 런처가 원격 폰트 카탈로그로 소비하므로, 견고성 차원의 마무리.
