### PR TITLE
chore: husky pre-commit이 WSL에서 lint-staged를 Windows pwsh로 위임

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,16 @@
-npx lint-staged
+# WSL에서는 공유 node_modules에 Linux 네이티브 바인딩(unrs-resolver/rollup 등)이
+# 없어 lint-staged→eslint가 "Cannot find native binding"으로 실패한다. 같은
+# node_modules를 Windows pwsh(npm ci)로 채워 두기 때문. → WSL 감지 시 lint-staged
+# 실행을 Windows pwsh에 위임한다(경로는 wslpath로 동적 산출, 하드코딩 금지).
+if grep -qiE 'microsoft|WSL' /proc/version 2>/dev/null; then
+  WINDIR="$(wslpath -w "$PWD" 2>/dev/null || true)"
+  PS="$(command -v pwsh.exe || command -v powershell.exe || true)"
+  if [ -z "$PS" ] || [ -z "$WINDIR" ]; then
+    echo "husky(pre-commit): WSL 감지했으나 pwsh/wslpath 미탐지 — lint-staged를 실행할 수 없습니다." >&2
+    echo "  Windows pwsh에서 커밋하거나 도구 설치를 확인하세요(--no-verify로 강제하지 말 것)." >&2
+    exit 1
+  fi
+  "$PS" -NoProfile -Command "\$ErrorActionPreference='Stop'; Set-Location -LiteralPath '$WINDIR'; npx lint-staged; if (\$null -eq \$LASTEXITCODE) { exit 1 }; exit \$LASTEXITCODE"
+else
+  npx lint-staged
+fi


### PR DESCRIPTION
## Summary

- `.husky/pre-commit`가 WSL 감지 시(`/proc/version`) lint-staged를 Windows pwsh에 위임(경로는 `wslpath -w`로 동적 산출, 하드코딩 없음). 비-WSL 경로는 기존 `npx lint-staged` 그대로.
- pwsh/wslpath 미탐지 시 fail-closed(`exit 1`) — lint를 조용히 건너뛰지 않음. lint-staged 실패 종료코드도 훅으로 전파.

## 배경

WSL에서 `git commit` 시 lint-staged→eslint가 `unrs-resolver` "Cannot find native binding"으로 실패한다(공유 node_modules를 Windows `npm ci`로 채워 Linux 바인딩 부재). 지금까지 커밋만 Windows pwsh에서 수행하는 회피를 써 왔고, 이 위임으로 WSL에서도 `--no-verify` 없이 커밋할 수 있다.

AGENTS-ROADMAP 백로그의 마지막 항목. 설계 근거·선결검증 메모: `docs/archive/2026-05-20-residual-work.md` §2.5. 분리 리뷰 '조건부 통과'(silent-pass 봉인 + `sh -e` dead-code 2건 반영 완료).
