### PR TITLE
fix: 예약 패치 실행이 예상보다 오래 걸릴 때 실패 알림이 표시되는 문제 수정

### DIFF
--- a/docs/archive/2026-07-19-patch-reservation-watchdog.md
+++ b/docs/archive/2026-07-19-patch-reservation-watchdog.md
@@ -1,0 +1,102 @@
+# 예약 패치 무응답 watchdog 개선
+
+> 작성일: 2026-07-19 · 갱신: 2026-07-20 · 상태: 완료 · 브랜치: `fix/patch-reservation-watchdog`
+
+## 배경
+
+POE1 Kakao Games 예약 패치가 실제로는 다운로드를 정상 진행했지만,
+`TRIGGERED` 진입 후 고정 30초가 지나자 실패 알림을 표시했다. 로그에서는
+런처 프로세스 활동이 27초, 게임 프로세스 및 로그 세션이 36~37초,
+패치 확인 완료가 44초, UI 완료가 86초에 관찰됐다.
+
+현재 `TRIGGERED` 타이머는 이름과 달리 마지막 활동 기준 silence timeout이
+아니라 상태 진입 기준 절대 timeout이다. 30초가 지나면 실행 이벤트 구독을
+모두 제거하므로 이후의 정상 패치 진행과 완료를 관찰하지 못한다.
+
+회귀 경계는 `4536cfe`(`feat: 게임 예약 패치 성능 최적화`)다. 이 변경에서
+초기 제한이 60초에서 30초로 단축되고 `PATCH_RESERVATION_SUCCESS` 기반
+timeout 해제가 제거됐다.
+
+## 소유권과 경계
+
+- `PatchReservationService`: 예약 task, FSM, 현재 PID, watchdog의 단일 owner
+- `ProcessWatcher`: 프로세스 시작/종료 사실의 owner
+- `LogWatcher`: 로그 세션과 패치 확인 사실의 owner
+- `AutoPatchHandler`: WebRoot 기반 예약 readiness/failure 신호의 owner
+- 새 EventBus 이벤트, IPC, 설정 필드는 추가하지 않는다.
+- 실제 다운로드 총시간에는 절대 제한을 두지 않는다.
+
+## 계획
+
+### M1. 회귀 테스트
+
+- 실제 로그 순서(27초 process start → 37초 session/readiness → 44초 patch
+  check → 장시간 title tick → done)를 fake timer로 재현한다.
+- 각 유효 활동 후 59초까지 생존하고 추가 활동 없이 60초가 되면 실패하는
+  계약을 고정한다.
+- PID 교체, 이전 task의 stale timeout, 기존 PID 종료 무시를 검증한다.
+
+### M2. sliding watchdog
+
+- 단계별 무응답 제한과 PID 교체 유예를 각각 60초 상수로 정의한다.
+- task generation과 예상 상태를 timeout callback에서 재검증한다.
+- `PROCESS_START`, `LOG_SESSION_START`, `PATCH_RESERVATION_SUCCESS`를 현재
+  task의 유효 활동으로 처리한다.
+- `LOG_PATCH_CHECK_COMPLETE`만 `TRIGGERED`에서 `PATCH_WAITING`으로 전환한다.
+- `PATCH_WAITING`에서는 현재 PID의 UI title tick을 liveness로 인정한다.
+- 현재 PID가 종료되면 state watchdog을 멈추고 60초 PID 교체 유예로
+  전환한다. 후속 process/session 신호에서 state watchdog을 재개한다.
+- `PATCH_RESERVATION_FAILED`는 현재 task에 한해 즉시 실패 처리한다.
+
+### M3. 검증과 리뷰
+
+- Windows PowerShell에서 관련 테스트, 전체 테스트, lint, build:check를
+  실행한다.
+- 구현과 분리된 리뷰어가 DoD, 이벤트 소유권, timeout 경합을 검토한다.
+- 실제 Windows POE1 예약 패치 확인은 사용자가 수행한다.
+
+## DoD
+
+- `[Windows-pwsh]` 각 상태의 유효 활동 후 59초에는 실패하지 않고, 이후
+  60초 동안 무응답이면 실패한다.
+- `[Windows-pwsh]` 다운로드가 1분을 넘더라도 현재 patch PID의 title tick이
+  계속되면 실패하지 않는다.
+- `[Windows-pwsh]` 현재 PID 종료 후 60초 이내 교체 PID가 나타나면 작업을
+  유지하고, 나타나지 않으면 실패한다.
+- `[Windows-pwsh]` 이전 PID 종료와 이전 task의 stale timeout은 현재 task에
+  영향을 주지 않는다.
+- `[Windows-pwsh]` no-update, 완료, 명시적 예약 실패 경로가 유지된다.
+- `[Windows-pwsh]` 전체 테스트, lint, build:check가 통과한다.
+- `[사용자]` POE1 예약 패치가 오류 알림 없이 실제 완료되고 설정에 따른
+  후속 종료까지 정상 동작한다.
+
+## 설계 리뷰
+
+- 2026-07-19 설계 패스: 진행 가능, blocking 없음.
+- 이벤트 payload에 reservation id가 없어 같은 game/service의 늦은 domain
+  event를 완전히 상관시킬 수는 없다. 이번 수정은 local generation으로 stale
+  timeout을 차단하고, 이벤트 schema 확장은 범위에 포함하지 않는다.
+
+## 검증 현황
+
+- 전용 회귀 테스트: 구현 전 6건 실패 → 구현 후 6건 통과
+- 전체 테스트 1차: 신규 테스트 포함 207건 통과, 무관한
+  `UpdateHandler.test.ts` 1건이 5초 suite timeout으로 실패
+- `UpdateHandler.test.ts` 단독 재실행: 2건 통과
+- 전체 테스트 2차: 42개 파일, 208건 전부 통과
+- 전체 ESLint: 통과
+- `build:check`(`tsc && vite build`): 통과
+
+## 구현 리뷰
+
+- 2026-07-19 리뷰 1라운드: **통과**, blocking 지적 없음.
+- sliding state watchdog/PID rotation, generation+epoch 방어, terminal-first
+  전환, 큐/stop cleanup, no-update 및 `terminateAfterPatch` 의미 보존 확인.
+- 새 이벤트, IPC, 설정 계약 변경 없음.
+- 2026-07-20 `[사용자]`: POE1 예약 패치 실동작 정상 확인.
+- 사용자 검증을 포함한 모든 DoD 통과.
+
+## 마무리
+
+- 로컬에서 `project_llm_wiki` 저장소를 찾지 못해 raw note 작성 및 `/ingest`는
+  수행하지 못했다. 이 문서를 완료 기록으로 `docs/archive/`에 보존한다.

