### PR TITLE
fix: 외부 링크를 열 수 없을 때 치명적 오류가 표시되는 문제 수정

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -103,6 +103,7 @@ import {
   printBanner,
 } from "./utils/logger";
 import { LogParser } from "./utils/LogParser";
+import { openExternalSafely } from "./utils/open-external";
 import { PowerShellManager } from "./utils/powershell";
 import {
   getGameInstallPath,
@@ -2026,7 +2027,7 @@ async function createWindow() {
   // [Security] Force external links to open in default browser
   mainWindow.webContents.setWindowOpenHandler(({ url }) => {
     if (url.startsWith("http:") || url.startsWith("https:")) {
-      shell.openExternal(url);
+      void openExternalSafely(url, mainWindow);
     }
     return { action: "deny" };
   });
@@ -2040,7 +2041,7 @@ async function createWindow() {
 
     if (!isInternal && (url.startsWith("http:") || url.startsWith("https:"))) {
       event.preventDefault();
-      shell.openExternal(url);
+      void openExternalSafely(url, mainWindow);
     }
   });
 

--- a/src/main/tests/open-external.test.ts
+++ b/src/main/tests/open-external.test.ts
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { openExternalSafely } from "../utils/open-external";
+
+const mocks = vi.hoisted(() => ({
+  clipboardWriteText: vi.fn(),
+  dialogShowMessageBox: vi.fn(),
+  loggerError: vi.fn(),
+  loggerWarn: vi.fn(),
+  shellOpenExternal: vi.fn(),
+}));
+
+vi.mock("electron", () => ({
+  clipboard: {
+    writeText: mocks.clipboardWriteText,
+  },
+  dialog: {
+    showMessageBox: mocks.dialogShowMessageBox,
+  },
+  shell: {
+    openExternal: mocks.shellOpenExternal,
+  },
+}));
+
+vi.mock("../utils/logger", () => ({
+  logger: {
+    error: mocks.loggerError,
+    warn: mocks.loggerWarn,
+  },
+}));
+
+describe("openExternalSafely", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.dialogShowMessageBox.mockResolvedValue({ response: 1 });
+    mocks.shellOpenExternal.mockResolvedValue(undefined);
+  });
+
+  it("opens the URL without showing recovery UI when a browser is available", async () => {
+    await expect(openExternalSafely("https://example.com")).resolves.toBe(true);
+
+    expect(mocks.shellOpenExternal).toHaveBeenCalledWith("https://example.com");
+    expect(mocks.dialogShowMessageBox).not.toHaveBeenCalled();
+    expect(mocks.clipboardWriteText).not.toHaveBeenCalled();
+  });
+
+  it("turns browser launch failures into a non-fatal recovery dialog", async () => {
+    const openError = new Error("Failed to open: application not found");
+    mocks.shellOpenExternal.mockRejectedValueOnce(openError);
+
+    await expect(openExternalSafely("https://example.com")).resolves.toBe(
+      false,
+    );
+
+    expect(mocks.loggerWarn).toHaveBeenCalledWith(
+      "[ExternalLink] Failed to open URL in the default browser.",
+      openError,
+    );
+    expect(mocks.dialogShowMessageBox).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "기본 브라우저에서 링크를 열지 못했습니다.",
+        buttons: ["링크 복사", "확인"],
+      }),
+    );
+  });
+
+  it("attaches the recovery dialog to a live parent window", async () => {
+    const parentWindow = {
+      isDestroyed: vi.fn(() => false),
+    } as unknown as NonNullable<Parameters<typeof openExternalSafely>[1]>;
+    mocks.shellOpenExternal.mockRejectedValueOnce(new Error("no browser"));
+
+    await openExternalSafely("https://example.com", parentWindow);
+
+    expect(mocks.dialogShowMessageBox).toHaveBeenCalledWith(
+      parentWindow,
+      expect.objectContaining({
+        message: "기본 브라우저에서 링크를 열지 못했습니다.",
+      }),
+    );
+  });
+
+  it("skips recovery UI when the parent window was destroyed", async () => {
+    const parentWindow = {
+      isDestroyed: vi.fn(() => true),
+    } as unknown as NonNullable<Parameters<typeof openExternalSafely>[1]>;
+    mocks.shellOpenExternal.mockRejectedValueOnce(new Error("no browser"));
+
+    await expect(
+      openExternalSafely("https://example.com", parentWindow),
+    ).resolves.toBe(false);
+
+    expect(mocks.dialogShowMessageBox).not.toHaveBeenCalled();
+    expect(mocks.loggerWarn).toHaveBeenCalledWith(
+      "[ExternalLink] Skipped the recovery dialog because its parent window was destroyed.",
+    );
+  });
+
+  it("copies the original URL when the user selects link copy", async () => {
+    mocks.shellOpenExternal.mockRejectedValueOnce(new Error("no browser"));
+    mocks.dialogShowMessageBox.mockResolvedValueOnce({ response: 0 });
+
+    await openExternalSafely("https://example.com/path?q=1");
+
+    expect(mocks.clipboardWriteText).toHaveBeenCalledWith(
+      "https://example.com/path?q=1",
+    );
+  });
+
+  it("does not reject even if the recovery dialog also fails", async () => {
+    const dialogError = new Error("dialog unavailable");
+    mocks.shellOpenExternal.mockRejectedValueOnce(new Error("no browser"));
+    mocks.dialogShowMessageBox.mockRejectedValueOnce(dialogError);
+
+    await expect(openExternalSafely("https://example.com")).resolves.toBe(
+      false,
+    );
+
+    expect(mocks.loggerError).toHaveBeenCalledWith(
+      "[ExternalLink] Failed to show the recovery dialog.",
+      dialogError,
+    );
+  });
+
+  it("does not reject when copying the fallback URL fails", async () => {
+    const clipboardError = new Error("clipboard unavailable");
+    mocks.shellOpenExternal.mockRejectedValueOnce(new Error("no browser"));
+    mocks.dialogShowMessageBox.mockResolvedValueOnce({ response: 0 });
+    mocks.clipboardWriteText.mockImplementationOnce(() => {
+      throw clipboardError;
+    });
+
+    await expect(openExternalSafely("https://example.com")).resolves.toBe(
+      false,
+    );
+
+    expect(mocks.loggerError).toHaveBeenCalledWith(
+      "[ExternalLink] Failed to copy URL to the clipboard.",
+      clipboardError,
+    );
+  });
+});

