### PR TITLE
chore: pickFontName 순수함수 추출·테스트 + 프리뷰 fill dead code 정리

### DIFF
--- a/AGENTS-ROADMAP.md
+++ b/AGENTS-ROADMAP.md
@@ -12,10 +12,11 @@
       — DoD: WSL에서 `git commit`이 `--no-verify` 없이 통과 / 검증: WSL 실커밋
       1회 `[WSL]` + Windows 커밋 회귀 없음 `[Windows-pwsh]`.
       의사코드: `docs/archive/2026-05-20-residual-work.md` §2.5.
-- [ ] opentype.js v2 정리: v2 자체 타입 번들 여부 확인 → 번들 시
-      `@types/opentype.js@^1.3.3` 제거(현재 잔존; v1 타입이 `opentype.load`를 유효해
-      보이게 만들어 v2 no-op 스텁을 가림). 미번들이면 유지. — DoD: `build:check`
-      green 유지 / 검증: `[Windows-pwsh]`. (2026-07 renovate 배치 F2)
+- [x] ~~opentype.js v2 정리: `@types/opentype.js` 제거 검토~~ → **유지 결정 (2026-07-08).**
+      opentype.js@2.0.0은 자체 타입 미번들(package.json `types`/`typings` 필드 없음,
+      패키지 내 `.d.ts` 0개) → 제거 시 opentype.js가 완전 untyped(implicit any). v1
+      타입이 v2 API를 유효해 보이게 하는 오인 위험은 opentype-v2-contract 테스트 +
+      ESM 로드 가드(#237/#238)로 보완됨. 소스 변경 없음, `build:check` 이미 green.
 - [ ] FontManager 폰트명 추출(`pickFontName`)을 순수 함수로 추출 + 우선순위 엣지
       단위 테스트(macintosh-only ko, fontFamily 폴백, names 부재 등). 현재는 실폰트
       계약 테스트(`opentype-v2-contract.integration.test.ts`)만 존재. — 검증:

--- a/src/main/services/FontManager.ts
+++ b/src/main/services/FontManager.ts
@@ -6,6 +6,7 @@ import { Worker } from "node:worker_threads";
 import { app } from "electron";
 import * as opentype from "opentype.js";
 
+import { pickFontName } from "./pickFontName";
 import { SyncEngine } from "./SyncEngine";
 import {
   TARGET_SERVICES_CONFIG,
@@ -117,37 +118,6 @@ export class FontManager {
   }
 
   /**
-   * opentype.js v2의 플랫폼별 names 구조({unicode,macintosh,windows})에서 표시
-   * 이름을 추출한다. v1의 평탄 접근(fullName/fontFamily × ko/en) 우선순위를
-   * 보존하며, @types/opentype.js가 아직 v1이라 unknown으로 받아 접근한다.
-   */
-  private pickFontName(names: unknown): string | undefined {
-    type NameTable = Record<
-      string,
-      Record<string, string | undefined> | undefined
-    >;
-    const n = names as {
-      unicode?: NameTable;
-      macintosh?: NameTable;
-      windows?: NameTable;
-    };
-    const platforms = [n.windows, n.macintosh, n.unicode];
-    const pick = (prop: string, lang: string): string | undefined => {
-      for (const p of platforms) {
-        const v = p?.[prop]?.[lang];
-        if (v) return v;
-      }
-      return undefined;
-    };
-    return (
-      pick("fullName", "ko") ||
-      pick("fullName", "en") ||
-      pick("fontFamily", "ko") ||
-      pick("fontFamily", "en")
-    );
-  }
-
-  /**
    * Buffer로부터 메타데이터 및 실시간 미리보기 추출 (가져오기 마법사 최적화)
    */
   public async extractMetadataFromBuffer(
@@ -167,7 +137,7 @@ export class FontManager {
         );
 
         // 이름 추출 (v2 플랫폼별 names 대응, fullName 우선)
-        const originalName = this.pickFontName(font.names) || fallbackName;
+        const originalName = pickFontName(font.names) || fallbackName;
 
         // 실시간 미리보기 생성
         const previewDataUrl = this.generateFontThumbnail(font);
@@ -211,9 +181,12 @@ export class FontManager {
       const pathData = font.getPath(text, x, y, fontSize);
       const svgPath = pathData.toSVG(2);
 
+      // opentype.js v2의 toSVG는 fill 속성을 생략한다(→ SVG 기본값인 검은색 path).
+      // 표시 측이 이를 보정한다: FontManagerModal은 흰 배경, ExternalFontImportModal은
+      // invert(1) 필터. 여기서 fill을 주입하면 두 미리보기 렌더가 깨지므로 그대로 둔다.
       const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}">
         <rect width="100%" height="100%" fill="transparent" />
-        ${svgPath.replace('fill="black"', 'fill="white"')}
+        ${svgPath}
       </svg>`;
 
       return `data:image/svg+xml;base64,${Buffer.from(svg).toString("base64")}`;
@@ -268,7 +241,7 @@ export class FontManager {
 
     // [v15] 이름 추출 로직 고도화: 스타일 정보가 포함된 fullName 우선
     const originalName =
-      overrideOriginalName || this.pickFontName(font.names) || "Unknown Font";
+      overrideOriginalName || pickFontName(font.names) || "Unknown Font";
 
     // [v15] 중복 체크 기준을 '해시(ID)'로 변경
     // 이름(originalName)이 같더라도 해시가 다르면 다른 폰트(Bold 등)로 허용

--- a/src/main/services/pickFontName.ts
+++ b/src/main/services/pickFontName.ts
@@ -1,0 +1,39 @@
+/**
+ * opentype.js v2의 플랫폼별 names 구조({unicode, macintosh, windows})에서 표시
+ * 이름을 추출한다. v1의 평탄 접근(fullName/fontFamily × ko/en) 우선순위를
+ * 그대로 보존한다.
+ *
+ * 우선순위: (프로퍼티 × 언어)를 바깥 순서로, 각 쌍마다 플랫폼(windows →
+ * macintosh → unicode)을 안쪽에서 훑어 첫 truthy 값을 반환한다.
+ *   fullName.ko → fullName.en → fontFamily.ko → fontFamily.en
+ *
+ * @types/opentype.js가 아직 v1 형태(평탄 names)라 실제 v2 구조와 어긋나므로
+ * `names`를 unknown으로 받아 안전하게 접근한다. names가 객체가 아니면 undefined.
+ */
+export function pickFontName(names: unknown): string | undefined {
+  if (!names || typeof names !== "object") return undefined;
+
+  type NameTable = Record<
+    string,
+    Record<string, string | undefined> | undefined
+  >;
+  const n = names as {
+    unicode?: NameTable;
+    macintosh?: NameTable;
+    windows?: NameTable;
+  };
+  const platforms = [n.windows, n.macintosh, n.unicode];
+  const pick = (prop: string, lang: string): string | undefined => {
+    for (const p of platforms) {
+      const v = p?.[prop]?.[lang];
+      if (v) return v;
+    }
+    return undefined;
+  };
+  return (
+    pick("fullName", "ko") ||
+    pick("fullName", "en") ||
+    pick("fontFamily", "ko") ||
+    pick("fontFamily", "en")
+  );
+}

--- a/src/main/tests/opentype-v2-contract.integration.test.ts
+++ b/src/main/tests/opentype-v2-contract.integration.test.ts
@@ -60,6 +60,8 @@ describe("opentype.js v2 계약 (FontManager 의존 표면)", () => {
     const svg = font.getPath("가", 0, 0, 32).toSVG(2);
     expect(typeof svg).toBe("string");
     expect(svg.length).toBeGreaterThan(0);
+    // v2 toSVG는 fill 속성을 생략 → FontManager가 replace 없이 path를 그대로 삽입하는 근거.
+    expect(svg).not.toContain("fill=");
     const os2 = font.tables.os2 as { sTypoAscender?: unknown };
     expect(typeof os2.sTypoAscender).toBe("number");
   });

--- a/src/main/tests/pickFontName.test.ts
+++ b/src/main/tests/pickFontName.test.ts
@@ -1,0 +1,101 @@
+// src/main/tests/pickFontName.test.ts
+import { describe, it, expect } from "vitest";
+
+import { pickFontName } from "../services/pickFontName";
+
+/**
+ * pickFontName 우선순위/폴백 순수 단위 테스트.
+ *
+ * 실폰트 한 개의 happy path만 지나가는 opentype-v2-contract 테스트와 달리,
+ * 여기서는 합성 names 객체로 분기(프로퍼티×언어×플랫폼)를 직접 고정한다.
+ * 우선순위: fullName.ko → fullName.en → fontFamily.ko → fontFamily.en,
+ * 각 쌍마다 플랫폼은 windows → macintosh → unicode 순.
+ */
+describe("pickFontName", () => {
+  it("전부 존재하면 windows.fullName.ko를 최우선으로 고른다", () => {
+    const names = {
+      windows: {
+        fullName: { ko: "한글 풀네임", en: "English Full" },
+        fontFamily: { ko: "한글 패밀리", en: "English Family" },
+      },
+    };
+    expect(pickFontName(names)).toBe("한글 풀네임");
+  });
+
+  it("fullName에서 ko가 en보다 우선한다", () => {
+    const names = { windows: { fullName: { ko: "코", en: "En" } } };
+    expect(pickFontName(names)).toBe("코");
+    const enOnly = { windows: { fullName: { en: "En" } } };
+    expect(pickFontName(enOnly)).toBe("En");
+  });
+
+  it("fullName이 fontFamily보다 우선한다 (fullName.en > fontFamily.ko)", () => {
+    const names = {
+      windows: {
+        fullName: { en: "Full En" },
+        fontFamily: { ko: "패밀리 코" },
+      },
+    };
+    expect(pickFontName(names)).toBe("Full En");
+  });
+
+  it("같은 (프로퍼티,언어)에서 플랫폼은 windows > macintosh > unicode", () => {
+    const all = {
+      windows: { fullName: { ko: "W" } },
+      macintosh: { fullName: { ko: "M" } },
+      unicode: { fullName: { ko: "U" } },
+    };
+    expect(pickFontName(all)).toBe("W");
+    expect(
+      pickFontName({ macintosh: all.macintosh, unicode: all.unicode }),
+    ).toBe("M");
+    expect(pickFontName({ unicode: all.unicode })).toBe("U");
+  });
+
+  it("macintosh-only ko: windows 부재 시 플랫폼을 폴스루한다", () => {
+    const names = { macintosh: { fullName: { ko: "맥 전용" } } };
+    expect(pickFontName(names)).toBe("맥 전용");
+  });
+
+  it("(프로퍼티·언어) 쌍이 플랫폼보다 바깥 우선순위다 — windows.fontFamily.en < macintosh.fullName.ko", () => {
+    // 올바른 구현(쌍 바깥·플랫폼 안쪽): fullName.ko가 모든 fontFamily보다 먼저라 "MK".
+    // 틀린 구현(플랫폼 바깥): windows를 먼저 소진해 "WF"가 됨 → 이 케이스만이 둘을 구분.
+    const names = {
+      windows: { fontFamily: { en: "WF" } },
+      macintosh: { fullName: { ko: "MK" } },
+    };
+    expect(pickFontName(names)).toBe("MK");
+  });
+
+  it("fullName이 전혀 없으면 fontFamily로 폴백한다 (ko 우선)", () => {
+    const names = {
+      windows: { fontFamily: { ko: "패밀리 코", en: "Fam En" } },
+    };
+    expect(pickFontName(names)).toBe("패밀리 코");
+    const enOnly = { windows: { fontFamily: { en: "Fam En" } } };
+    expect(pickFontName(enOnly)).toBe("Fam En");
+  });
+
+  it("빈 문자열 값은 없는 것으로 간주하고 다음 후보로 넘어간다", () => {
+    const names = {
+      windows: { fullName: { ko: "", en: "" } },
+      macintosh: { fullName: { ko: "맥 코" } },
+    };
+    expect(pickFontName(names)).toBe("맥 코");
+  });
+
+  it("이름 부재: 어떤 후보도 없으면 undefined", () => {
+    expect(pickFontName({})).toBeUndefined();
+    expect(pickFontName({ windows: {} })).toBeUndefined();
+    expect(pickFontName({ windows: { fullName: {} } })).toBeUndefined();
+    expect(
+      pickFontName({ windows: { postScriptName: { en: "PS" } } }),
+    ).toBeUndefined();
+  });
+
+  it("names가 객체가 아니면(undefined/null/문자열) undefined", () => {
+    expect(pickFontName(undefined)).toBeUndefined();
+    expect(pickFontName(null)).toBeUndefined();
+    expect(pickFontName("not-a-table")).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

- `FontManager.pickFontName`(private) → `src/main/services/pickFontName.ts` 모듈 순수함수로 분리하고 우선순위 엣지 단위테스트 10건 신규.
- `generateFontThumbnail`의 `replace('fill="black"', …)` 제거 — opentype.js v2 `toSVG`가 fill 속성을 생략해 no-op(사실 최초 도입 `0196b3a`·v1부터 dead code, v2 회귀 아님). 렌더 보정 계약(FontManagerModal 흰 배경 / ExternalFontImportModal invert 필터)을 주석화하고 계약 테스트로 고정.
- AGENTS-ROADMAP: `@types/opentype.js`를 '유지' 결론으로 종결(opentype.js v2 자체 타입 미번들 확인).

## 배경

AGENTS-ROADMAP 백로그의 폰트 정리 3건. `pickFontName`은 FontManager가 Electron 런타임 의존이라 vitest 인스턴스화가 불가능해 우선순위 로직을 직접 단위테스트할 수 없었음 → 순수함수로 분리해 (프로퍼티 × 언어 × 플랫폼) 우선순위·폴스루·부재 케이스를 고정한다.

런타임 동작 무변경(순수 이동 + 확정 dead code 제거). blast radius 0 — config schema/IPC/EventBus/updater/카카오 셀렉터 무관. 분리 리뷰 '조건부 통과'(지적 2건 반영 완료).