--- a/src/main/services/PatchReservationService.ts
+++ b/src/main/services/PatchReservationService.ts
@@ -12,13 +12,13 @@ import { Notification } from "electron";
  *    - 처리 위치: `handleGameStartup`
  *
  * 3. 실패 (Failure / Canceled)
- *    - 프로세스 종료(`PROCESS_STOP`) 후 10초 내에 새로운 프로세스가 시작되지 않고,
+ *    - 프로세스 종료(`PROCESS_STOP`) 후 60초 내에 새로운 프로세스가 시작되지 않고,
  *    - 이전에 "완료" 문구를 확인하지 못한 상태인 경우.
- *    - 처리 위치: `handleProcessStop` -> `abnormalExitTimeout` (10초 유예)
+ *    - 처리 위치: `PR_ProcessStopHandler` -> `abnormalExitTimeout` (60초 유예)
  *
  * 4. PID 교체 (Normal Flow)
- *    - 프로세스 종료 후 10초 이내에 새로운 세션(`LOG_SESSION_START`)이 시작되는 경우.
- *    - 처리 위치: `handleProcessStop`에서 타이머 시작 -> `LOG_SESSION_START`에서 타이머 해제
+ *    - 프로세스 종료 후 60초 이내에 새 프로세스나 세션이 시작되는 경우.
+ *    - 처리 위치: `PR_ProcessStopHandler`에서 타이머 시작 -> 시작 신호에서 해제
  */
 import { PatchReservation, AppConfig } from "../../shared/types";
 import { GAME_SERVICE_PROFILES } from "../config/GameServiceProfiles";