--- a/src/main/utils/open-external.ts
+++ b/src/main/utils/open-external.ts
@@ -1,0 +1,67 @@
+import {
+  clipboard,
+  dialog,
+  shell,
+  type BrowserWindow,
+  type MessageBoxOptions,
+} from "electron";
+
+import { logger } from "./logger";
+
+const OPEN_EXTERNAL_FAILURE_OPTIONS: MessageBoxOptions = {
+  type: "warning",
+  title: "외부 링크 열기 실패",
+  message: "기본 브라우저에서 링크를 열지 못했습니다.",
+  detail:
+    "Windows 설정 > 앱 > 기본 앱에서 사용할 브라우저를 기본값으로 설정한 뒤 다시 시도해 주세요.\n\n필요하면 링크를 복사하여 브라우저 주소창에 붙여넣을 수 있습니다.",
+  buttons: ["링크 복사", "확인"],
+  defaultId: 1,
+  cancelId: 1,
+  noLink: true,
+};
+
+export async function openExternalSafely(
+  url: string,
+  parentWindow?: BrowserWindow | null,
+): Promise<boolean> {
+  try {
+    await shell.openExternal(url);
+    return true;
+  } catch (error) {
+    logger.warn(
+      "[ExternalLink] Failed to open URL in the default browser.",
+      error,
+    );
+  }
+
+  if (parentWindow?.isDestroyed()) {
+    logger.warn(
+      "[ExternalLink] Skipped the recovery dialog because its parent window was destroyed.",
+    );
+    return false;
+  }
+
+  let shouldCopyUrl = false;
+
+  try {
+    const result = parentWindow
+      ? await dialog.showMessageBox(parentWindow, OPEN_EXTERNAL_FAILURE_OPTIONS)
+      : await dialog.showMessageBox(OPEN_EXTERNAL_FAILURE_OPTIONS);
+    shouldCopyUrl = result.response === 0;
+  } catch (error) {
+    logger.error("[ExternalLink] Failed to show the recovery dialog.", error);
+  }
+
+  if (shouldCopyUrl) {
+    try {
+      clipboard.writeText(url);
+    } catch (error) {
+      logger.error(
+        "[ExternalLink] Failed to copy URL to the clipboard.",
+        error,
+      );
+    }
+  }
+
+  return false;
+}


### PR DESCRIPTION
## Summary

- 외부 링크 실행 실패를 전역 치명적 오류 대신 비치명적 복구 흐름으로 처리합니다.
- Windows 기본 브라우저 설정 안내와 링크 복사 기능을 제공합니다.
- 대화상자와 클립보드 실패, 부모 창 종료 경합을 포함한 회귀 테스트를 추가합니다.

## Motivation

Edge 제거 등으로 Windows의 HTTP/HTTPS 기본 앱 연결이 없거나 손상되면 Electron의 외부 링크 실행 Promise가 거부됐습니다. 기존 코드는 이 거부를 처리하지 않아 실제 런처 장애가 아닌 상황도 FATAL 오류로 표시했으므로, 사용자가 직접 복구할 수 있는 안내로 전환합니다.