@@ -34,6 +34,8 @@ import {
   LogPatchCheckCompleteEvent,
   LogGameStartupEvent,
   ProcessEvent,
+  PatchReservationFailedEvent,
+  PatchReservationSuccessEvent,
   PatchRetryRequestedEvent,
   ConfigChangeEvent,
   PatchUiTitleTickEvent,
@@ -52,9 +54,13 @@ export enum PatchTaskStatus {
 
 export type PatchTaskResult = "success" | "failure" | "no-update";
 
+const INACTIVITY_TIMEOUT_MS = 60_000;
+const PID_ROTATION_GRACE_MS = 60_000;
+
 interface TaskContext {
   reservation: PatchReservation;
   currentPid: number | null;
+  generation: number;
 }
 
 export class PatchReservationService implements IService {
@@ -75,6 +81,9 @@ export class PatchReservationService implements IService {
   // State-specific timeouts
   private stateTimeout: NodeJS.Timeout | null = null;
   private abnormalExitTimeout: NodeJS.Timeout | null = null;
+  private stateWatchdogEpoch = 0;
+  private abnormalExitWatchdogEpoch = 0;
+  private taskGeneration = 0;
 
   // Dynamic listener IDs for cleanup
   private dynamicListenerIds: Map<EventType, string> = new Map();
@@ -126,6 +135,13 @@ export class PatchReservationService implements IService {
     nextStatus: PatchTaskStatus,
     result?: PatchTaskResult,
   ) {
+    if (
+      nextStatus === PatchTaskStatus.COMPLETED &&
+      (this.status === PatchTaskStatus.COMPLETED || !this.currentContext)
+    ) {
+      return;
+    }
+
     const prevStatus = this.status;
     const now = Date.now();
     const duration =
@@ -140,11 +156,8 @@ export class PatchReservationService implements IService {
       `[FSM] Transition: [${prevStatus}] -> [${nextStatus}]${duration}${result ? ` (Result: ${result})` : ""}`,
     );
 
-    // Stop current state timer if any
-    if (this.stateTimeout) {
-      clearTimeout(this.stateTimeout);
-      this.stateTimeout = null;
-    }
+    // Stop current state timer and invalidate already-queued callbacks.
+    this.clearStateWatchdog();
 
     switch (nextStatus) {
       case PatchTaskStatus.TRIGGERED:
@@ -165,12 +178,14 @@ export class PatchReservationService implements IService {
   private async handleTriggeredEntry() {
     if (!this.currentContext) return;
     const { reservation } = this.currentContext;
-    const key = `${reservation.gameId}_${reservation.serviceId}`;
 
     // 1. Subscribe to events
     this.subscribeExecutionEvents();
 
-    // 2. Start game/patch
+    // 2. Arm before launch so early activity cannot race ahead of the watchdog.
+    this.armStateWatchdog("reservation triggered");
+
+    // 3. Start game/patch
     const retryCount = (reservation as PatchReservation).retryCount || 0;
     registerAutoPatchExpectation(
       reservation.gameId,
@@ -185,16 +200,10 @@ export class PatchReservationService implements IService {
         res.serviceId as AppConfig["serviceChannel"],
       );
     }
-    eventBus.emit<UIEvent>(EventType.UI_GAME_START_CLICK, this.context, {
+    await eventBus.emit<UIEvent>(EventType.UI_GAME_START_CLICK, this.context, {
       gameId: res.gameId as AppConfig["activeGame"],
       serviceId: res.serviceId as AppConfig["serviceChannel"],
     });
-
-    // 3. 30s Silence Timeout
-    this.stateTimeout = setTimeout(() => {
-      logger.warn(`[FSM] TRIGGERED 30s Silence timeout for ${key}.`);
-      this.transitionTo(PatchTaskStatus.COMPLETED, "failure");
-    }, 30000);
   }
 
   private handlePatchWaitingEntry() {
@@ -203,22 +212,30 @@ export class PatchReservationService implements IService {
     logger.log(
       `[FSM] Entered PATCH_WAITING for ${key}. Watching UI for "Done" or PID swap...`,
     );
+    this.armStateWatchdog("patch waiting entered");
   }
 
   private async handleCompletedEntry(result: PatchTaskResult) {
     if (!this.currentContext) return;
-    const { gameId, serviceId } = this.currentContext.reservation;
+    const { reservation, currentPid } = this.currentContext;
+    const { gameId, serviceId } = reservation;
 
     // 1. Unsubscribe
     this.cleanupExecutionListeners();
 
     // 2. Clear all state timers
-    if (this.abnormalExitTimeout) {
-      clearTimeout(this.abnormalExitTimeout);
-      this.abnormalExitTimeout = null;
+    this.clearStateWatchdog();
+    this.clearAbnormalExitWatchdog();
+
+    // 3. Stop the observed patch/game process only after terminal state is locked.
+    if (result === "success" || result === "no-update") {
+      const terminate = this.context.getConfig("terminateAfterPatch") !== false;
+      if (terminate) {
+        await this.cleanupProcess(gameId, serviceId, currentPid);
+      }
     }
 
-    // 3. Notification
+    // 4. Notification
     if (result === "success" || result === "no-update") {
       this.notifyUpdateResult(gameId, serviceId, result === "success");
     } else {
@@ -229,11 +246,11 @@ export class PatchReservationService implements IService {
       });
     }
 
-    // 4. Cleanup context
+    // 5. Cleanup context
     this.currentContext = null;
 
-    // 5. Back to IDLE
-    this.transitionTo(PatchTaskStatus.IDLE);
+    // 6. Back to IDLE
+    await this.transitionTo(PatchTaskStatus.IDLE);
   }
 
   private handleIdleEntry() {
@@ -242,10 +259,107 @@ export class PatchReservationService implements IService {
     this.processQueue();
   }
 
+  private clearStateWatchdog() {
+    this.stateWatchdogEpoch += 1;
+    if (this.stateTimeout) clearTimeout(this.stateTimeout);
+    this.stateTimeout = null;
+  }
+
+  private clearAbnormalExitWatchdog() {
+    this.abnormalExitWatchdogEpoch += 1;
+    if (this.abnormalExitTimeout) clearTimeout(this.abnormalExitTimeout);
+    this.abnormalExitTimeout = null;
+  }
+
+  private armStateWatchdog(reason: string) {
+    if (
+      !this.currentContext ||
+      (this.status !== PatchTaskStatus.TRIGGERED &&
+        this.status !== PatchTaskStatus.PATCH_WAITING)
+    ) {
+      return;
+    }
+
+    this.clearStateWatchdog();
+    const { reservation, generation } = this.currentContext;
+    const expectedStatus = this.status;
+    const expectedEpoch = this.stateWatchdogEpoch;
+    const key = `${reservation.gameId}_${reservation.serviceId}`;
+
+    logger.log(
+      `[FSM] ${expectedStatus} activity for ${key} (${reason}). Resetting 60s inactivity watchdog.`,
+    );
+
+    this.stateTimeout = setTimeout(() => {
+      if (
+        this.currentContext?.generation !== generation ||
+        this.status !== expectedStatus ||
+        this.stateWatchdogEpoch !== expectedEpoch
+      ) {
+        return;
+      }
+
+      this.stateTimeout = null;
+      logger.warn(`[FSM] ${expectedStatus} 60s inactivity timeout for ${key}.`);
+      void this.transitionTo(PatchTaskStatus.COMPLETED, "failure");
+    }, INACTIVITY_TIMEOUT_MS);
+  }
+
+  private resumeFromProcessActivity(pid: number, reason: string) {
+    if (!this.currentContext) return;
+    this.currentContext.currentPid = pid;
+    this.clearAbnormalExitWatchdog();
+    this.armStateWatchdog(reason);
+  }
+
+  private armAbnormalExitWatchdog(stoppedPid: number) {
+    if (!this.currentContext) return;
+
+    this.clearAbnormalExitWatchdog();
+    const { reservation, generation } = this.currentContext;
+    const expectedStatus = this.status;
+    const expectedEpoch = this.abnormalExitWatchdogEpoch;
+    const key = `${reservation.gameId}_${reservation.serviceId}`;
+
+    logger.warn(
+      `[FSM] Process ${stoppedPid} stopped for ${key}. Waiting 60s for PID rotation...`,
+    );
+
+    this.abnormalExitTimeout = setTimeout(() => {
+      if (
+        this.currentContext?.generation !== generation ||
+        this.currentContext.currentPid !== null ||
+        this.status !== expectedStatus ||
+        this.abnormalExitWatchdogEpoch !== expectedEpoch
+      ) {
+        return;
+      }
+
+      this.abnormalExitTimeout = null;
+      logger.error(
+        `[FSM] Process did not recover after 60s for ${key}. Ending task.`,
+      );
+      void this.transitionTo(PatchTaskStatus.COMPLETED, "failure");
+    }, PID_ROTATION_GRACE_MS);
+  }
+
   private subscribeExecutionEvents() {
     this.cleanupExecutionListeners();
 
-    // 1. Session Start (PID Tracking)
+    // 1. Process Start (launcher/patcher activity and PID rotation)
+    this.registerHandler<ProcessEvent>({
+      id: "PR_ProcessStartHandler",
+      targetEvent: EventType.PROCESS_START,
+      handle: async (event) => {
+        const { gameId, serviceId, pid } = event.payload;
+        if (!gameId || !serviceId) return;
+        if (!this.isCurrentTask(gameId as string, serviceId as string)) return;
+
+        this.resumeFromProcessActivity(pid, "process started");
+      },
+    });
+
+    // 2. Session Start (PID Tracking)
     this.registerHandler({
       id: "PR_LogSessionHandler",
       targetEvent: EventType.LOG_SESSION_START,
@@ -257,28 +371,52 @@ export class PatchReservationService implements IService {
           logger.log(
             `[FSM] PID Rotation detected: ${pid}. Clearing exit timeout.`,
           );
-          clearTimeout(this.abnormalExitTimeout);
-          this.abnormalExitTimeout = null;
         }
-        if (this.currentContext) this.currentContext.currentPid = pid;
+        this.resumeFromProcessActivity(pid, "log session started");
         logger.log(`[FSM] Tracking PID ${pid} for ${gameId}_${serviceId}`);
       },
     });
 
-    // 2. Patch Check Complete
+    // 3. WebRoot readiness is activity, not final patch completion.
+    this.registerHandler<PatchReservationSuccessEvent>({
+      id: "PR_ReservationSuccessHandler",
+      targetEvent: EventType.PATCH_RESERVATION_SUCCESS,
+      handle: async (event) => {
+        const { gameId, serviceId } = event.payload;
+        if (!this.isCurrentTask(gameId, serviceId)) return;
+        if (this.currentContext?.currentPid === null) return;
+
+        this.armStateWatchdog("patch reservation ready");
+      },
+    });
+
+    // 4. Explicit auto-patch failure
+    this.registerHandler<PatchReservationFailedEvent>({
+      id: "PR_ReservationFailedHandler",
+      targetEvent: EventType.PATCH_RESERVATION_FAILED,
+      handle: async (event) => {
+        const { gameId, serviceId } = event.payload;
+        if (!this.isCurrentTask(gameId, serviceId)) return;
+
+        await this.transitionTo(PatchTaskStatus.COMPLETED, "failure");
+      },
+    });
+
+    // 5. Patch Check Complete
     this.registerHandler({
       id: "PR_LogPatchCheckCompleteHandler",
       targetEvent: EventType.LOG_PATCH_CHECK_COMPLETE,
       handle: async (event: LogPatchCheckCompleteEvent) => {
-        const { gameId, serviceId } = event.payload;
+        const { gameId, serviceId, pid } = event.payload;
         if (!this.isCurrentTask(gameId as string, serviceId as string)) return;
+        this.resumeFromProcessActivity(pid, "patch check complete");
         if (this.status === PatchTaskStatus.TRIGGERED) {
-          this.transitionTo(PatchTaskStatus.PATCH_WAITING);
+          await this.transitionTo(PatchTaskStatus.PATCH_WAITING);
         }
       },
     });
 
-    // 3. Game Startup (No-update case)
+    // 6. Game Startup (No-update case)
     this.registerHandler({
       id: "PR_LogGameStartupHandler",
       targetEvent: EventType.LOG_GAME_STARTUP,
@@ -287,16 +425,12 @@ export class PatchReservationService implements IService {
         if (!this.isCurrentTask(gameId as string, serviceId as string)) return;
 
         logger.log(`[FSM] Game started directly for ${gameId}_${serviceId}.`);
-        const terminate =
-          this.context.getConfig("terminateAfterPatch") !== false;
-        if (terminate)
-          await this.cleanupProcess(gameId as string, serviceId as string, pid);
-
-        this.transitionTo(PatchTaskStatus.COMPLETED, "no-update");
+        if (this.currentContext) this.currentContext.currentPid = pid;
+        await this.transitionTo(PatchTaskStatus.COMPLETED, "no-update");
       },
     });
 
-    // 4. UI Title Detection
+    // 7. UI Title Detection
     this.registerHandler({
       id: "PR_UiTitleTickHandler",
       targetEvent: EventType.PATCH_UI_TITLE_TICK,
@@ -304,6 +438,7 @@ export class PatchReservationService implements IService {
         const { title, gameId, serviceId, pid } = event.payload;
         if (!this.isCurrentTask(gameId as string, serviceId as string)) return;
         if (this.status !== PatchTaskStatus.PATCH_WAITING) return;
+        if (this.currentContext?.currentPid !== pid) return;
 
         const isDone =
           /Done|Pronto|Завершено|Fertig|Hecho|Terminé|완료|完了|เสร็จสิ้น|完成/i.test(
@@ -311,20 +446,15 @@ export class PatchReservationService implements IService {
           );
         if (isDone) {
           logger.log(`[FSM] UI "Done" detected for ${gameId}_${serviceId}.`);
-          const terminate =
-            this.context.getConfig("terminateAfterPatch") !== false;
-          if (terminate)
-            await this.cleanupProcess(
-              gameId as string,
-              serviceId as string,
-              pid,
-            );
-          this.transitionTo(PatchTaskStatus.COMPLETED, "success");
+          await this.transitionTo(PatchTaskStatus.COMPLETED, "success");
+          return;
         }
+
+        this.armStateWatchdog("patch UI responded");
       },
     });
 
-    // 5. Process Stop (Error/Exit detection)
+    // 8. Process Stop (Error/Exit detection)
     this.registerHandler({
       id: "PR_ProcessStopHandler",
       targetEvent: EventType.PROCESS_STOP,
@@ -332,13 +462,9 @@ export class PatchReservationService implements IService {
         const { pid } = event.payload;
         if (this.currentContext?.currentPid !== pid) return;
 
-        logger.warn(
-          `[FSM] Process ${pid} stopped. Waiting 30s for recovery/rotation...`,
-        );
-        this.abnormalExitTimeout = setTimeout(() => {
-          logger.error(`[FSM] Process did not recover after 30s. Ending task.`);
-          this.transitionTo(PatchTaskStatus.COMPLETED, "failure");
-        }, 30000);
+        this.currentContext.currentPid = null;
+        this.clearStateWatchdog();
+        this.armAbnormalExitWatchdog(pid);
       },
     });
   }
@@ -396,8 +522,12 @@ export class PatchReservationService implements IService {
     this.isProcessing = true;
     const nextItem = this.reservationQueue[0];
 
-    this.currentContext = { reservation: nextItem, currentPid: null };
-    this.transitionTo(PatchTaskStatus.TRIGGERED);
+    this.currentContext = {
+      reservation: nextItem,
+      currentPid: null,
+      generation: ++this.taskGeneration,
+    };
+    void this.transitionTo(PatchTaskStatus.TRIGGERED);
   }
 
   private async cleanupProcess(
@@ -484,12 +614,13 @@ export class PatchReservationService implements IService {
   public async stop(): Promise<void> {
     for (const timer of this.scheduledTimers.values()) clearTimeout(timer);
     this.scheduledTimers.clear();
-    if (this.stateTimeout) clearTimeout(this.stateTimeout);
-    if (this.abnormalExitTimeout) clearTimeout(this.abnormalExitTimeout);
+    this.clearStateWatchdog();
+    this.clearAbnormalExitWatchdog();
     this.cleanupExecutionListeners();
     this.reservationQueue = [];
     this.isProcessing = false;
     this.currentContext = null;
     this.status = PatchTaskStatus.IDLE;
+    this.taskGeneration += 1;
   }
 }

--- a/src/main/tests/PatchReservationService.test.ts
+++ b/src/main/tests/PatchReservationService.test.ts
@@ -1,0 +1,293 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { eventBus } from "../events/EventBus";
+import { AppContext, AppEvent, EventHandler, EventType } from "../events/types";
+import { PatchReservationService } from "../services/PatchReservationService";
+import { logger } from "../utils/logger";
+
+import type { AppConfig, PatchReservation } from "../../shared/types";
+
+vi.mock("electron", () => ({
+  Notification: {
+    isSupported: vi.fn(() => false),
+  },
+}));
+
+vi.mock("../events/EventBus", () => ({
+  eventBus: {
+    emit: vi.fn(async () => undefined),
+    off: vi.fn(),
+    register: vi.fn(),
+  },
+}));
+
+vi.mock("../events/handlers/AutoPatchHandler", () => ({
+  registerAutoPatchExpectation: vi.fn(),
+}));
+
+vi.mock("../utils/config-utils", () => ({
+  setConfigWithEvent: vi.fn(),
+}));
+
+vi.mock("../utils/logger", () => ({
+  logger: {
+    error: vi.fn(),
+    log: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+vi.mock("../utils/powershell", () => ({
+  PowerShellManager: {
+    getInstance: vi.fn(() => ({
+      execute: vi.fn(async () => undefined),
+    })),
+  },
+}));
+
+const NOW = new Date("2026-07-19T12:55:00.000Z");
+const GAME_ID = "POE1";
+const SERVICE_ID = "Kakao Games";
+
+const createReservation = (id: string): PatchReservation => ({
+  id,
+  gameId: GAME_ID,
+  serviceId: SERVICE_ID,
+  targetTime: NOW.toISOString(),
+  createdAt: NOW.toISOString(),
+});
+
+describe("PatchReservationService inactivity watchdog", () => {
+  const handlers = new Map<string, EventHandler<AppEvent>>();
+  let config: AppConfig;
+  let context: AppContext;
+  let service: PatchReservationService | null;
+
+  const handlerKey = (type: EventType, id: string) => `${type}:${id}`;
+
+  const dispatch = async (type: EventType, payload: unknown) => {
+    const event = { type, payload, timestamp: Date.now() } as AppEvent;
+    const matching = [...handlers.values()].filter(
+      (handler) => handler.targetEvent === type,
+    );
+
+    for (const handler of matching) {
+      if (!handler.condition || handler.condition(event, context)) {
+        await handler.handle(event, context);
+      }
+    }
+
+    await Promise.resolve();
+  };
+
+  const startService = async (
+    reservations = [createReservation("patch-1")],
+  ) => {
+    config = {
+      patchReservations: reservations,
+      silentPatchNotification: true,
+      terminateAfterPatch: false,
+    } as AppConfig;
+    context = {
+      getConfig: vi.fn((key?: keyof AppConfig) =>
+        key === undefined ? config : config[key],
+      ),
+    } as unknown as AppContext;
+
+    service = new PatchReservationService(context);
+    await service.init();
+    await vi.advanceTimersByTimeAsync(0);
+    await Promise.resolve();
+  };
+
+  const processPayload = (pid: number) => ({
+    pid,
+    name: "PathOfExile_KG.exe",
+    path: "G:\\Daum Games\\Path of Exile\\PathOfExile_KG.exe",
+    gameId: GAME_ID,
+    serviceId: SERVICE_ID,
+  });
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    vi.clearAllMocks();
+    handlers.clear();
+    service = null;
+
+    vi.mocked(eventBus.register).mockImplementation((handler) => {
+      const captured = handler as EventHandler<AppEvent>;
+      handlers.set(handlerKey(captured.targetEvent, captured.id), captured);
+    });
+    vi.mocked(eventBus.off).mockImplementation((type, id) => {
+      handlers.delete(handlerKey(type, id));
+    });
+  });
+
+  afterEach(async () => {
+    await service?.stop();
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it("keeps the observed POE1 patch flow alive until the Done title", async () => {
+    await startService();
+
+    await vi.advanceTimersByTimeAsync(27_000);
+    await dispatch(EventType.PROCESS_START, processPayload(217_932));
+
+    await vi.advanceTimersByTimeAsync(10_000);
+    await dispatch(EventType.LOG_SESSION_START, {
+      gameId: GAME_ID,
+      serviceId: SERVICE_ID,
+      pid: 112_884,
+    });
+    await dispatch(EventType.PATCH_RESERVATION_SUCCESS, {
+      gameId: GAME_ID,
+      serviceId: SERVICE_ID,
+    });
+
+    await vi.advanceTimersByTimeAsync(2_000);
+    await dispatch(EventType.PROCESS_START, processPayload(235_412));
+    await dispatch(EventType.PROCESS_STOP, processPayload(112_884));
+
+    await vi.advanceTimersByTimeAsync(5_000);
+    await dispatch(EventType.LOG_PATCH_CHECK_COMPLETE, {
+      gameId: GAME_ID,
+      serviceId: SERVICE_ID,
+      pid: 235_412,
+    });
+
+    for (const [delay, title] of [
+      [11_000, "26.91%  속도: 87.81MB/s"],
+      [12_000, "55.35%  속도: 90.55MB/s"],
+      [10_000, "83.17%  속도: 50.49MB/s"],
+      [9_000, "완료"],
+    ] as const) {
+      await vi.advanceTimersByTimeAsync(delay);
+      await dispatch(EventType.PATCH_UI_TITLE_TICK, {
+        processName: "PathOfExile_KG",
+        pid: 235_412,
+        title,
+        gameId: GAME_ID,
+        serviceId: SERVICE_ID,
+      });
+    }
+
+    expect(logger.error).not.toHaveBeenCalled();
+    expect(logger.log).toHaveBeenCalledWith(
+      expect.stringContaining("패치 예약 동작이 성공적으로 완료되었습니다"),
+    );
+  });
+
+  it("fails only after 60 seconds without activity in TRIGGERED", async () => {
+    await startService();
+
+    await vi.advanceTimersByTimeAsync(59_000);
+    expect(logger.error).not.toHaveBeenCalled();
+
+    await dispatch(EventType.PROCESS_START, processPayload(100));
+    await vi.advanceTimersByTimeAsync(59_999);
+    expect(logger.error).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining("FINAL FAILURE"),
+    );
+  });
+
+  it("allows an arbitrarily long patch while the current PID remains responsive", async () => {
+    await startService();
+    await dispatch(EventType.PROCESS_START, processPayload(200));
+    await dispatch(EventType.LOG_PATCH_CHECK_COMPLETE, {
+      gameId: GAME_ID,
+      serviceId: SERVICE_ID,
+      pid: 200,
+    });
+
+    for (let index = 0; index < 3; index += 1) {
+      await vi.advanceTimersByTimeAsync(59_000);
+      await dispatch(EventType.PATCH_UI_TITLE_TICK, {
+        processName: "PathOfExile_KG",
+        pid: 200,
+        title: "공간을 확보하는 중…",
+        gameId: GAME_ID,
+        serviceId: SERVICE_ID,
+      });
+      expect(logger.error).not.toHaveBeenCalled();
+    }
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining("FINAL FAILURE"),
+    );
+  });
+
+  it("gives the current process 60 seconds to rotate to a new PID", async () => {
+    await startService();
+    await dispatch(EventType.PROCESS_START, processPayload(300));
+    await dispatch(EventType.LOG_PATCH_CHECK_COMPLETE, {
+      gameId: GAME_ID,
+      serviceId: SERVICE_ID,
+      pid: 300,
+    });
+    await dispatch(EventType.PROCESS_STOP, processPayload(300));
+
+    await vi.advanceTimersByTimeAsync(59_999);
+    expect(logger.error).not.toHaveBeenCalled();
+
+    await dispatch(EventType.PROCESS_START, processPayload(301));
+    await dispatch(EventType.PROCESS_STOP, processPayload(300));
+    await vi.advanceTimersByTimeAsync(59_999);
+    expect(logger.error).not.toHaveBeenCalled();
+
+    await dispatch(EventType.PATCH_UI_TITLE_TICK, {
+      processName: "PathOfExile_KG",
+      pid: 301,
+      title: "50%",
+      gameId: GAME_ID,
+      serviceId: SERVICE_ID,
+    });
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining("FINAL FAILURE"),
+    );
+  });
+
+  it("does not let the previous task timeout fail the next queued task", async () => {
+    await startService([
+      createReservation("patch-1"),
+      createReservation("patch-2"),
+    ]);
+
+    await vi.advanceTimersByTimeAsync(10_000);
+    await dispatch(EventType.LOG_GAME_STARTUP, {
+      gameId: GAME_ID,
+      serviceId: SERVICE_ID,
+      pid: 400,
+    });
+
+    vi.mocked(logger.error).mockClear();
+    await vi.advanceTimersByTimeAsync(50_000);
+    expect(logger.error).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining("FINAL FAILURE"),
+    );
+  });
+
+  it("fails the current task immediately on an explicit reservation failure", async () => {
+    await startService();
+
+    await dispatch(EventType.PATCH_RESERVATION_FAILED, {
+      gameId: GAME_ID,
+      serviceId: SERVICE_ID,
+      reason: "Max retries reached without log response.",
+    });
+
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining("FINAL FAILURE"),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- 예약 패치의 단계별 무응답 판정을 60초 sliding watchdog으로 변경했습니다.
- 프로세스·로그·UI 활동과 PID 교체를 현재 예약 작업에 맞춰 추적하고, 이전 작업의 stale timeout을 차단했습니다.
- 실제 POE1 로그 타임라인, 장시간 패치, PID 교체 경로를 회귀 테스트로 추가했습니다.

## Motivation

예약 패치가 정상적으로 진행 중이어도 실행 시작 후 고정 30초가 지나면 실패로 판정해 오류 알림을 표시하고 이후 완료 상태를 관찰하지 못했습니다. 실제 다운로드 총시간을 제한하지 않으면서 각 단계에서 60초 동안 활동이 없을 때만 실패하도록 판정 기준을 바로잡습니다.
