### PR TITLE
fix: 카카오게임즈로 설치된 게임의 경로 유효성 검토 강화

### DIFF
--- a/.agents/skills/windows-electron-debugging/SKILL.md
+++ b/.agents/skills/windows-electron-debugging/SKILL.md
@@ -1,118 +1,122 @@
 ---
 name: windows-electron-debugging
-description: Use this skill whenever debugging or visually verifying the POE2 launcher UI, Electron runtime errors, Vite dev-server behavior, Chrome DevTools attachment, screenshots, or CDP capture. This project is Windows-first; this skill prevents WSL/mock-browser verification mistakes by forcing pwsh npm run dev, launcher terminal logs, Chrome remote debugging, and real Electron screenshots.
+description: Run any Windows command invisibly from WSL through one owned GUI-bootstrap runner, including Windows tests, lint, typecheck, builds, package commands, long-running processes, Electron launches, CDP inspection, screenshots, log collection, timeout handling, and exact process-tree cleanup. Use whenever an agent in WSL needs Windows execution or must debug or visually verify a Windows Electron GUI without showing or focusing terminals, console hosts, or app windows.
 ---
 
-# Skill: Windows Electron Debugging
+# Hidden WSL-to-Windows Execution
 
-Use this workflow for launcher UI verification, runtime error triage, and screenshots. The app is Windows-first, so do not validate Electron behavior through WSL-only browser mocks.
+Use `scripts/run-hidden-windows.cjs` as the only WSL-facing entrypoint. Never
+invoke `pwsh.exe`, `powershell.exe`, `cmd.exe`, Windows `node.exe`, Electron, or
+another Windows executable directly from WSL.
 
-## Required Flow
+The runner creates a request, enters Windows through GUI-subsystem
+`wscript.exe //B //NoLogo`, starts its worker hidden, and launches children with
+exact argv, `shell: false`, and `windowsHide: true`. Its supervisor creates the
+target suspended, assigns it to a kill-on-close Windows Job, then resumes it so
+natural root exit cannot orphan descendants. Keep fragile quoting, ownership,
+timeout, redaction, and cleanup logic inside the bundled scripts.
 
-1. Start from WSL only for source inspection and edits.
-2. Run the app from Windows PowerShell:
+## Run a bounded command
 
-```powershell
-cd "D:\project_poe2\POE2-unofficial-launcher"
-npm run dev
+Pass a project-selected cwd and an argv array after `--`. Use `@node` for the
+hidden worker's Windows Node or `@pwsh` for hidden PowerShell. Use
+`--literal-env NAME=VALUE` only for non-secret values that may exist briefly in
+the transient request. Use `--env-path` for a non-secret mounted path. Pass
+sensitive values only as pre-existing named WSL variables with
+`--pass-env NAME`; their values must never appear in CLI arguments or child
+argv. The worker consumes named values from its inherited environment, redacts
+persisted command data to basename plus an argv fingerprint, and deletes the
+transient request before launching the child.
+
+Named pass-through values are exact UTF-8 byte-redacted across output chunks
+before logs or sync relay. Never let a child print secrets: transformed,
+encoded, or binary representations are opaque and cannot be reliably redacted.
+
+```bash
+node <skill>/scripts/run-hidden-windows.cjs sync \
+  --cwd <mounted-wsl-project-path> \
+  --timeout-ms <bounded-ms> \
+  --literal-env MODE=value \
+  --pass-env SECRET_NAME \
+  -- @node <windows-or-cwd-relative-script> <arg>...
 ```
 
-`npm run dev` starts Electron with `--remote-debugging-port=9222` by default. Override only when needed:
+The runner relays stdout and stderr separately and exits with the child exit
+code. Exit `124` means a timeout whose owned tree was verified stopped. Exit
+`125` means cleanup could not verify exact-tree death; treat it as actionable
+failure and never claim the process stopped. Cleanup failure emits a structured
+result containing cleanup detail and child-liveness evidence. On any runner
+failure, diagnose its result/metadata/log artifacts; do not bypass the runner.
 
-```powershell
-$env:ELECTRON_REMOTE_DEBUGGING_PORT="9333"
-npm run dev
+## Start a hidden long-running process
+
+Use detached mode. Supply distinct stdout, stderr, and metadata paths. Include
+`{runId}` to isolate concurrent runs. Configure an optional generic HTTP(S) or
+file readiness probe when the caller needs proof that startup completed.
+
+```bash
+node <skill>/scripts/run-hidden-windows.cjs detached \
+  --cwd <mounted-wsl-project-path> \
+  --stdout <artifact-dir>/{runId}.stdout.log \
+  --stderr <artifact-dir>/{runId}.stderr.log \
+  --metadata <artifact-dir>/{runId}.metadata.json \
+  --ready-url <caller-provided-url> \
+  --ready-timeout-ms <bounded-ms> \
+  --literal-env MODE=value \
+  -- <command> <arg>...
 ```
 
-3. Read the launcher terminal logs before making visual claims. Fatal modal reports, IPC errors, and service errors appear there first.
-4. Verify the debugging endpoint from Windows:
+Copy the returned WSL `metadataPath` verbatim into stop. Returned cwd/log/
+metadata paths are WSL-safe even though internal ownership metadata remains in
+Windows form. Record the run ID and child PID. Do not infer readiness merely
+from process existence.
 
-```powershell
-curl.exe -sS http://127.0.0.1:9222/json/version
-curl.exe -sS http://127.0.0.1:9222/json/list
+## Stop and clean up
+
+Stop only from the metadata returned by detached mode. The runner validates the
+schema, run ID, ownership token, metadata path, and known root PID before
+requesting graceful then bounded force cleanup of that exact tree.
+
+```bash
+node <skill>/scripts/run-hidden-windows.cjs stop \
+  --metadata <copy-returned-WSL-metadataPath-verbatim> \
+  --timeout-ms <bounded-ms>
 ```
 
-5. Attach Chrome DevTools to the real launcher page, not the debug console page:
+Never edit metadata, substitute a PID, kill by executable name, or touch an
+unrelated process. Preserve requested logs and evidence; remove only artifacts
+and temporary profiles owned by the completed run. Accept stop success only
+when the result says `cleanup.stopped: true` and
+`childAliveAfterCleanup: false` plus `targetAliveAfterCleanup: false` with
+matching run/worker/supervisor/target identity; otherwise report cleanup failure.
 
-```powershell
-$targets = Invoke-RestMethod http://127.0.0.1:9222/json/list
-$main = $targets | Where-Object { $_.url -eq "http://localhost:54321/" } | Select-Object -First 1
-Start-Process "C:\Program Files\Google\Chrome\Application\chrome.exe" $main.devtoolsFrontendUrl
+## Verify Windows Electron
+
+Launch Electron detached with caller-provided hidden-start, isolated user-data,
+debugging, and application-specific environment values. Never use a normal user
+profile. Use a readiness probe selected by the project, then inspect the owned
+stdout/stderr logs before CDP or visual claims.
+
+Run caller-selected CDP or screenshot scripts through sync mode while the
+detached owner remains alive. Target the actual Electron renderer, not a mock
+browser surface. Report the launcher argv/debug endpoint evidence, selected
+target, fatal/runtime events, screenshot path, and relevant owned log excerpts.
+
+Keep Electron hidden unless verification is impossible without visibility. Ask
+before showing or focusing it. Stop the detached owner through metadata and
+confirm cleanup after capture.
+
+## Validate the runner
+
+Run parser/static tests in WSL first:
+
+```bash
+node <skill>/scripts/run-hidden-windows.node-test.cjs
 ```
 
-If the main target is missing, inspect the terminal log and Electron process command line before proceeding.
-
-## Capture Screenshot
-
-Use the bundled script to capture the actual Electron surface and print a small DOM/error summary:
-
-```powershell
-cd "D:\project_poe2\POE2-unofficial-launcher"
-node .agents\skills\windows-electron-debugging\scripts\cdp-capture.js
-```
-
-Default output: `.tmp/electron-cdp.png`.
-
-Optional overrides:
-
-```powershell
-$env:CDP_PORT="9333"
-$env:CDP_TARGET_URL="http://localhost:54321/"
-$env:CDP_OUTPUT="D:\project_poe2\POE2-unofficial-launcher\.tmp\launcher.png"
-node .agents\skills\windows-electron-debugging\scripts\cdp-capture.js
-```
-
-## Kakao Automation Popup Dumps
-
-When diagnosing Kakao login, Daum Game Starter, SecurityCenter, or hidden automation windows, keep the app running from Windows PowerShell and inspect the launcher terminal log first. Then collect the real popup dumps from Windows temp.
-
-In dev mode, automation pages are dumped by default when an automation window is force-shown, times out, or is exposed by inactive-window debugging. Disable only when needed:
-
-```powershell
-$env:VITE_KAKAO_PAGE_DUMP="false"
-npm run dev
-```
-
-Dump location:
-
-```powershell
-$dumpRoot = Join-Path $env:TEMP "poe2-unofficial-launcher\kakao-page-dumps"
-Get-ChildItem $dumpRoot | Sort-Object LastWriteTime -Descending | Select-Object -First 20
-```
-
-Back up each user-run flow before asking them to reproduce another state:
-
-```powershell
-cd "D:\project_poe2\POE2-unofficial-launcher"
-$stamp = Get-Date -Format "yyyyMMdd-HHmmss"
-$backup = ".tmp\kakao-page-dumps\$stamp-login-flow"
-New-Item -ItemType Directory -Force $backup
-Copy-Item "$dumpRoot\*" $backup -Recurse -Force
-```
-
-Read the files in this order:
-
-- `.json`: reason, triggerContext, window id, URL, title, visibility/focus, bounds.
-- `.txt`: visible body text, useful for recognizing transient prompts.
-- `.html`: selectors and page state; use `rg`, not visual guesses.
-- `.png`: final confirmation of the visible surface.
-
-For `security-center.game.daum.net`, do not decide visibility from the URL alone — classify by DOM state. **The SecurityCenter visibility-classification policy (which selectors keep-hidden vs show) lives in the `kakao-automation` skill (Rule 3).** Collect and read the dumps here; apply that policy there.
-
-## What To Report
-
-Report the exact checks, not guesses:
-
-- Electron main process argv includes `--remote-debugging-port=...`.
-- `/json/version` responds.
-- `/json/list` has the `http://localhost:54321/` page target.
-- CDP summary shows whether fatal text is present.
-- Screenshot path and the visible UI state.
-- Kakao popup dump backup path, if automation windows were involved.
-- Launcher terminal log excerpts for the relevant click or error.
-
-## Avoid
-
-- Do not use WSL Playwright/Chromium as the primary verifier for this Windows Electron app.
-- Do not build mock HTML to judge real launcher UI.
-- Do not dismiss an error modal as visual contrast or layout until terminal logs and CDP state are checked.
+Run worker integration tests and the window-visibility probe only through the
+public runner. Trust Windows evidence only after the native monitor observes at
+least 20 samples over a held workload, no gap above 100 ms, zero visible owned
+top-level windows, and zero owned foreground/focus samples. Report owned
+console-host PIDs and names as informational evidence; an invisible console host
+is not itself a failure.

--- a/.agents/skills/windows-electron-debugging/scripts/run-hidden-windows-bootstrap.js
+++ b/.agents/skills/windows-electron-debugging/scripts/run-hidden-windows-bootstrap.js
@@ -1,0 +1,108 @@
+(function () {
+  "use strict";
+
+  var fso = new ActiveXObject("Scripting.FileSystemObject");
+
+  function readUtf8(filePath) {
+    var stream = new ActiveXObject("ADODB.Stream");
+    stream.Type = 2;
+    stream.Charset = "utf-8";
+    stream.Open();
+    stream.LoadFromFile(filePath);
+    var text = stream.ReadText();
+    stream.Close();
+    return text;
+  }
+
+  function writeUtf8(filePath, text) {
+    var stream = new ActiveXObject("ADODB.Stream");
+    stream.Type = 2;
+    stream.Charset = "utf-8";
+    stream.Open();
+    stream.WriteText(text);
+    stream.SaveToFile(filePath, 2);
+    stream.Close();
+  }
+
+  function escapeJson(value) {
+    return String(value)
+      .replace(/\\/g, "\\\\")
+      .replace(/"/g, '\\"')
+      .replace(/\r/g, "\\r")
+      .replace(/\n/g, "\\n");
+  }
+
+  function writeBootstrapLog(message) {
+    try {
+      if (request && request.bootstrapLogPath) {
+        writeUtf8(request.bootstrapLogPath, String(message) + "\r\n");
+      }
+    } catch (_error) {
+      // The public entrypoint has a bounded missing-result failure.
+    }
+  }
+
+  function quoteWindowsArgument(value) {
+    var text = String(value);
+    return (
+      '"' + text.replace(/(\\*)"/g, '$1$1\\"').replace(/(\\*)$/, "$1$1") + '"'
+    );
+  }
+
+  var requestPath =
+    WScript.Arguments.length > 0 ? WScript.Arguments.Item(0) : "";
+  if (!requestPath || !fso.FileExists(requestPath)) {
+    WScript.Quit(2);
+  }
+
+  var request;
+  try {
+    request = eval("(" + readUtf8(requestPath) + ")");
+    if (!request.windowsNodeExe || !request.workerPath || !request.resultPath) {
+      throw new Error("Runner bootstrap request is incomplete.");
+    }
+    writeBootstrapLog("request-validated");
+
+    var command =
+      quoteWindowsArgument(request.windowsNodeExe) +
+      " " +
+      quoteWindowsArgument(request.workerPath) +
+      " --request " +
+      quoteWindowsArgument(requestPath);
+    var shell = new ActiveXObject("WScript.Shell");
+    shell.Run(command, 0, false);
+    writeBootstrapLog("worker-launch-requested");
+  } catch (error) {
+    var bootstrapError =
+      "bootstrap-error: " +
+      String(error.description || error.message || error) +
+      " (number=" +
+      String(error.number || "unknown") +
+      ")";
+    writeBootstrapLog(bootstrapError);
+    try {
+      if (request && request.resultPath) {
+        var errorText = String(error.description || error.message || error);
+        var errorResult =
+          '{"schemaVersion":1,"runId":"' +
+          escapeJson(request.runId || "") +
+          '","status":"bootstrap-error","exitCode":null,"signal":null,"timedOut":false,"error":"' +
+          escapeJson(errorText) +
+          '"}\r\n';
+        writeUtf8(request.resultPath, errorResult);
+      }
+    } catch (_writeError) {
+      // The public entrypoint will report a bounded missing-result error.
+    }
+    try {
+      if (requestPath && fso.FileExists(requestPath)) {
+        fso.DeleteFile(requestPath, true);
+      }
+    } catch (_deleteError) {
+      // The public entrypoint also attempts a best-effort unlink.
+    }
+    WScript.Quit(1);
+  }
+
+  WScript.Quit(0);
+})();

--- a/.agents/skills/windows-electron-debugging/scripts/run-hidden-windows-fixture.cjs
+++ b/.agents/skills/windows-electron-debugging/scripts/run-hidden-windows-fixture.cjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+"use strict";
+
+const fs = require("node:fs");
+const { spawn } = require("node:child_process");
+
+const [mode, ...args] = process.argv.slice(2);
+
+if (mode === "echo") {
+  const exitCode = Number(args.shift() || 0);
+  process.stdout.write(
+    `${JSON.stringify({ argv: args, cwd: process.cwd(), explicitEnv: process.env.RUNNER_EXPLICIT_ENV || null })}\n`,
+  );
+  process.stderr.write("fixture-stderr\n");
+  process.exitCode = exitCode;
+} else if (mode === "immediate-exit") {
+  process.exitCode = Number(args[0] || 0);
+} else if (mode === "hold") {
+  const readyPath = args[0];
+  if (readyPath) {
+    fs.writeFileSync(
+      readyPath,
+      JSON.stringify({ pid: process.pid, parentPid: process.ppid }),
+      "utf8",
+    );
+  }
+  process.stdout.write(`hold-ready:${process.pid}\n`);
+  setInterval(() => {}, 1000);
+} else if (mode === "secret-check") {
+  const readyPath = args[0];
+  if (readyPath) {
+    fs.writeFileSync(
+      readyPath,
+      JSON.stringify({
+        pid: process.pid,
+        parentPid: process.ppid,
+        secretPresent: Boolean(process.env.RUNNER_SECRET_MARKER),
+      }),
+      "utf8",
+    );
+  }
+  process.stdout.write(
+    `secret-present:${Boolean(process.env.RUNNER_SECRET_MARKER)}\n`,
+  );
+  setInterval(() => {}, 1000);
+} else if (mode === "large-exit") {
+  const byteCount = Number(args[0] || 1024 * 1024);
+  const stdoutChunk = "o".repeat(byteCount);
+  const stderrChunk = "e".repeat(byteCount);
+  process.stdout.write(stdoutChunk, () => {
+    process.stderr.write(stderrChunk);
+  });
+} else if (mode === "split-secret") {
+  const marker = process.env.RUNNER_SECRET_MARKER;
+  if (!marker) throw new Error("split-secret requires RUNNER_SECRET_MARKER");
+  const splitAt = Math.max(1, Math.floor(marker.length / 2));
+  const emit = async (stream, prefix) => {
+    stream.write(`${prefix}${marker.slice(0, splitAt)}`);
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    stream.write(`${marker.slice(splitAt)}:done\n`);
+  };
+  void Promise.all([
+    emit(process.stdout, "stdout:"),
+    emit(process.stderr, "stderr:"),
+  ]);
+} else if (mode === "pid-alive") {
+  const pid = Number(args[0]);
+  try {
+    process.kill(pid, 0);
+    process.exitCode = 0;
+  } catch {
+    process.exitCode = 1;
+  }
+} else if (mode === "tree") {
+  const pidPath = args[0];
+  if (!pidPath) throw new Error("tree fixture requires a PID output path");
+  const grandchild = spawn(process.execPath, [__filename, "hold"], {
+    shell: false,
+    windowsHide: true,
+    stdio: "ignore",
+  });
+  fs.writeFileSync(
+    pidPath,
+    JSON.stringify({ parentPid: process.pid, grandchildPid: grandchild.pid }),
+    "utf8",
+  );
+  setInterval(() => {}, 1000);
+} else if (mode === "orphan-exit") {
+  const pidPath = args[0];
+  const exitDelayMs = Number(args[1] || 0);
+  if (!pidPath)
+    throw new Error("orphan-exit fixture requires a PID output path");
+  const grandchild = spawn(process.execPath, [__filename, "hold"], {
+    shell: false,
+    windowsHide: true,
+    stdio: "ignore",
+  });
+  fs.writeFileSync(
+    pidPath,
+    JSON.stringify({ parentPid: process.pid, grandchildPid: grandchild.pid }),
+    "utf8",
+  );
+  grandchild.unref();
+  if (exitDelayMs > 0) setTimeout(() => {}, exitDelayMs);
+} else {
+  throw new Error(`Unknown fixture mode: ${mode || "<missing>"}`);
+}

--- a/.agents/skills/windows-electron-debugging/scripts/run-hidden-windows-job-supervisor.ps1
+++ b/.agents/skills/windows-electron-debugging/scripts/run-hidden-windows-job-supervisor.ps1
@@ -1,0 +1,393 @@
+param(
+  [Parameter(Mandatory = $true)]
+  [string]$Request
+)
+
+$ErrorActionPreference = 'Stop'
+
+$requestJson = [System.IO.File]::ReadAllText($Request, [System.Text.Encoding]::UTF8)
+$requestData = $requestJson | ConvertFrom-Json
+Remove-Item -LiteralPath $Request -Force -ErrorAction SilentlyContinue
+
+Add-Type -TypeDefinition @'
+using System;
+using System.ComponentModel;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Win32.SafeHandles;
+
+public static class HiddenWindowsJobSupervisor
+{
+    private const uint CREATE_SUSPENDED = 0x00000004;
+    private const uint CREATE_NO_WINDOW = 0x08000000;
+    private const uint STARTF_USESHOWWINDOW = 0x00000001;
+    private const uint STARTF_USESTDHANDLES = 0x00000100;
+    private const short SW_HIDE = 0;
+    private const uint HANDLE_FLAG_INHERIT = 0x00000001;
+    private const uint GENERIC_READ = 0x80000000;
+    private const uint FILE_SHARE_READ = 0x00000001;
+    private const uint FILE_SHARE_WRITE = 0x00000002;
+    private const uint OPEN_EXISTING = 3;
+    private const uint INFINITE = 0xFFFFFFFF;
+    private const uint SYNCHRONIZE = 0x00100000;
+    private const uint WAIT_OBJECT_0 = 0;
+    private const uint JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE = 0x00002000;
+    private const int JobObjectExtendedLimitInformation = 9;
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct SECURITY_ATTRIBUTES
+    {
+        public int nLength;
+        public IntPtr lpSecurityDescriptor;
+        [MarshalAs(UnmanagedType.Bool)] public bool bInheritHandle;
+    }
+
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    private struct STARTUPINFO
+    {
+        public int cb;
+        public string lpReserved;
+        public string lpDesktop;
+        public string lpTitle;
+        public uint dwX;
+        public uint dwY;
+        public uint dwXSize;
+        public uint dwYSize;
+        public uint dwXCountChars;
+        public uint dwYCountChars;
+        public uint dwFillAttribute;
+        public uint dwFlags;
+        public short wShowWindow;
+        public short cbReserved2;
+        public IntPtr lpReserved2;
+        public IntPtr hStdInput;
+        public IntPtr hStdOutput;
+        public IntPtr hStdError;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct PROCESS_INFORMATION
+    {
+        public IntPtr hProcess;
+        public IntPtr hThread;
+        public uint dwProcessId;
+        public uint dwThreadId;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct JOBOBJECT_BASIC_LIMIT_INFORMATION
+    {
+        public long PerProcessUserTimeLimit;
+        public long PerJobUserTimeLimit;
+        public uint LimitFlags;
+        public UIntPtr MinimumWorkingSetSize;
+        public UIntPtr MaximumWorkingSetSize;
+        public uint ActiveProcessLimit;
+        public UIntPtr Affinity;
+        public uint PriorityClass;
+        public uint SchedulingClass;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct IO_COUNTERS
+    {
+        public ulong ReadOperationCount;
+        public ulong WriteOperationCount;
+        public ulong OtherOperationCount;
+        public ulong ReadTransferCount;
+        public ulong WriteTransferCount;
+        public ulong OtherTransferCount;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct JOBOBJECT_EXTENDED_LIMIT_INFORMATION
+    {
+        public JOBOBJECT_BASIC_LIMIT_INFORMATION BasicLimitInformation;
+        public IO_COUNTERS IoInfo;
+        public UIntPtr ProcessMemoryLimit;
+        public UIntPtr JobMemoryLimit;
+        public UIntPtr PeakProcessMemoryUsed;
+        public UIntPtr PeakJobMemoryUsed;
+    }
+
+    [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+    private static extern bool CreateProcessW(
+        string lpApplicationName,
+        StringBuilder lpCommandLine,
+        IntPtr lpProcessAttributes,
+        IntPtr lpThreadAttributes,
+        bool bInheritHandles,
+        uint dwCreationFlags,
+        IntPtr lpEnvironment,
+        string lpCurrentDirectory,
+        ref STARTUPINFO lpStartupInfo,
+        out PROCESS_INFORMATION lpProcessInformation);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern bool CreatePipe(
+        out IntPtr hReadPipe,
+        out IntPtr hWritePipe,
+        ref SECURITY_ATTRIBUTES lpPipeAttributes,
+        uint nSize);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern bool SetHandleInformation(
+        IntPtr hObject,
+        uint dwMask,
+        uint dwFlags);
+
+    [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+    private static extern IntPtr CreateFileW(
+        string lpFileName,
+        uint dwDesiredAccess,
+        uint dwShareMode,
+        ref SECURITY_ATTRIBUTES lpSecurityAttributes,
+        uint dwCreationDisposition,
+        uint dwFlagsAndAttributes,
+        IntPtr hTemplateFile);
+
+    [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+    private static extern IntPtr CreateJobObjectW(
+        IntPtr lpJobAttributes,
+        string lpName);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern bool SetInformationJobObject(
+        IntPtr hJob,
+        int JobObjectInfoClass,
+        IntPtr lpJobObjectInfo,
+        uint cbJobObjectInfoLength);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern bool AssignProcessToJobObject(
+        IntPtr hJob,
+        IntPtr hProcess);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern uint ResumeThread(IntPtr hThread);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern uint WaitForSingleObject(IntPtr hHandle, uint dwMilliseconds);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern uint WaitForMultipleObjects(
+        uint nCount,
+        IntPtr[] lpHandles,
+        bool bWaitAll,
+        uint dwMilliseconds);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern IntPtr OpenProcess(
+        uint dwDesiredAccess,
+        bool bInheritHandle,
+        uint dwProcessId);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern bool GetExitCodeProcess(IntPtr hProcess, out uint lpExitCode);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern bool TerminateProcess(IntPtr hProcess, uint uExitCode);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern bool CloseHandle(IntPtr hObject);
+
+    private static void ThrowLastError(string operation)
+    {
+        throw new Win32Exception(Marshal.GetLastWin32Error(), operation);
+    }
+
+    private static string QuoteArgument(string value)
+    {
+        if (value.Length == 0) return "\"\"";
+        if (value.IndexOfAny(new[] { ' ', '\t', '\n', '\v', '\"' }) < 0) return value;
+
+        var result = new StringBuilder("\"");
+        var backslashes = 0;
+        foreach (var character in value)
+        {
+            if (character == '\\')
+            {
+                backslashes++;
+                continue;
+            }
+            if (character == '\"')
+            {
+                result.Append('\\', backslashes * 2 + 1);
+                result.Append('\"');
+                backslashes = 0;
+                continue;
+            }
+            result.Append('\\', backslashes);
+            backslashes = 0;
+            result.Append(character);
+        }
+        result.Append('\\', backslashes * 2);
+        result.Append('\"');
+        return result.ToString();
+    }
+
+    private static string BuildCommandLine(string command, string[] arguments)
+    {
+        var commandLine = new StringBuilder(QuoteArgument(command));
+        foreach (var argument in arguments)
+        {
+            commandLine.Append(' ');
+            commandLine.Append(QuoteArgument(argument));
+        }
+        return commandLine.ToString();
+    }
+
+    private static void WriteStatus(string statusPath, uint targetPid, string state)
+    {
+        var temporaryPath = statusPath + "." +
+            System.Diagnostics.Process.GetCurrentProcess().Id + ".tmp";
+        var json = "{\"schemaVersion\":1,\"state\":\"" + state +
+            "\",\"targetPid\":" + targetPid + "}" + Environment.NewLine;
+        Directory.CreateDirectory(Path.GetDirectoryName(statusPath));
+        File.WriteAllText(temporaryPath, json, new UTF8Encoding(false));
+        if (File.Exists(statusPath)) File.Delete(statusPath);
+        File.Move(temporaryPath, statusPath);
+    }
+
+    public static int Run(uint ownerPid, string command, string[] arguments, string cwd, string statusPath)
+    {
+        var security = new SECURITY_ATTRIBUTES
+        {
+            nLength = Marshal.SizeOf(typeof(SECURITY_ATTRIBUTES)),
+            bInheritHandle = true
+        };
+        IntPtr stdoutRead = IntPtr.Zero;
+        IntPtr stdoutWrite = IntPtr.Zero;
+        IntPtr stderrRead = IntPtr.Zero;
+        IntPtr stderrWrite = IntPtr.Zero;
+        IntPtr stdinHandle = IntPtr.Zero;
+        IntPtr jobHandle = IntPtr.Zero;
+        IntPtr ownerHandle = IntPtr.Zero;
+        PROCESS_INFORMATION process = new PROCESS_INFORMATION();
+        FileStream stdoutStream = null;
+        FileStream stderrStream = null;
+        var targetLifecycleComplete = false;
+
+        try
+        {
+            ownerHandle = OpenProcess(SYNCHRONIZE, false, ownerPid);
+            if (ownerHandle == IntPtr.Zero) ThrowLastError("OpenProcess(owner)");
+            if (!CreatePipe(out stdoutRead, out stdoutWrite, ref security, 0)) ThrowLastError("CreatePipe(stdout)");
+            if (!SetHandleInformation(stdoutRead, HANDLE_FLAG_INHERIT, 0)) ThrowLastError("SetHandleInformation(stdout)");
+            if (!CreatePipe(out stderrRead, out stderrWrite, ref security, 0)) ThrowLastError("CreatePipe(stderr)");
+            if (!SetHandleInformation(stderrRead, HANDLE_FLAG_INHERIT, 0)) ThrowLastError("SetHandleInformation(stderr)");
+            stdinHandle = CreateFileW("NUL", GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE,
+                ref security, OPEN_EXISTING, 0, IntPtr.Zero);
+            if (stdinHandle == new IntPtr(-1)) ThrowLastError("CreateFile(NUL)");
+
+            jobHandle = CreateJobObjectW(IntPtr.Zero, null);
+            if (jobHandle == IntPtr.Zero) ThrowLastError("CreateJobObject");
+            var limits = new JOBOBJECT_EXTENDED_LIMIT_INFORMATION();
+            limits.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+            var limitsSize = Marshal.SizeOf(typeof(JOBOBJECT_EXTENDED_LIMIT_INFORMATION));
+            var limitsPointer = Marshal.AllocHGlobal(limitsSize);
+            try
+            {
+                Marshal.StructureToPtr(limits, limitsPointer, false);
+                if (!SetInformationJobObject(jobHandle, JobObjectExtendedLimitInformation,
+                    limitsPointer, (uint)limitsSize)) ThrowLastError("SetInformationJobObject");
+            }
+            finally
+            {
+                Marshal.FreeHGlobal(limitsPointer);
+            }
+
+            var startup = new STARTUPINFO
+            {
+                cb = Marshal.SizeOf(typeof(STARTUPINFO)),
+                dwFlags = STARTF_USESHOWWINDOW | STARTF_USESTDHANDLES,
+                wShowWindow = SW_HIDE,
+                hStdInput = stdinHandle,
+                hStdOutput = stdoutWrite,
+                hStdError = stderrWrite
+            };
+            var commandLine = new StringBuilder(BuildCommandLine(command, arguments));
+            if (!CreateProcessW(command, commandLine, IntPtr.Zero, IntPtr.Zero, true,
+                CREATE_SUSPENDED | CREATE_NO_WINDOW, IntPtr.Zero, cwd, ref startup, out process))
+                ThrowLastError("CreateProcessW");
+
+            if (!AssignProcessToJobObject(jobHandle, process.hProcess))
+                ThrowLastError("AssignProcessToJobObject");
+
+            WriteStatus(statusPath, process.dwProcessId, "assigned");
+            if (ResumeThread(process.hThread) == 0xFFFFFFFF) ThrowLastError("ResumeThread");
+            WriteStatus(statusPath, process.dwProcessId, "running");
+
+            CloseHandle(stdoutWrite);
+            stdoutWrite = IntPtr.Zero;
+            CloseHandle(stderrWrite);
+            stderrWrite = IntPtr.Zero;
+            CloseHandle(stdinHandle);
+            stdinHandle = IntPtr.Zero;
+            CloseHandle(process.hThread);
+            process.hThread = IntPtr.Zero;
+
+            stdoutStream = new FileStream(new SafeFileHandle(stdoutRead, true), FileAccess.Read, 4096, false);
+            stdoutRead = IntPtr.Zero;
+            stderrStream = new FileStream(new SafeFileHandle(stderrRead, true), FileAccess.Read, 4096, false);
+            stderrRead = IntPtr.Zero;
+            var stdoutCopy = Task.Run(() => stdoutStream.CopyTo(Console.OpenStandardOutput()));
+            var stderrCopy = Task.Run(() => stderrStream.CopyTo(Console.OpenStandardError()));
+
+            var waitResult = WaitForMultipleObjects(
+                2,
+                new[] { process.hProcess, ownerHandle },
+                false,
+                INFINITE);
+            if (waitResult == WAIT_OBJECT_0 + 1)
+            {
+                CloseHandle(jobHandle);
+                jobHandle = IntPtr.Zero;
+                WaitForSingleObject(process.hProcess, 5000);
+                targetLifecycleComplete = true;
+                return 125;
+            }
+            if (waitResult != WAIT_OBJECT_0) ThrowLastError("WaitForMultipleObjects");
+            uint exitCode;
+            if (!GetExitCodeProcess(process.hProcess, out exitCode)) ThrowLastError("GetExitCodeProcess");
+
+            CloseHandle(jobHandle);
+            jobHandle = IntPtr.Zero;
+            Task.WaitAll(stdoutCopy, stderrCopy);
+            targetLifecycleComplete = true;
+            return unchecked((int)exitCode);
+        }
+        finally
+        {
+            if (!targetLifecycleComplete && process.hProcess != IntPtr.Zero)
+            {
+                TerminateProcess(process.hProcess, 125);
+                WaitForSingleObject(process.hProcess, 5000);
+            }
+            if (stdoutStream != null) stdoutStream.Dispose();
+            if (stderrStream != null) stderrStream.Dispose();
+            if (jobHandle != IntPtr.Zero) CloseHandle(jobHandle);
+            if (ownerHandle != IntPtr.Zero) CloseHandle(ownerHandle);
+            if (process.hThread != IntPtr.Zero) CloseHandle(process.hThread);
+            if (process.hProcess != IntPtr.Zero) CloseHandle(process.hProcess);
+            if (stdoutRead != IntPtr.Zero) CloseHandle(stdoutRead);
+            if (stdoutWrite != IntPtr.Zero) CloseHandle(stdoutWrite);
+            if (stderrRead != IntPtr.Zero) CloseHandle(stderrRead);
+            if (stderrWrite != IntPtr.Zero) CloseHandle(stderrWrite);
+            if (stdinHandle != IntPtr.Zero && stdinHandle != new IntPtr(-1)) CloseHandle(stdinHandle);
+        }
+    }
+}
+'@
+
+$arguments = @($requestData.arguments | ForEach-Object { [string]$_ })
+$exitCode = [HiddenWindowsJobSupervisor]::Run(
+  [uint32]$requestData.ownerPid,
+  [string]$requestData.command,
+  [string[]]$arguments,
+  [string]$requestData.cwd,
+  [string]$requestData.statusPath
+)
+exit $exitCode

--- a/.agents/skills/windows-electron-debugging/scripts/run-hidden-windows-public.node-test.cjs
+++ b/.agents/skills/windows-electron-debugging/scripts/run-hidden-windows-public.node-test.cjs
@@ -1,0 +1,884 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const crypto = require("node:crypto");
+const fs = require("node:fs");
+const path = require("node:path");
+const { spawn } = require("node:child_process");
+const test = require("node:test");
+
+const { toWindowsPath } = require("./run-hidden-windows.cjs");
+
+const RUNNER_PATH = path.join(__dirname, "run-hidden-windows.cjs");
+const FIXTURE_PATH = path.join(__dirname, "run-hidden-windows-fixture.cjs");
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const runPublic = (args, extraEnv = {}) =>
+  new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [RUNNER_PATH, ...args], {
+      cwd: process.cwd(),
+      env: { ...process.env, ...extraEnv },
+      shell: false,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => (stdout += chunk));
+    child.stderr.on("data", (chunk) => (stderr += chunk));
+    child.once("error", reject);
+    child.once("close", (code, signal) =>
+      resolve({ code, signal, stdout, stderr }),
+    );
+  });
+
+const parseJson = (text, label) => {
+  try {
+    return JSON.parse(text);
+  } catch (error) {
+    throw new Error(`${label} was not JSON: ${text}\n${error.message}`);
+  }
+};
+
+const parseTrailingJson = (text, label) => {
+  for (
+    let index = text.lastIndexOf("\n{");
+    index >= 0;
+    index = text.lastIndexOf("\n{", index - 1)
+  ) {
+    try {
+      return JSON.parse(text.slice(index + 1));
+    } catch {
+      // Keep scanning for the final complete structured object after relayed output.
+    }
+  }
+  return parseJson(text, label);
+};
+
+const assertPidDeadThroughPublicRunner = async (artifactRoot, pid, label) => {
+  const probe = await runPublic([
+    "sync",
+    "--cwd",
+    process.cwd(),
+    "--run-root",
+    path.join(artifactRoot, "pid-probes"),
+    "--timeout-ms",
+    "10000",
+    "--",
+    "@node",
+    toWindowsPath(FIXTURE_PATH),
+    "pid-alive",
+    String(pid),
+  ]);
+  assert.equal(probe.code, 1, `${label}: ${probe.stderr}`);
+};
+
+const waitForJson = async (filePath, predicate, label, timeoutMs = 10_000) => {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (fs.existsSync(filePath)) {
+      const value = readJson(filePath);
+      if (predicate(value)) return value;
+    }
+    await sleep(25);
+  }
+  throw new Error(`${label} not observed: ${filePath}`);
+};
+
+test("public detached output metadata path is copy-pasteable into stop and leaves no secret or child", async () => {
+  const marker = `public-secret-${crypto.randomBytes(12).toString("hex")}`;
+  const evidenceParent = path.join(
+    process.cwd(),
+    ".tmp",
+    "windows-runner-public-evidence",
+  );
+  fs.mkdirSync(evidenceParent, { recursive: true });
+  const artifactRoot = fs.mkdtempSync(path.join(evidenceParent, "public-e2e-"));
+  const runRoot = path.join(artifactRoot, "requests");
+  const readyPath = path.join(artifactRoot, "ready.json");
+  let detached;
+  let metadata;
+  let stopped = false;
+  try {
+    detached = await runPublic(
+      [
+        "detached",
+        "--cwd",
+        process.cwd(),
+        "--run-root",
+        runRoot,
+        "--stdout",
+        path.join(artifactRoot, "{runId}.stdout.log"),
+        "--stderr",
+        path.join(artifactRoot, "{runId}.stderr.log"),
+        "--metadata",
+        path.join(artifactRoot, "{runId}.metadata.json"),
+        "--ready-file",
+        readyPath,
+        "--ready-timeout-ms",
+        "5000",
+        "--ready-interval-ms",
+        "25",
+        "--pass-env",
+        "RUNNER_SECRET_MARKER",
+        "--",
+        "@node",
+        toWindowsPath(FIXTURE_PATH),
+        "secret-check",
+        toWindowsPath(readyPath),
+      ],
+      { RUNNER_SECRET_MARKER: marker },
+    );
+    assert.equal(detached.code, 0, detached.stderr);
+    assert.doesNotMatch(
+      `${detached.stdout}${detached.stderr}`,
+      new RegExp(marker),
+    );
+    const publicMetadata = parseJson(detached.stdout, "detached output");
+    assert.match(publicMetadata.metadataPath, /^\/mnt\/[a-z]\//);
+    assert.equal("argv" in publicMetadata, false);
+
+    metadata = JSON.parse(fs.readFileSync(publicMetadata.metadataPath, "utf8"));
+    assert.equal(metadata.status, "running");
+    assert.equal("argv" in metadata, false);
+    assert.equal(
+      fs.existsSync(path.join(runRoot, publicMetadata.runId, "request.json")),
+      false,
+    );
+
+    const stop = await runPublic([
+      "stop",
+      "--metadata",
+      publicMetadata.metadataPath,
+      "--timeout-ms",
+      "10000",
+    ]);
+    assert.equal(stop.code, 0, stop.stderr);
+    assert.doesNotMatch(`${stop.stdout}${stop.stderr}`, new RegExp(marker));
+    const stopResult = parseJson(stop.stdout, "stop output");
+    assert.equal(stopResult.status, "stopped");
+    assert.equal(stopResult.cleanup.stopped, true);
+    assert.equal(stopResult.childAliveAfterCleanup, false);
+    assert.equal(stopResult.targetAliveAfterCleanup, false);
+    stopped = true;
+
+    const persistedResultPath = path.join(
+      runRoot,
+      publicMetadata.runId,
+      "result.json",
+    );
+    const persistedResult = readJson(persistedResultPath);
+    fs.writeFileSync(
+      persistedResultPath,
+      `${JSON.stringify({ ...persistedResult, workerPid: persistedResult.workerPid + 1 }, null, 2)}\n`,
+      "utf8",
+    );
+    const mismatch = await runPublic([
+      "stop",
+      "--metadata",
+      publicMetadata.metadataPath,
+      "--timeout-ms",
+      "10000",
+    ]);
+    assert.equal(mismatch.code, 125, mismatch.stderr);
+    fs.writeFileSync(
+      persistedResultPath,
+      `${JSON.stringify(persistedResult, null, 2)}\n`,
+      "utf8",
+    );
+
+    await assertPidDeadThroughPublicRunner(
+      artifactRoot,
+      metadata.childPid,
+      "stopped supervisor",
+    );
+
+    const persisted = [
+      publicMetadata.metadataPath,
+      publicMetadata.stdoutPath,
+      publicMetadata.stderrPath,
+      path.join(runRoot, publicMetadata.runId, "result.json"),
+    ]
+      .map((filePath) =>
+        fs.existsSync(filePath) ? fs.readFileSync(filePath, "utf8") : "",
+      )
+      .join("\n");
+    assert.doesNotMatch(persisted, new RegExp(marker));
+    process.stdout.write(
+      `${JSON.stringify({ runId: publicMetadata.runId, childPid: metadata.childPid, workerPid: metadata.workerPid, metadataPath: publicMetadata.metadataPath, stdoutPath: publicMetadata.stdoutPath, stderrPath: publicMetadata.stderrPath, status: stopResult.status, cleanupStopped: stopResult.cleanup.stopped, childAliveAfterCleanup: stopResult.childAliveAfterCleanup })}\n`,
+    );
+  } finally {
+    if (!stopped && detached?.code === 0) {
+      const publicMetadata = parseJson(detached.stdout, "cleanup metadata");
+      const cleanup = await runPublic([
+        "stop",
+        "--metadata",
+        publicMetadata.metadataPath,
+        "--timeout-ms",
+        "10000",
+      ]);
+      assert.equal(cleanup.code, 0, cleanup.stderr);
+    }
+    if (!stopped) {
+      process.stderr.write(`Public E2E evidence retained at ${artifactRoot}\n`);
+    }
+  }
+});
+
+test("public sync relay and logs redact a named secret split across chunks", async () => {
+  const marker = `public-split-secret-${crypto.randomBytes(16).toString("hex")}`;
+  const evidenceParent = path.join(
+    process.cwd(),
+    ".tmp",
+    "windows-runner-public-evidence",
+  );
+  fs.mkdirSync(evidenceParent, { recursive: true });
+  const artifactRoot = fs.mkdtempSync(
+    path.join(evidenceParent, "public-secret-redaction-"),
+  );
+  const runRoot = path.join(artifactRoot, "requests");
+  const result = await runPublic(
+    [
+      "sync",
+      "--cwd",
+      process.cwd(),
+      "--run-root",
+      runRoot,
+      "--pass-env",
+      "RUNNER_SECRET_MARKER",
+      "--timeout-ms",
+      "10000",
+      "--",
+      "@node",
+      toWindowsPath(FIXTURE_PATH),
+      "split-secret",
+    ],
+    { RUNNER_SECRET_MARKER: marker },
+  );
+
+  assert.equal(result.code, 0, result.stderr);
+  assert.doesNotMatch(`${result.stdout}${result.stderr}`, new RegExp(marker));
+  assert.match(result.stdout, /stdout:<redacted>:done/);
+  assert.match(result.stderr, /stderr:<redacted>:done/);
+  const persisted = fs
+    .readdirSync(runRoot, { recursive: true })
+    .filter((entry) => typeof entry === "string")
+    .map((entry) => path.join(runRoot, entry))
+    .filter((entry) => fs.existsSync(entry) && fs.statSync(entry).isFile())
+    .map((entry) => fs.readFileSync(entry, "utf8"))
+    .join("\n");
+  assert.doesNotMatch(persisted, new RegExp(marker));
+  assert.match(persisted, /<redacted>/);
+});
+
+test("public sync cleanup failure prints structured liveness detail and exits 125", async () => {
+  const injectionName = "CODEX_HIDDEN_WINDOWS_TEST_INJECT_CLEANUP_FAILURE";
+  const evidenceParent = path.join(
+    process.cwd(),
+    ".tmp",
+    "windows-runner-public-evidence",
+  );
+  fs.mkdirSync(evidenceParent, { recursive: true });
+  const artifactRoot = fs.mkdtempSync(
+    path.join(evidenceParent, "public-sync-cleanup-failure-"),
+  );
+  const result = await runPublic(
+    [
+      "sync",
+      "--cwd",
+      process.cwd(),
+      "--run-root",
+      path.join(artifactRoot, "requests"),
+      "--timeout-ms",
+      "100",
+      "--pass-env",
+      injectionName,
+      "--",
+      "@node",
+      toWindowsPath(FIXTURE_PATH),
+      "hold",
+    ],
+    { [injectionName]: "inject-cleanup-failure" },
+  );
+  assert.equal(result.code, 125, result.stderr);
+  const structured = parseTrailingJson(result.stdout, "sync cleanup failure");
+  assert.equal(structured.status, "cleanup-failed");
+  assert.equal(structured.cleanup.stopped, false);
+  assert.equal(structured.cleanup.actualStoppedBeforeInjection, true);
+  assert.equal(structured.childAliveAfterCleanup, false);
+  assert.equal(structured.targetAliveAfterCleanup, false);
+});
+
+test("public detached readiness cleanup failure returns structured result and exact exit 125 before startup succeeds", async () => {
+  const cleanupInjectionName =
+    "CODEX_HIDDEN_WINDOWS_TEST_INJECT_CLEANUP_FAILURE";
+  const evidenceParent = path.join(
+    process.cwd(),
+    ".tmp",
+    "windows-runner-public-evidence",
+  );
+  fs.mkdirSync(evidenceParent, { recursive: true });
+  const artifactRoot = fs.mkdtempSync(
+    path.join(evidenceParent, "public-cleanup-failure-"),
+  );
+  const runRoot = path.join(artifactRoot, "requests");
+  const readyPath = path.join(artifactRoot, "never-ready.json");
+  let internalMetadata;
+  const detached = await runPublic(
+    [
+      "detached",
+      "--cwd",
+      process.cwd(),
+      "--run-root",
+      runRoot,
+      "--stdout",
+      path.join(artifactRoot, "{runId}.stdout.log"),
+      "--stderr",
+      path.join(artifactRoot, "{runId}.stderr.log"),
+      "--metadata",
+      path.join(artifactRoot, "{runId}.metadata.json"),
+      "--ready-file",
+      readyPath,
+      "--ready-timeout-ms",
+      "250",
+      "--ready-interval-ms",
+      "25",
+      "--pass-env",
+      cleanupInjectionName,
+      "--",
+      "@node",
+      toWindowsPath(FIXTURE_PATH),
+      "hold",
+    ],
+    { [cleanupInjectionName]: "inject-cleanup-failure" },
+  );
+  assert.equal(detached.code, 125, detached.stderr);
+  const result = parseJson(detached.stdout, "readiness cleanup failure");
+  const metadataPath = path.join(artifactRoot, `${result.runId}.metadata.json`);
+  internalMetadata = readJson(metadataPath);
+  try {
+    assert.equal(result.status, "cleanup-failed");
+    assert.equal(result.cleanup.stopped, false);
+    assert.equal(result.cleanup.actualStoppedBeforeInjection, true);
+    assert.equal(result.childAliveAfterCleanup, false);
+    assert.equal(result.targetAliveAfterCleanup, false);
+    assert.equal(internalMetadata.status, "cleanup-failed");
+    assert.match(result.error, /could not verify/i);
+    process.stdout.write(
+      `${JSON.stringify({ runId: result.runId, workerPid: internalMetadata.workerPid, supervisorPid: internalMetadata.childPid, targetPid: internalMetadata.targetPid, status: result.status, exitCode: detached.code, metadataPath })}\n`,
+    );
+  } finally {
+    if (internalMetadata?.childPid) {
+      await assertPidDeadThroughPublicRunner(
+        artifactRoot,
+        internalMetadata.childPid,
+        "cleanup-failed supervisor",
+      );
+      await assertPidDeadThroughPublicRunner(
+        artifactRoot,
+        internalMetadata.targetPid,
+        "job-contained target",
+      );
+    }
+  }
+});
+
+test(
+  "public stop accepts natural detached exit only with verified Job cleanup and dead descendants",
+  { timeout: 45_000 },
+  async () => {
+    const evidenceParent = path.join(
+      process.cwd(),
+      ".tmp",
+      "windows-runner-public-evidence",
+    );
+    fs.mkdirSync(evidenceParent, { recursive: true });
+    const artifactRoot = fs.mkdtempSync(
+      path.join(evidenceParent, "public-natural-exit-"),
+    );
+    const runRoot = path.join(artifactRoot, "requests");
+    const pidPath = path.join(artifactRoot, "descendant-pids.json");
+
+    const detached = await runPublic([
+      "detached",
+      "--cwd",
+      process.cwd(),
+      "--run-root",
+      runRoot,
+      "--stdout",
+      path.join(artifactRoot, "{runId}.stdout.log"),
+      "--stderr",
+      path.join(artifactRoot, "{runId}.stderr.log"),
+      "--metadata",
+      path.join(artifactRoot, "{runId}.metadata.json"),
+      "--",
+      "@node",
+      toWindowsPath(FIXTURE_PATH),
+      "orphan-exit",
+      toWindowsPath(pidPath),
+      "750",
+    ]);
+    assert.equal(detached.code, 0, detached.stderr);
+    const publicMetadata = parseJson(detached.stdout, "natural-exit metadata");
+    const metadata = await waitForJson(
+      publicMetadata.metadataPath,
+      (value) => value.status === "exited",
+      "natural exited metadata",
+    );
+    const resultPath = path.join(runRoot, publicMetadata.runId, "result.json");
+    const finalized = await waitForJson(
+      resultPath,
+      (value) => value.status === "exited",
+      "natural exited result",
+    );
+    const fixturePids = readJson(pidPath);
+
+    assert.equal(finalized.cleanup.stopped, true);
+    assert.equal(finalized.cleanup.mechanism, "job-close");
+    assert.equal(finalized.childAliveAfterCleanup, false);
+    assert.equal(finalized.targetAliveAfterCleanup, false);
+    fs.writeFileSync(
+      resultPath,
+      `${JSON.stringify({ ...finalized, targetPid: finalized.targetPid + 1 }, null, 2)}\n`,
+      "utf8",
+    );
+    const mismatch = await runPublic([
+      "stop",
+      "--metadata",
+      publicMetadata.metadataPath,
+      "--timeout-ms",
+      "10000",
+    ]);
+    assert.equal(mismatch.code, 125, mismatch.stderr);
+    fs.writeFileSync(
+      resultPath,
+      `${JSON.stringify(finalized, null, 2)}\n`,
+      "utf8",
+    );
+    const stop = await runPublic([
+      "stop",
+      "--metadata",
+      publicMetadata.metadataPath,
+      "--timeout-ms",
+      "10000",
+    ]);
+    assert.equal(stop.code, 0, stop.stderr);
+    const stopResult = parseJson(stop.stdout, "natural-exit stop result");
+    assert.equal(stopResult.status, "exited");
+    assert.equal(stopResult.cleanup.stopped, true);
+    assert.equal(stopResult.childAliveAfterCleanup, false);
+    assert.equal(stopResult.targetAliveAfterCleanup, false);
+
+    for (const [label, pid] of [
+      ["worker", metadata.workerPid],
+      ["supervisor", metadata.childPid],
+      ["target", metadata.targetPid],
+      ["held grandchild", fixturePids.grandchildPid],
+    ]) {
+      await assertPidDeadThroughPublicRunner(artifactRoot, pid, label);
+    }
+    process.stdout.write(
+      `${JSON.stringify({ runId: publicMetadata.runId, workerPid: metadata.workerPid, supervisorPid: metadata.childPid, targetPid: metadata.targetPid, grandchildPid: fixturePids.grandchildPid, status: stopResult.status, cleanupStopped: stopResult.cleanup.stopped, childAliveAfterCleanup: stopResult.childAliveAfterCleanup, targetAliveAfterCleanup: stopResult.targetAliveAfterCleanup, metadataPath: publicMetadata.metadataPath })}\n`,
+    );
+  },
+);
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, "utf8"));
+}
+
+test(
+  "public stop retries a transient metadata replacement gap",
+  { timeout: 30_000 },
+  async () => {
+    const evidenceParent = path.join(
+      process.cwd(),
+      ".tmp",
+      "windows-runner-public-evidence",
+    );
+    fs.mkdirSync(evidenceParent, { recursive: true });
+    const artifactRoot = fs.mkdtempSync(
+      path.join(evidenceParent, "public-metadata-gap-"),
+    );
+    const readyPath = path.join(artifactRoot, "ready.json");
+    const detached = await runPublic([
+      "detached",
+      "--cwd",
+      process.cwd(),
+      "--run-root",
+      path.join(artifactRoot, "requests"),
+      "--stdout",
+      path.join(artifactRoot, "{runId}.stdout.log"),
+      "--stderr",
+      path.join(artifactRoot, "{runId}.stderr.log"),
+      "--metadata",
+      path.join(artifactRoot, "{runId}.metadata.json"),
+      "--ready-file",
+      readyPath,
+      "--ready-timeout-ms",
+      "5000",
+      "--",
+      "@node",
+      toWindowsPath(FIXTURE_PATH),
+      "hold",
+      toWindowsPath(readyPath),
+    ]);
+    assert.equal(detached.code, 0, detached.stderr);
+    const metadata = parseJson(detached.stdout, "metadata gap detached");
+    const backupPath = `${metadata.metadataPath}.gap-backup`;
+    fs.renameSync(metadata.metadataPath, backupPath);
+    fs.writeFileSync(metadata.metadataPath, "{", "utf8");
+    let stopped = false;
+    const restore = setTimeout(() => {
+      fs.rmSync(metadata.metadataPath, { force: true });
+      fs.renameSync(backupPath, metadata.metadataPath);
+    }, 200);
+    try {
+      const stop = await runPublic([
+        "stop",
+        "--metadata",
+        metadata.metadataPath,
+        "--timeout-ms",
+        "10000",
+      ]);
+      assert.equal(stop.code, 0, stop.stderr);
+      assert.equal(
+        parseJson(stop.stdout, "metadata gap stop").status,
+        "stopped",
+      );
+      stopped = true;
+    } finally {
+      clearTimeout(restore);
+      if (fs.existsSync(backupPath)) {
+        fs.rmSync(metadata.metadataPath, { force: true });
+        fs.renameSync(backupPath, metadata.metadataPath);
+      }
+      if (!stopped && fs.existsSync(metadata.metadataPath)) {
+        const cleanup = await runPublic([
+          "stop",
+          "--metadata",
+          metadata.metadataPath,
+          "--timeout-ms",
+          "10000",
+        ]);
+        assert.equal(cleanup.code, 0, cleanup.stderr);
+      }
+    }
+  },
+);
+
+test(
+  "public stop waits for terminal metadata carrying the same finalization after result-first gap",
+  { timeout: 30_000 },
+  async () => {
+    const injectionName = "CODEX_HIDDEN_WINDOWS_TEST_FINALIZATION_GAP_MS";
+    const evidenceParent = path.join(
+      process.cwd(),
+      ".tmp",
+      "windows-runner-public-evidence",
+    );
+    fs.mkdirSync(evidenceParent, { recursive: true });
+    const artifactRoot = fs.mkdtempSync(
+      path.join(evidenceParent, "public-finalization-gap-"),
+    );
+    const runRoot = path.join(artifactRoot, "requests");
+    const readyPath = path.join(artifactRoot, "ready.json");
+    const detached = await runPublic(
+      [
+        "detached",
+        "--cwd",
+        process.cwd(),
+        "--run-root",
+        runRoot,
+        "--stdout",
+        path.join(artifactRoot, "{runId}.stdout.log"),
+        "--stderr",
+        path.join(artifactRoot, "{runId}.stderr.log"),
+        "--metadata",
+        path.join(artifactRoot, "{runId}.metadata.json"),
+        "--ready-file",
+        readyPath,
+        "--ready-timeout-ms",
+        "5000",
+        "--pass-env",
+        injectionName,
+        "--",
+        "@node",
+        toWindowsPath(FIXTURE_PATH),
+        "hold",
+        toWindowsPath(readyPath),
+      ],
+      { [injectionName]: "500" },
+    );
+    assert.equal(detached.code, 0, detached.stderr);
+    const publicMetadata = parseJson(detached.stdout, "finalization gap");
+    const resultPath = path.join(runRoot, publicMetadata.runId, "result.json");
+    const stopPromise = runPublic([
+      "stop",
+      "--metadata",
+      publicMetadata.metadataPath,
+      "--timeout-ms",
+      "10000",
+      "--cleanup-grace-ms",
+      "250",
+    ]);
+    const resultFirst = await waitForJson(
+      resultPath,
+      (value) => value.status === "stopped",
+      "result-first stopped result",
+    );
+    assert.equal(readJson(publicMetadata.metadataPath).status, "running");
+    const stop = await stopPromise;
+    assert.equal(stop.code, 0, stop.stderr);
+    const stopped = parseJson(stop.stdout, "finalization gap stop");
+    const terminalMetadata = readJson(publicMetadata.metadataPath);
+    assert.equal(stopped.finalizationId, resultFirst.finalizationId);
+    assert.equal(terminalMetadata.finalizationId, resultFirst.finalizationId);
+    assert.equal(terminalMetadata.status, "stopped");
+  },
+);
+
+test(
+  "public stop fails closed when terminal metadata write never follows the finalized result",
+  { timeout: 30_000 },
+  async () => {
+    const injectionName =
+      "CODEX_HIDDEN_WINDOWS_TEST_INJECT_TERMINAL_METADATA_FAILURE";
+    const evidenceParent = path.join(
+      process.cwd(),
+      ".tmp",
+      "windows-runner-public-evidence",
+    );
+    fs.mkdirSync(evidenceParent, { recursive: true });
+    const artifactRoot = fs.mkdtempSync(
+      path.join(evidenceParent, "public-terminal-metadata-failure-"),
+    );
+    const runRoot = path.join(artifactRoot, "requests");
+    const readyPath = path.join(artifactRoot, "ready.json");
+    const detached = await runPublic(
+      [
+        "detached",
+        "--cwd",
+        process.cwd(),
+        "--run-root",
+        runRoot,
+        "--stdout",
+        path.join(artifactRoot, "{runId}.stdout.log"),
+        "--stderr",
+        path.join(artifactRoot, "{runId}.stderr.log"),
+        "--metadata",
+        path.join(artifactRoot, "{runId}.metadata.json"),
+        "--ready-file",
+        readyPath,
+        "--ready-timeout-ms",
+        "5000",
+        "--pass-env",
+        injectionName,
+        "--",
+        "@node",
+        toWindowsPath(FIXTURE_PATH),
+        "hold",
+        toWindowsPath(readyPath),
+      ],
+      { [injectionName]: "inject-terminal-metadata-failure" },
+    );
+    assert.equal(detached.code, 0, detached.stderr);
+    const publicMetadata = parseJson(detached.stdout, "terminal failure");
+    const stop = await runPublic([
+      "stop",
+      "--metadata",
+      publicMetadata.metadataPath,
+      "--timeout-ms",
+      "10000",
+      "--cleanup-grace-ms",
+      "100",
+    ]);
+    assert.equal(stop.code, 125, stop.stderr);
+    const result = parseJson(stop.stdout, "terminal metadata failure stop");
+    assert.equal(result.status, "stopped");
+    assert.match(
+      result.terminalMetadataError,
+      /terminal metadata write failure/i,
+    );
+    assert.equal(readJson(publicMetadata.metadataPath).status, "running");
+    await assertPidDeadThroughPublicRunner(
+      artifactRoot,
+      result.pid,
+      "terminal metadata failure supervisor",
+    );
+    await assertPidDeadThroughPublicRunner(
+      artifactRoot,
+      result.targetPid,
+      "terminal metadata failure target",
+    );
+  },
+);
+
+test(
+  "public sync and detached handshake cleanup failure return structured exit 125",
+  { timeout: 45_000 },
+  async () => {
+    const injectionName = "CODEX_HIDDEN_WINDOWS_TEST_INJECT_HANDSHAKE_FAILURE";
+    const evidenceParent = path.join(
+      process.cwd(),
+      ".tmp",
+      "windows-runner-public-evidence",
+    );
+    fs.mkdirSync(evidenceParent, { recursive: true });
+    for (const mode of ["sync", "detached"]) {
+      const artifactRoot = fs.mkdtempSync(
+        path.join(evidenceParent, `public-handshake-${mode}-`),
+      );
+      const args = [
+        mode,
+        "--cwd",
+        process.cwd(),
+        "--run-root",
+        path.join(artifactRoot, "requests"),
+      ];
+      if (mode === "detached") {
+        args.push(
+          "--stdout",
+          path.join(artifactRoot, "{runId}.stdout.log"),
+          "--stderr",
+          path.join(artifactRoot, "{runId}.stderr.log"),
+          "--metadata",
+          path.join(artifactRoot, "{runId}.metadata.json"),
+        );
+      }
+      args.push(
+        "--pass-env",
+        injectionName,
+        "--",
+        "@node",
+        toWindowsPath(FIXTURE_PATH),
+        "hold",
+      );
+      const outcome = await runPublic(args, {
+        [injectionName]: "inject-handshake-cleanup-failure",
+      });
+      assert.equal(outcome.code, 125, `${mode}: ${outcome.stderr}`);
+      const result =
+        mode === "sync"
+          ? parseTrailingJson(outcome.stdout, `${mode} handshake`)
+          : parseJson(outcome.stdout, `${mode} handshake`);
+      assert.equal(result.status, "cleanup-failed", mode);
+      assert.equal(result.cleanup.stopped, false, mode);
+      assert.equal(result.cleanup.actualStoppedBeforeInjection, true, mode);
+      assert.equal(result.childAliveAfterCleanup, false, mode);
+      assert.equal(result.targetAliveAfterCleanup, false, mode);
+      assert.match(result.error, /supervisor start handshake failure/i, mode);
+      await assertPidDeadThroughPublicRunner(
+        artifactRoot,
+        result.pid,
+        `${mode} handshake supervisor`,
+      );
+      await assertPidDeadThroughPublicRunner(
+        artifactRoot,
+        result.targetPid,
+        `${mode} handshake target`,
+      );
+    }
+  },
+);
+
+test(
+  "public detached expands one ready-file placeholder for worker and child then stops exactly",
+  { timeout: 30_000 },
+  async () => {
+    const evidenceParent = path.join(
+      process.cwd(),
+      ".tmp",
+      "windows-runner-public-evidence",
+    );
+    fs.mkdirSync(evidenceParent, { recursive: true });
+    const artifactRoot = fs.mkdtempSync(
+      path.join(evidenceParent, "public-ready-placeholder-"),
+    );
+    const runRoot = path.join(artifactRoot, "requests");
+    const readyTemplate = path.join(artifactRoot, "ready-{runId}.json");
+    let publicMetadata;
+    let internalMetadata;
+    let stopped = false;
+    try {
+      const detached = await runPublic([
+        "detached",
+        "--cwd",
+        process.cwd(),
+        "--run-root",
+        runRoot,
+        "--stdout",
+        path.join(artifactRoot, "{runId}.stdout.log"),
+        "--stderr",
+        path.join(artifactRoot, "{runId}.stderr.log"),
+        "--metadata",
+        path.join(artifactRoot, "{runId}.metadata.json"),
+        "--ready-file",
+        readyTemplate,
+        "--ready-timeout-ms",
+        "5000",
+        "--ready-interval-ms",
+        "25",
+        "--",
+        "@node",
+        toWindowsPath(FIXTURE_PATH),
+        "hold",
+        toWindowsPath(readyTemplate),
+      ]);
+      assert.equal(detached.code, 0, detached.stderr);
+      publicMetadata = parseJson(detached.stdout, "placeholder ready metadata");
+      internalMetadata = readJson(publicMetadata.metadataPath);
+      const expandedReadyPath = readyTemplate.replace(
+        "{runId}",
+        publicMetadata.runId,
+      );
+      assert.equal(fs.existsSync(expandedReadyPath), true);
+      const ready = readJson(expandedReadyPath);
+      assert.equal(ready.pid, internalMetadata.targetPid);
+      assert.doesNotMatch(
+        JSON.stringify({ internalMetadata, ready, expandedReadyPath }),
+        /\{runId\}/,
+      );
+
+      const stop = await runPublic([
+        "stop",
+        "--metadata",
+        publicMetadata.metadataPath,
+        "--timeout-ms",
+        "10000",
+      ]);
+      assert.equal(stop.code, 0, stop.stderr);
+      const result = parseJson(stop.stdout, "placeholder ready stop");
+      assert.equal(result.status, "stopped");
+      assert.equal(result.cleanup.stopped, true);
+      assert.equal(result.childAliveAfterCleanup, false);
+      assert.equal(result.targetAliveAfterCleanup, false);
+      stopped = true;
+      await assertPidDeadThroughPublicRunner(
+        artifactRoot,
+        internalMetadata.childPid,
+        "placeholder ready supervisor",
+      );
+      await assertPidDeadThroughPublicRunner(
+        artifactRoot,
+        internalMetadata.targetPid,
+        "placeholder ready target",
+      );
+      process.stdout.write(
+        `${JSON.stringify({ runId: publicMetadata.runId, workerPid: internalMetadata.workerPid, supervisorPid: internalMetadata.childPid, targetPid: internalMetadata.targetPid, readyPath: expandedReadyPath, status: result.status, cleanupStopped: result.cleanup.stopped })}\n`,
+      );
+    } finally {
+      if (!stopped && publicMetadata?.metadataPath) {
+        const cleanup = await runPublic([
+          "stop",
+          "--metadata",
+          publicMetadata.metadataPath,
+          "--timeout-ms",
+          "10000",
+        ]);
+        assert.equal(cleanup.code, 0, cleanup.stderr);
+      }
+    }
+  },
+);

--- a/.agents/skills/windows-electron-debugging/scripts/run-hidden-windows-visibility-probe.cjs
+++ b/.agents/skills/windows-electron-debugging/scripts/run-hidden-windows-visibility-probe.cjs
@@ -1,0 +1,391 @@
+#!/usr/bin/env node
+"use strict";
+
+const crypto = require("node:crypto");
+const fs = require("node:fs");
+const path = require("node:path");
+const { spawn } = require("node:child_process");
+
+const [outputPath, durationValue = "2500", intervalValue = "50"] =
+  process.argv.slice(2);
+const durationMs = Number(durationValue);
+const intervalMs = Number(intervalValue);
+if (!outputPath) throw new Error("visibility probe requires an output path");
+if (!Number.isFinite(durationMs) || durationMs < 2500) {
+  throw new Error("visibility probe duration must be at least 2500ms");
+}
+if (!Number.isFinite(intervalMs) || intervalMs < 20) {
+  throw new Error("visibility probe interval must be at least 20ms");
+}
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const startPowerShell = (script, extraEnv) => {
+  const candidates = [
+    "C:\\Program Files\\PowerShell\\7\\pwsh.exe",
+    "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+  ];
+  const executable = candidates.find((candidate) => fs.existsSync(candidate));
+  if (!executable)
+    throw new Error("PowerShell is unavailable for visibility probe");
+  const child = spawn(
+    executable,
+    ["-NoProfile", "-NonInteractive", "-Command", script],
+    {
+      shell: false,
+      windowsHide: true,
+      stdio: ["ignore", "pipe", "pipe"],
+      env: { ...process.env, ...extraEnv },
+    },
+  );
+  let stdout = "";
+  let stderr = "";
+  child.stdout.setEncoding("utf8");
+  child.stderr.setEncoding("utf8");
+  child.stdout.on("data", (chunk) => (stdout += chunk));
+  child.stderr.on("data", (chunk) => (stderr += chunk));
+  const completion = new Promise((resolve, reject) => {
+    child.once("error", reject);
+    child.once("close", (code) => {
+      if (code !== 0) {
+        reject(
+          new Error(`visibility probe PowerShell failed: ${stderr.trim()}`),
+        );
+      } else {
+        resolve(JSON.parse(stdout.trim()));
+      }
+    });
+  });
+  return { child, completion };
+};
+
+const waitForFile = async (filePath, timeoutMs) => {
+  const deadline = Date.now() + timeoutMs;
+  while (!fs.existsSync(filePath)) {
+    if (Date.now() >= deadline) {
+      throw new Error(`visibility monitor did not start within ${timeoutMs}ms`);
+    }
+    await sleep(20);
+  }
+};
+
+const waitForExit = (child) =>
+  new Promise((resolve, reject) => {
+    if (child.exitCode !== null) {
+      resolve(child.exitCode);
+      return;
+    }
+    child.once("error", reject);
+    child.once("close", resolve);
+  });
+
+const script = String.raw`
+$ErrorActionPreference = 'Stop'
+Add-Type -TypeDefinition @'
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+public sealed class ProbeWindow {
+  public int pid { get; set; }
+  public long hwnd { get; set; }
+}
+
+public sealed class ProbeProcess {
+  public int pid { get; set; }
+  public string name { get; set; }
+}
+
+public sealed class ProbeSample {
+  public long elapsedMs { get; set; }
+  public int[] ownedPids { get; set; }
+  public ProbeWindow[] visible { get; set; }
+  public int foregroundPid { get; set; }
+  public int focusPid { get; set; }
+}
+
+public sealed class ProbeResult {
+  public string runId { get; set; }
+  public int workerPid { get; set; }
+  public long durationMs { get; set; }
+  public int requestedSampleIntervalMs { get; set; }
+  public int sampleCount { get; set; }
+  public long firstSampleMs { get; set; }
+  public long lastSampleMs { get; set; }
+  public long maxGapMs { get; set; }
+  public int maxVisibleTopLevelWindowCount { get; set; }
+  public int ownedForegroundCount { get; set; }
+  public int ownedFocusCount { get; set; }
+  public ProbeProcess[] consoleHosts { get; set; }
+  public int consoleHostCount { get; set; }
+  public ProbeSample[] samples { get; set; }
+}
+
+public static class RunnerWindowProbe {
+  private const uint TH32CS_SNAPPROCESS = 0x00000002;
+  private static readonly IntPtr INVALID_HANDLE_VALUE = new IntPtr(-1);
+
+  public delegate bool EnumWindowsProc(IntPtr hWnd, IntPtr lParam);
+
+  [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+  private struct PROCESSENTRY32 {
+    public uint dwSize;
+    public uint cntUsage;
+    public uint th32ProcessID;
+    public IntPtr th32DefaultHeapID;
+    public uint th32ModuleID;
+    public uint cntThreads;
+    public uint th32ParentProcessID;
+    public int pcPriClassBase;
+    public uint dwFlags;
+    [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 260)]
+    public string szExeFile;
+  }
+
+  [StructLayout(LayoutKind.Sequential)]
+  private struct RECT {
+    public int left;
+    public int top;
+    public int right;
+    public int bottom;
+  }
+
+  [StructLayout(LayoutKind.Sequential)]
+  private struct GUITHREADINFO {
+    public uint cbSize;
+    public uint flags;
+    public IntPtr hwndActive;
+    public IntPtr hwndFocus;
+    public IntPtr hwndCapture;
+    public IntPtr hwndMenuOwner;
+    public IntPtr hwndMoveSize;
+    public IntPtr hwndCaret;
+    public RECT rcCaret;
+  }
+
+  private sealed class ProcessEntry {
+    public int Pid;
+    public int ParentPid;
+    public string Name;
+  }
+
+  [DllImport("kernel32.dll", SetLastError = true)]
+  private static extern IntPtr CreateToolhelp32Snapshot(uint flags, uint processId);
+  [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+  private static extern bool Process32FirstW(IntPtr snapshot, ref PROCESSENTRY32 entry);
+  [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+  private static extern bool Process32NextW(IntPtr snapshot, ref PROCESSENTRY32 entry);
+  [DllImport("kernel32.dll", SetLastError = true)]
+  private static extern bool CloseHandle(IntPtr handle);
+  [DllImport("user32.dll")]
+  private static extern bool EnumWindows(EnumWindowsProc callback, IntPtr lParam);
+  [DllImport("user32.dll")]
+  private static extern bool IsWindowVisible(IntPtr hWnd);
+  [DllImport("user32.dll")]
+  private static extern uint GetWindowThreadProcessId(IntPtr hWnd, out uint processId);
+  [DllImport("user32.dll")]
+  private static extern IntPtr GetForegroundWindow();
+  [DllImport("user32.dll")]
+  private static extern bool GetGUIThreadInfo(uint threadId, ref GUITHREADINFO info);
+
+  private static List<ProcessEntry> SnapshotProcesses() {
+    var result = new List<ProcessEntry>();
+    IntPtr snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
+    if (snapshot == INVALID_HANDLE_VALUE) {
+      throw new System.ComponentModel.Win32Exception(Marshal.GetLastWin32Error());
+    }
+    try {
+      var entry = new PROCESSENTRY32();
+      entry.dwSize = (uint)Marshal.SizeOf(typeof(PROCESSENTRY32));
+      if (!Process32FirstW(snapshot, ref entry)) return result;
+      do {
+        result.Add(new ProcessEntry {
+          Pid = (int)entry.th32ProcessID,
+          ParentPid = (int)entry.th32ParentProcessID,
+          Name = entry.szExeFile ?? ""
+        });
+        entry.dwSize = (uint)Marshal.SizeOf(typeof(PROCESSENTRY32));
+      } while (Process32NextW(snapshot, ref entry));
+    } finally {
+      CloseHandle(snapshot);
+    }
+    return result;
+  }
+
+  private static HashSet<int> FindOwned(List<ProcessEntry> processes, int rootPid) {
+    var owned = new HashSet<int>();
+    var queue = new Queue<int>();
+    queue.Enqueue(rootPid);
+    while (queue.Count > 0) {
+      int pid = queue.Dequeue();
+      if (!owned.Add(pid)) continue;
+      foreach (var process in processes) {
+        if (process.ParentPid == pid) queue.Enqueue(process.Pid);
+      }
+    }
+    return owned;
+  }
+
+  private static int WindowPid(IntPtr window, out uint threadId) {
+    uint pid;
+    threadId = GetWindowThreadProcessId(window, out pid);
+    return (int)pid;
+  }
+
+  public static ProbeResult Run(int rootPid, int durationMs, int intervalMs, string readyPath) {
+    var stopwatch = Stopwatch.StartNew();
+    var samples = new List<ProbeSample>();
+    var consoleHosts = new Dictionary<int, ProbeProcess>();
+    int maxVisible = 0;
+    int ownedForegroundCount = 0;
+    int ownedFocusCount = 0;
+    long maxGap = 0;
+    long previousSample = -1;
+
+    do {
+      long sampleStarted = stopwatch.ElapsedMilliseconds;
+      if (previousSample >= 0) maxGap = Math.Max(maxGap, sampleStarted - previousSample);
+      previousSample = sampleStarted;
+      List<ProcessEntry> processes = SnapshotProcesses();
+      HashSet<int> owned = FindOwned(processes, rootPid);
+      var visible = new List<ProbeWindow>();
+      EnumWindows(delegate(IntPtr hWnd, IntPtr lParam) {
+        uint threadId;
+        int pid = WindowPid(hWnd, out threadId);
+        if (owned.Contains(pid) && IsWindowVisible(hWnd)) {
+          visible.Add(new ProbeWindow { pid = pid, hwnd = hWnd.ToInt64() });
+        }
+        return true;
+      }, IntPtr.Zero);
+
+      foreach (var process in processes) {
+        if (!owned.Contains(process.Pid)) continue;
+        string name = Path.GetFileNameWithoutExtension(process.Name);
+        if (String.Equals(name, "conhost", StringComparison.OrdinalIgnoreCase) ||
+            String.Equals(name, "OpenConsole", StringComparison.OrdinalIgnoreCase)) {
+          consoleHosts[process.Pid] = new ProbeProcess { pid = process.Pid, name = name };
+        }
+      }
+
+      int foregroundPid = 0;
+      int focusPid = 0;
+      IntPtr foreground = GetForegroundWindow();
+      uint foregroundThread = 0;
+      if (foreground != IntPtr.Zero) {
+        foregroundPid = WindowPid(foreground, out foregroundThread);
+        if (owned.Contains(foregroundPid)) ownedForegroundCount++;
+        var gui = new GUITHREADINFO();
+        gui.cbSize = (uint)Marshal.SizeOf(typeof(GUITHREADINFO));
+        if (foregroundThread != 0 && GetGUIThreadInfo(foregroundThread, ref gui) &&
+            gui.hwndFocus != IntPtr.Zero) {
+          uint focusThread;
+          focusPid = WindowPid(gui.hwndFocus, out focusThread);
+          if (owned.Contains(focusPid)) ownedFocusCount++;
+        }
+      }
+
+      maxVisible = Math.Max(maxVisible, visible.Count);
+      var ownedPids = new int[owned.Count];
+      owned.CopyTo(ownedPids);
+      Array.Sort(ownedPids);
+      samples.Add(new ProbeSample {
+        elapsedMs = sampleStarted,
+        ownedPids = ownedPids,
+        visible = visible.ToArray(),
+        foregroundPid = foregroundPid,
+        focusPid = focusPid
+      });
+
+      if (samples.Count == 1) {
+        File.WriteAllText(readyPath, "ready");
+      }
+      long remaining = intervalMs - (stopwatch.ElapsedMilliseconds - sampleStarted);
+      if (remaining > 0) Thread.Sleep((int)remaining);
+    } while (stopwatch.ElapsedMilliseconds < durationMs);
+
+    return new ProbeResult {
+      runId = Environment.GetEnvironmentVariable("CODEX_HIDDEN_WINDOWS_RUN_ID"),
+      workerPid = rootPid,
+      durationMs = stopwatch.ElapsedMilliseconds,
+      requestedSampleIntervalMs = intervalMs,
+      sampleCount = samples.Count,
+      firstSampleMs = samples.Count == 0 ? -1 : samples[0].elapsedMs,
+      lastSampleMs = samples.Count == 0 ? -1 : samples[samples.Count - 1].elapsedMs,
+      maxGapMs = maxGap,
+      maxVisibleTopLevelWindowCount = maxVisible,
+      ownedForegroundCount = ownedForegroundCount,
+      ownedFocusCount = ownedFocusCount,
+      consoleHosts = new List<ProbeProcess>(consoleHosts.Values).ToArray(),
+      consoleHostCount = consoleHosts.Count,
+      samples = samples.ToArray()
+    };
+  }
+}
+'@
+$result = [RunnerWindowProbe]::Run(
+  [int]$env:CODEX_HIDDEN_WINDOWS_WORKER_PID,
+  ${Math.trunc(durationMs)},
+  ${Math.trunc(intervalMs)},
+  $env:RUNNER_VISIBILITY_READY_PATH
+)
+$result | ConvertTo-Json -Depth 8 -Compress
+`;
+
+const absoluteOutputPath = path.resolve(outputPath);
+const readyPath = path.join(
+  path.dirname(absoluteOutputPath),
+  `visibility-ready-${process.pid}-${crypto.randomBytes(4).toString("hex")}`,
+);
+
+const run = async () => {
+  fs.mkdirSync(path.dirname(absoluteOutputPath), { recursive: true });
+  const monitor = startPowerShell(script, {
+    RUNNER_VISIBILITY_READY_PATH: readyPath,
+  });
+  let sentinel;
+  try {
+    await waitForFile(readyPath, 10_000);
+    const sentinelDurationMs = Math.max(2000, Math.trunc(durationMs - 300));
+    sentinel = spawn(
+      process.execPath,
+      ["-e", `setTimeout(() => {}, ${sentinelDurationMs})`],
+      { shell: false, windowsHide: true, stdio: "ignore" },
+    );
+    const [result] = await Promise.all([
+      monitor.completion,
+      waitForExit(sentinel),
+    ]);
+    fs.writeFileSync(
+      absoluteOutputPath,
+      `${JSON.stringify(result, null, 2)}\n`,
+      "utf8",
+    );
+    process.stdout.write(`${JSON.stringify(result)}\n`);
+    if (
+      result.maxVisibleTopLevelWindowCount !== 0 ||
+      result.ownedForegroundCount !== 0 ||
+      result.ownedFocusCount !== 0 ||
+      result.maxGapMs > 100 ||
+      result.sampleCount < 20
+    ) {
+      process.exitCode = 1;
+    }
+  } finally {
+    fs.rmSync(readyPath, { force: true });
+    if (sentinel && sentinel.exitCode === null) {
+      sentinel.kill("SIGTERM");
+      await waitForExit(sentinel).catch(() => {});
+    }
+    if (monitor.child.exitCode === null) {
+      monitor.child.kill("SIGTERM");
+    }
+  }
+};
+
+run().catch((error) => {
+  process.stderr.write(`${error.message}\n`);
+  process.exitCode = 1;
+});

--- a/.agents/skills/windows-electron-debugging/scripts/run-hidden-windows-worker.cjs
+++ b/.agents/skills/windows-electron-debugging/scripts/run-hidden-windows-worker.cjs
@@ -1,0 +1,1041 @@
+#!/usr/bin/env node
+"use strict";
+
+const crypto = require("node:crypto");
+const fs = require("node:fs");
+const path = require("node:path");
+const { spawn } = require("node:child_process");
+const { Transform } = require("node:stream");
+const { finished } = require("node:stream/promises");
+
+const SCHEMA_VERSION = 1;
+const CONTROL_POLL_MS = 100;
+const SUPERVISOR_START_TIMEOUT_MS = 10_000;
+const OUTPUT_DRAIN_TIMEOUT_MS = 500;
+const REDACTION_REPLACEMENT = Buffer.from("<redacted>", "utf8");
+const JOB_SUPERVISOR_PATH = path.join(
+  __dirname,
+  "run-hidden-windows-job-supervisor.ps1",
+);
+const TEST_CLEANUP_FAILURE_ENV =
+  "CODEX_HIDDEN_WINDOWS_TEST_INJECT_CLEANUP_FAILURE";
+const TEST_HANDSHAKE_FAILURE_ENV =
+  "CODEX_HIDDEN_WINDOWS_TEST_INJECT_HANDSHAKE_FAILURE";
+const TEST_FINALIZATION_GAP_ENV =
+  "CODEX_HIDDEN_WINDOWS_TEST_FINALIZATION_GAP_MS";
+const TEST_TERMINAL_METADATA_FAILURE_ENV =
+  "CODEX_HIDDEN_WINDOWS_TEST_INJECT_TERMINAL_METADATA_FAILURE";
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const settleWithin = async (promise, timeoutMs) =>
+  await Promise.race([
+    promise.then(
+      () => true,
+      () => true,
+    ),
+    sleep(timeoutMs).then(() => false),
+  ]);
+
+const redactExactValues = (buffer, secretBuffers, final) => {
+  if (secretBuffers.length === 0) return { output: buffer, remainder: null };
+  const longest = secretBuffers[0].length;
+  const cutoff = final
+    ? buffer.length
+    : Math.max(0, buffer.length - longest + 1);
+  const output = [];
+  let cursor = 0;
+
+  while (cursor < cutoff) {
+    let matchIndex = -1;
+    let matchLength = 0;
+    for (const secret of secretBuffers) {
+      const candidate = buffer.indexOf(secret, cursor);
+      if (
+        candidate >= 0 &&
+        (matchIndex < 0 ||
+          candidate < matchIndex ||
+          (candidate === matchIndex && secret.length > matchLength))
+      ) {
+        matchIndex = candidate;
+        matchLength = secret.length;
+      }
+    }
+    if (matchIndex < 0 || matchIndex >= cutoff) {
+      output.push(buffer.subarray(cursor, cutoff));
+      cursor = cutoff;
+      break;
+    }
+    if (matchIndex > cursor) output.push(buffer.subarray(cursor, matchIndex));
+    output.push(REDACTION_REPLACEMENT);
+    cursor = matchIndex + matchLength;
+  }
+
+  return {
+    output: output.length === 1 ? output[0] : Buffer.concat(output),
+    remainder: cursor < buffer.length ? buffer.subarray(cursor) : null,
+  };
+};
+
+const createExactValueRedactor = (values) => {
+  const secretBuffers = [
+    ...new Map(
+      Object.values(values || {})
+        .filter((value) => typeof value === "string" && value.length > 0)
+        .map((value) => {
+          const buffer = Buffer.from(value, "utf8");
+          return [buffer.toString("hex"), buffer];
+        }),
+    ).values(),
+  ].sort((left, right) => right.length - left.length);
+  let pending = Buffer.alloc(0);
+
+  return new Transform({
+    transform(chunk, _encoding, callback) {
+      pending = Buffer.concat([pending, Buffer.from(chunk)]);
+      const redacted = redactExactValues(pending, secretBuffers, false);
+      pending = redacted.remainder || Buffer.alloc(0);
+      callback(null, redacted.output);
+    },
+    flush(callback) {
+      const redacted = redactExactValues(pending, secretBuffers, true);
+      pending = Buffer.alloc(0);
+      callback(null, redacted.output);
+    },
+  });
+};
+
+const writeJsonAtomic = (filePath, value) => {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  const temporaryPath = `${filePath}.${process.pid}.tmp`;
+  fs.writeFileSync(
+    temporaryPath,
+    `${JSON.stringify(value, null, 2)}\r\n`,
+    "utf8",
+  );
+  try {
+    fs.renameSync(temporaryPath, filePath);
+  } catch (error) {
+    if (!["EEXIST", "EPERM", "EACCES"].includes(error?.code)) throw error;
+    fs.rmSync(filePath, { force: true, maxRetries: 10, retryDelay: 10 });
+    fs.renameSync(temporaryPath, filePath);
+  }
+};
+
+const readJson = (filePath) => JSON.parse(fs.readFileSync(filePath, "utf8"));
+
+const getEnvironmentValue = (name) => {
+  const key = Object.keys(process.env).find(
+    (candidate) => candidate.toLowerCase() === name.toLowerCase(),
+  );
+  return key ? process.env[key] : undefined;
+};
+
+const consumePassEnvironment = (names) => {
+  const values = {};
+  for (const name of names || []) {
+    const key = Object.keys(process.env).find(
+      (candidate) => candidate.toLowerCase() === name.toLowerCase(),
+    );
+    if (!key || process.env[key] === undefined) {
+      throw new Error(`Named pass-through environment is unavailable: ${name}`);
+    }
+    values[name] = process.env[key];
+    delete process.env[key];
+  }
+  return values;
+};
+
+const buildChildEnvironment = (literalEnv, passEnvValues, runId) => {
+  const baseNames = [
+    "SystemRoot",
+    "WINDIR",
+    "PATH",
+    "PATHEXT",
+    "TEMP",
+    "TMP",
+    "USERPROFILE",
+    "APPDATA",
+    "LOCALAPPDATA",
+    "ProgramFiles",
+    "ProgramFiles(x86)",
+    "ProgramW6432",
+    "CommonProgramFiles",
+    "CommonProgramFiles(x86)",
+    "COMSPEC",
+  ];
+  const env = {};
+  for (const name of baseNames) {
+    const value = getEnvironmentValue(name);
+    if (value !== undefined) env[name] = value;
+  }
+  Object.assign(env, literalEnv, passEnvValues);
+  env.CODEX_HIDDEN_WINDOWS_RUN_ID = runId;
+  env.CODEX_HIDDEN_WINDOWS_WORKER_PID = String(process.pid);
+  return env;
+};
+
+const resolveCommand = (command) => {
+  if (command === "@node") return process.execPath;
+  if (command === "@pwsh") {
+    const candidates = [
+      "C:\\Program Files\\PowerShell\\7\\pwsh.exe",
+      "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+    ];
+    const found = candidates.find((candidate) => fs.existsSync(candidate));
+    if (!found)
+      throw new Error("PowerShell executable was not found for @pwsh.");
+    return found;
+  }
+  return command;
+};
+
+const assertRequest = (request) => {
+  if (request.schemaVersion !== SCHEMA_VERSION) {
+    throw new Error("Unsupported hidden Windows runner request schema.");
+  }
+  if (!["sync", "detached"].includes(request.mode)) {
+    throw new Error("Runner request mode is invalid.");
+  }
+  if (!Array.isArray(request.argv) || request.argv.length === 0) {
+    throw new Error("Runner request argv is empty.");
+  }
+  if (
+    !request.literalEnv ||
+    typeof request.literalEnv !== "object" ||
+    Array.isArray(request.literalEnv)
+  ) {
+    throw new Error("Runner request literal environment is invalid.");
+  }
+  if (!Array.isArray(request.passEnvNames)) {
+    throw new Error("Runner request pass-through names are invalid.");
+  }
+  if (!request.cwd || !path.win32.isAbsolute(request.cwd)) {
+    throw new Error("Runner request cwd must be an absolute Windows path.");
+  }
+  for (const field of [
+    "stdoutPath",
+    "stderrPath",
+    "resultPath",
+    "metadataPath",
+    "controlPath",
+  ]) {
+    if (!request[field] || !path.win32.isAbsolute(request[field])) {
+      throw new Error(
+        `Runner request ${field} must be an absolute Windows path.`,
+      );
+    }
+  }
+  if (!Number.isSafeInteger(request.timeoutMs) || request.timeoutMs < 0) {
+    throw new Error("Runner request timeout is invalid.");
+  }
+  if (
+    !Number.isSafeInteger(request.cleanupGraceMs) ||
+    request.cleanupGraceMs < 1
+  ) {
+    throw new Error("Runner request cleanup grace is invalid.");
+  }
+};
+
+const openExclusiveLog = (filePath) => {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  const descriptor = fs.openSync(filePath, "wx");
+  return fs.createWriteStream(filePath, {
+    fd: descriptor,
+    autoClose: true,
+    encoding: "utf8",
+  });
+};
+
+const waitForStreamClose = (stream) =>
+  new Promise((resolve) => {
+    if (stream.closed) resolve();
+    else stream.once("close", resolve);
+  });
+
+const closeLogs = async (stdoutLog, stderrLog) => {
+  stdoutLog.end();
+  stderrLog.end();
+  await Promise.all([
+    waitForStreamClose(stdoutLog),
+    waitForStreamClose(stderrLog),
+  ]);
+};
+
+const finalizeCapturedOutput = async (
+  child,
+  stdoutLog,
+  stderrLog,
+  { forceAfterMs = OUTPUT_DRAIN_TIMEOUT_MS } = {},
+) => {
+  const drained = await settleWithin(child.outputDone, forceAfterMs);
+  if (!drained) child.abortOutputCapture();
+  await settleWithin(child.outputDone, forceAfterMs);
+  stdoutLog.end();
+  stderrLog.end();
+  const logsClosed = await settleWithin(
+    Promise.all([waitForStreamClose(stdoutLog), waitForStreamClose(stderrLog)]),
+    forceAfterMs,
+  );
+  if (!logsClosed) {
+    stdoutLog.destroy();
+    stderrLog.destroy();
+    await settleWithin(
+      Promise.all([
+        waitForStreamClose(stdoutLog),
+        waitForStreamClose(stderrLog),
+      ]),
+      forceAfterMs,
+    );
+  }
+  return { drained, logsClosed };
+};
+
+const isPidAlive = (pid) => {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return error && error.code === "EPERM";
+  }
+};
+
+const runTaskkill = (pid, force) =>
+  new Promise((resolve) => {
+    const args = ["/PID", String(pid), "/T"];
+    if (force) args.push("/F");
+    const taskkill = spawn("C:\\Windows\\System32\\taskkill.exe", args, {
+      shell: false,
+      windowsHide: true,
+      stdio: "ignore",
+    });
+    taskkill.once("error", (error) =>
+      resolve({ ok: false, error: error.message }),
+    );
+    taskkill.once("close", (code, signal) =>
+      resolve({ ok: code === 0 || !isPidAlive(pid), code, signal }),
+    );
+  });
+
+const cleanupProcessTree = async (pid, graceMs) => {
+  if (!isPidAlive(pid)) {
+    return { gracefulAttempted: false, forced: false, stopped: true };
+  }
+
+  const graceful = await runTaskkill(pid, false);
+  const deadline = Date.now() + graceMs;
+  while (isPidAlive(pid) && Date.now() < deadline) await sleep(50);
+  if (!isPidAlive(pid)) {
+    return {
+      gracefulAttempted: true,
+      graceful,
+      forced: false,
+      stopped: true,
+    };
+  }
+
+  const forced = await runTaskkill(pid, true);
+  const forceDeadline = Date.now() + graceMs;
+  while (isPidAlive(pid) && Date.now() < forceDeadline) await sleep(50);
+  return {
+    gracefulAttempted: true,
+    graceful,
+    forced: true,
+    forceResult: forced,
+    stopped: !isPidAlive(pid),
+  };
+};
+
+const summarizeCommand = (argv) => ({
+  basename: path.win32.basename(argv[0]),
+  argvSha256: crypto
+    .createHash("sha256")
+    .update(JSON.stringify(argv))
+    .digest("hex"),
+});
+
+const cleanupOutcome = (
+  baseStatus,
+  cleanup,
+  childPid,
+  targetPid,
+  isAlive = isPidAlive,
+) => {
+  const childAliveAfterCleanup = childPid ? isAlive(childPid) : false;
+  const targetAliveAfterCleanup = targetPid ? isAlive(targetPid) : false;
+  const succeeded =
+    cleanup?.stopped === true &&
+    !childAliveAfterCleanup &&
+    !targetAliveAfterCleanup;
+  return {
+    status: succeeded ? baseStatus : "cleanup-failed",
+    cleanup,
+    childAliveAfterCleanup,
+    targetAliveAfterCleanup,
+    ...(succeeded
+      ? {}
+      : {
+          error: `Owned process-tree cleanup could not verify supervisor ${childPid} and target ${targetPid ?? "unknown"} stopped.`,
+        }),
+  };
+};
+
+class SupervisorStartError extends Error {
+  constructor(message, details) {
+    super(message);
+    this.name = "SupervisorStartError";
+    this.code = "SUPERVISOR_START_FAILED";
+    Object.assign(this, details);
+  }
+}
+
+const createResult = (request, values) => ({
+  schemaVersion: SCHEMA_VERSION,
+  runId: request.runId,
+  status: values.status,
+  exitCode: values.exitCode ?? null,
+  signal: values.signal ?? null,
+  timedOut: Boolean(values.timedOut),
+  pid: values.pid ?? null,
+  targetPid: values.targetPid ?? null,
+  workerPid: process.pid,
+  cleanup: values.cleanup,
+  childAliveAfterCleanup: values.childAliveAfterCleanup,
+  targetAliveAfterCleanup: values.targetAliveAfterCleanup,
+  finalizationId: values.finalizationId,
+  terminalMetadataError: values.terminalMetadataError,
+  error: values.error,
+  finishedAt: new Date().toISOString(),
+});
+
+const checkReadiness = async (readiness) => {
+  if (readiness.kind === "file") return fs.existsSync(readiness.value);
+  if (readiness.kind === "url") {
+    try {
+      const response = await fetch(readiness.value, {
+        signal: AbortSignal.timeout(Math.min(readiness.intervalMs, 2000)),
+      });
+      return response.ok;
+    } catch {
+      return false;
+    }
+  }
+  throw new Error(`Unsupported readiness probe: ${readiness.kind}`);
+};
+
+const waitForReadiness = async (request, getTerminalState) => {
+  if (!request.readiness) return;
+  const { timeoutMs, intervalMs } = request.readiness;
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const terminal = getTerminalState();
+    if (terminal) {
+      throw new Error(
+        `Child exited before readiness (exitCode=${terminal.exitCode ?? "none"}, signal=${terminal.signal ?? "none"}).`,
+      );
+    }
+    if (await checkReadiness(request.readiness)) return;
+    await sleep(intervalMs);
+  }
+  throw new Error(`Readiness probe timed out after ${timeoutMs}ms.`);
+};
+
+const naturalExitOutcome = (child, exitCode, signal) => {
+  const childAlive = isPidAlive(child.pid);
+  const targetAlive = isPidAlive(child.targetPid);
+  return {
+    exitCode,
+    signal,
+    ...cleanupOutcome(
+      "exited",
+      {
+        gracefulAttempted: false,
+        forced: false,
+        mechanism: "job-close",
+        stopped: !childAlive && !targetAlive,
+      },
+      child.pid,
+      child.targetPid,
+    ),
+  };
+};
+
+const waitForSupervisorStart = async (child, statusPath) => {
+  const deadline = Date.now() + SUPERVISOR_START_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    if (child.spawnError) throw child.spawnError;
+    if (fs.existsSync(statusPath)) {
+      const status = readJson(statusPath);
+      if (
+        status.schemaVersion === SCHEMA_VERSION &&
+        status.state === "running" &&
+        Number.isInteger(status.targetPid) &&
+        status.targetPid > 0
+      ) {
+        return status.targetPid;
+      }
+    }
+    if (child.exitCode !== null || child.signalCode !== null) {
+      throw new Error(
+        `Job supervisor exited before target assignment completed (exitCode=${child.exitCode ?? "none"}, signal=${child.signalCode ?? "none"}).`,
+      );
+    }
+    await sleep(25);
+  }
+  throw new Error(
+    `Job supervisor did not confirm suspended target assignment within ${SUPERVISOR_START_TIMEOUT_MS}ms.`,
+  );
+};
+
+const spawnOwnedChild = async (
+  request,
+  stdoutLog,
+  stderrLog,
+  dependencies = { cleanupProcessTree },
+) => {
+  const cleanupOwnedTree =
+    dependencies.cleanupProcessTree || cleanupProcessTree;
+  const [command, ...args] = request.argv;
+  const runDirectory = path.dirname(request.resultPath);
+  const supervisorRequestPath = path.join(
+    runDirectory,
+    `supervisor-${process.pid}.request.json`,
+  );
+  const supervisorStatusPath = path.join(
+    runDirectory,
+    `supervisor-${process.pid}.status.json`,
+  );
+  writeJsonAtomic(supervisorRequestPath, {
+    schemaVersion: SCHEMA_VERSION,
+    ownerPid: process.pid,
+    command: resolveCommand(command),
+    arguments: args,
+    cwd: request.cwd,
+    statusPath: supervisorStatusPath,
+  });
+
+  const child = spawn(
+    resolveCommand("@pwsh"),
+    [
+      "-NoLogo",
+      "-NoProfile",
+      "-NonInteractive",
+      "-ExecutionPolicy",
+      "Bypass",
+      "-File",
+      JOB_SUPERVISOR_PATH,
+      "-Request",
+      supervisorRequestPath,
+    ],
+    {
+      cwd: request.cwd,
+      env: buildChildEnvironment(
+        request.literalEnv || {},
+        request.passEnvValues || {},
+        request.runId,
+      ),
+      shell: false,
+      windowsHide: true,
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+  child.spawnError = null;
+  child.terminalState = null;
+  child.pendingTerminal = null;
+  child.once("error", (error) => {
+    child.spawnError = error;
+    child.pendingTerminal = {
+      status: "spawn-error",
+      error: error.message,
+    };
+  });
+  child.once("close", (exitCode, signal) => {
+    child.pendingTerminal = { status: "exited", exitCode, signal };
+    if (child.targetPid) {
+      child.terminalState = naturalExitOutcome(child, exitCode, signal);
+    }
+  });
+  const stdoutRedactor = createExactValueRedactor(request.passEnvValues);
+  const stderrRedactor = createExactValueRedactor(request.passEnvValues);
+  child.stdout.pipe(stdoutRedactor).pipe(stdoutLog, { end: false });
+  child.stderr.pipe(stderrRedactor).pipe(stderrLog, { end: false });
+  const capturedOutputDone = Promise.all([
+    finished(stdoutRedactor),
+    finished(stderrRedactor),
+  ]);
+  void capturedOutputDone.catch(() => {});
+  child.outputDone = capturedOutputDone;
+  if (dependencies.outputDoneNeverSettles === true) {
+    child.outputDone = new Promise(() => {});
+  }
+  child.abortOutputCapture = () => {
+    child.stdout.unpipe(stdoutRedactor);
+    child.stderr.unpipe(stderrRedactor);
+    child.stdout.destroy();
+    child.stderr.destroy();
+    stdoutRedactor.destroy();
+    stderrRedactor.destroy();
+  };
+
+  try {
+    child.targetPid = await waitForSupervisorStart(child, supervisorStatusPath);
+    if (dependencies.injectSupervisorStartFailure === true) {
+      throw new Error("Injected supervisor start handshake failure.");
+    }
+    if (child.pendingTerminal) {
+      child.terminalState =
+        child.pendingTerminal.status === "spawn-error"
+          ? child.pendingTerminal
+          : naturalExitOutcome(
+              child,
+              child.pendingTerminal.exitCode,
+              child.pendingTerminal.signal,
+            );
+    }
+    return child;
+  } catch (error) {
+    const hasPid = Number.isInteger(child.pid) && child.pid > 0;
+    const isAlive = dependencies.isPidAlive || isPidAlive;
+    const cleanup = hasPid
+      ? await cleanupOwnedTree(child.pid, request.cleanupGraceMs)
+      : { stopped: true, gracefulAttempted: false, forced: false };
+    await finalizeCapturedOutput(child, stdoutLog, stderrLog);
+    const outcome = cleanupOutcome(
+      "spawn-error",
+      cleanup,
+      hasPid ? child.pid : null,
+      child.targetPid,
+      isAlive,
+    );
+    throw new SupervisorStartError(
+      `${error.message}${outcome.error ? ` ${outcome.error}` : ""}`,
+      {
+        ...outcome,
+        pid: hasPid ? child.pid : null,
+        targetPid: child.targetPid ?? null,
+      },
+    );
+  } finally {
+    fs.rmSync(supervisorRequestPath, { force: true });
+  }
+};
+
+const executeSyncRequest = async (
+  request,
+  dependencies = { cleanupProcessTree },
+) => {
+  assertRequest(request);
+  const isAlive = dependencies.isPidAlive || isPidAlive;
+  const stdoutLog = openExclusiveLog(request.stdoutPath);
+  const stderrLog = openExclusiveLog(request.stderrPath);
+  let child;
+  let timeout;
+
+  try {
+    child = await spawnOwnedChild(request, stdoutLog, stderrLog, dependencies);
+  } catch (error) {
+    await closeLogs(stdoutLog, stderrLog);
+    return createResult(request, {
+      status: error.status || "spawn-error",
+      pid: error.pid,
+      targetPid: error.targetPid,
+      cleanup: error.cleanup,
+      childAliveAfterCleanup: error.childAliveAfterCleanup,
+      targetAliveAfterCleanup: error.targetAliveAfterCleanup,
+      error: error.message,
+    });
+  }
+
+  return await new Promise((resolve) => {
+    let settled = false;
+    let terminationInProgress = false;
+    const finish = async (result) => {
+      if (settled) return;
+      settled = true;
+      if (timeout) clearTimeout(timeout);
+      await finalizeCapturedOutput(child, stdoutLog, stderrLog);
+      resolve(
+        createResult(request, {
+          ...result,
+          pid: child.pid,
+          targetPid: child.targetPid,
+        }),
+      );
+    };
+
+    child.once("error", (error) => {
+      void finish({ status: "spawn-error", error: error.message });
+    });
+    child.once("close", (exitCode, signal) => {
+      if (terminationInProgress) return;
+      void finish(naturalExitOutcome(child, exitCode, signal));
+    });
+    if (child.terminalState) void finish(child.terminalState);
+
+    if (request.timeoutMs > 0) {
+      timeout = setTimeout(() => {
+        terminationInProgress = true;
+        void (async () => {
+          const cleanup = await dependencies.cleanupProcessTree(
+            child.pid,
+            request.cleanupGraceMs,
+          );
+          await finish({
+            exitCode: null,
+            signal: null,
+            timedOut: true,
+            ...cleanupOutcome(
+              "timed-out",
+              cleanup,
+              child.pid,
+              child.targetPid,
+              isAlive,
+            ),
+          });
+        })();
+      }, request.timeoutMs);
+    }
+  });
+};
+
+const detachedMetadata = (request, child, status = "running") => ({
+  schemaVersion: SCHEMA_VERSION,
+  runId: request.runId,
+  ownerToken: request.ownerToken,
+  status,
+  workerPid: process.pid,
+  childPid: child.pid,
+  targetPid: child.targetPid,
+  cwd: request.cwd,
+  command: summarizeCommand(request.argv),
+  stdoutPath: request.stdoutPath,
+  stderrPath: request.stderrPath,
+  metadataPath: request.metadataPath,
+  controlPath: request.controlPath,
+  resultPath: request.resultPath,
+  startedAt: new Date().toISOString(),
+});
+
+const executeDetachedRequest = async (
+  request,
+  dependencies = { cleanupProcessTree, writeJsonAtomic },
+) => {
+  assertRequest(request);
+  const cleanupOwnedTree =
+    dependencies.cleanupProcessTree || cleanupProcessTree;
+  const writeAtomic = dependencies.writeJsonAtomic || writeJsonAtomic;
+  const isAlive = dependencies.isPidAlive || isPidAlive;
+  const stdoutLog = openExclusiveLog(request.stdoutPath);
+  const stderrLog = openExclusiveLog(request.stderrPath);
+  let child;
+
+  try {
+    child = await spawnOwnedChild(request, stdoutLog, stderrLog, {
+      ...dependencies,
+      cleanupProcessTree: cleanupOwnedTree,
+    });
+  } catch (error) {
+    await closeLogs(stdoutLog, stderrLog);
+    const result = createResult(request, {
+      status: error.status || "spawn-error",
+      pid: error.pid,
+      targetPid: error.targetPid,
+      cleanup: error.cleanup,
+      childAliveAfterCleanup: error.childAliveAfterCleanup,
+      targetAliveAfterCleanup: error.targetAliveAfterCleanup,
+      error: error.message,
+    });
+    writeAtomic(request.resultPath, result);
+    return result;
+  }
+
+  let childTerminal = child.terminalState;
+  let handleTerminal = null;
+  child.once("error", (error) => {
+    childTerminal = { status: "spawn-error", error: error.message };
+    handleTerminal?.();
+  });
+  child.once("close", (exitCode, signal) => {
+    childTerminal = naturalExitOutcome(child, exitCode, signal);
+    handleTerminal?.();
+  });
+
+  let metadata = detachedMetadata(
+    request,
+    child,
+    request.readiness ? "starting" : "running",
+  );
+  try {
+    writeAtomic(request.metadataPath, metadata);
+  } catch (error) {
+    const cleanup = await cleanupOwnedTree(child.pid, request.cleanupGraceMs);
+    const outcome = cleanupOutcome(
+      "metadata-error",
+      cleanup,
+      child.pid,
+      child.targetPid,
+      isAlive,
+    );
+    await finalizeCapturedOutput(child, stdoutLog, stderrLog);
+    const result = createResult(request, {
+      ...outcome,
+      pid: child.pid,
+      targetPid: child.targetPid,
+      error: `${error.message}${outcome.error ? ` ${outcome.error}` : ""}`,
+    });
+    writeAtomic(request.resultPath, result);
+    return result;
+  }
+
+  let timeout;
+  let terminationInProgress = false;
+  let finalizationPromise = null;
+  let cleanupInProgressPromise = null;
+  const finish = (values) => {
+    if (finalizationPromise) return finalizationPromise;
+    finalizationPromise = (async () => {
+      if (timeout) clearTimeout(timeout);
+      await finalizeCapturedOutput(child, stdoutLog, stderrLog);
+      const finalizationId = crypto.randomBytes(16).toString("hex");
+      const result = createResult(request, {
+        ...values,
+        pid: child.pid,
+        targetPid: child.targetPid,
+        finalizationId,
+      });
+      metadata = {
+        ...metadata,
+        status: result.status,
+        finishedAt: result.finishedAt,
+        exitCode: result.exitCode,
+        signal: result.signal,
+        timedOut: result.timedOut,
+        cleanup: result.cleanup,
+        childAliveAfterCleanup: result.childAliveAfterCleanup,
+        targetAliveAfterCleanup: result.targetAliveAfterCleanup,
+        error: result.error,
+        finalizationId,
+      };
+      writeAtomic(request.resultPath, result);
+      if (dependencies.finalizationGapMs > 0) {
+        await sleep(dependencies.finalizationGapMs);
+      }
+      try {
+        if (dependencies.injectTerminalMetadataFailure === true) {
+          throw new Error("Injected terminal metadata write failure.");
+        }
+        writeAtomic(request.metadataPath, metadata);
+        return result;
+      } catch (error) {
+        const failedResult = {
+          ...result,
+          terminalMetadataError: error.message,
+        };
+        writeAtomic(request.resultPath, failedResult);
+        return failedResult;
+      }
+    })();
+    return finalizationPromise;
+  };
+
+  const cleanupAndFinish = async (baseStatus, values = {}) => {
+    if (cleanupInProgressPromise) return await cleanupInProgressPromise;
+    cleanupInProgressPromise = (async () => {
+      terminationInProgress = true;
+      const cleanup = await cleanupOwnedTree(child.pid, request.cleanupGraceMs);
+      return await finish({
+        ...values,
+        ...cleanupOutcome(
+          baseStatus,
+          cleanup,
+          child.pid,
+          child.targetPid,
+          isAlive,
+        ),
+      });
+    })();
+    return await cleanupInProgressPromise;
+  };
+
+  handleTerminal = () => {
+    if (terminationInProgress || !childTerminal) return;
+    void finish(childTerminal);
+  };
+
+  if (request.readiness) {
+    try {
+      await waitForReadiness(request, () => childTerminal);
+      metadata = {
+        ...metadata,
+        status: "running",
+        readyAt: new Date().toISOString(),
+      };
+      writeAtomic(request.metadataPath, metadata);
+    } catch (error) {
+      if (childTerminal && !isPidAlive(child.pid)) {
+        return await finish({
+          status: "readiness-failed",
+          error: error.message,
+          cleanup: {
+            gracefulAttempted: false,
+            forced: false,
+            stopped: true,
+          },
+          childAliveAfterCleanup: false,
+          targetAliveAfterCleanup: false,
+        });
+      }
+      return await cleanupAndFinish("readiness-failed", {
+        error: error.message,
+      });
+    }
+  }
+
+  if (childTerminal) handleTerminal();
+
+  if (request.timeoutMs > 0) {
+    timeout = setTimeout(() => {
+      void cleanupAndFinish("timed-out", { timedOut: true });
+    }, request.timeoutMs);
+  }
+
+  while (!finalizationPromise && !cleanupInProgressPromise) {
+    if (fs.existsSync(request.controlPath)) {
+      let control;
+      try {
+        control = readJson(request.controlPath);
+      } catch (error) {
+        metadata = { ...metadata, lastControlError: "invalid-json" };
+        writeAtomic(request.metadataPath, metadata);
+        fs.rmSync(request.controlPath, { force: true });
+        await sleep(CONTROL_POLL_MS);
+        continue;
+      }
+
+      fs.rmSync(request.controlPath, { force: true });
+      const ownsRequest =
+        control.schemaVersion === SCHEMA_VERSION &&
+        control.action === "stop" &&
+        control.runId === request.runId &&
+        control.ownerToken === request.ownerToken;
+      if (!ownsRequest) {
+        metadata = { ...metadata, lastControlError: "ownership-mismatch" };
+        writeAtomic(request.metadataPath, metadata);
+        await sleep(CONTROL_POLL_MS);
+        continue;
+      }
+
+      void cleanupAndFinish("stopped");
+      break;
+    }
+    await sleep(CONTROL_POLL_MS);
+  }
+
+  return await (finalizationPromise || cleanupInProgressPromise);
+};
+
+const main = async () => {
+  const requestFlag = process.argv.indexOf("--request");
+  if (requestFlag < 0 || !process.argv[requestFlag + 1]) {
+    throw new Error("Worker requires --request <path>.");
+  }
+  const requestPath = process.argv[requestFlag + 1];
+  let request;
+  try {
+    request = readJson(requestPath);
+    assertRequest(request);
+    request = {
+      ...request,
+      passEnvValues: consumePassEnvironment(request.passEnvNames),
+    };
+  } catch (error) {
+    if (request?.resultPath) {
+      writeJsonAtomic(
+        request.resultPath,
+        createResult(request, {
+          status: "spawn-error",
+          error: error.message,
+        }),
+      );
+    }
+    return;
+  } finally {
+    fs.rmSync(requestPath, { force: true });
+  }
+  let result;
+  try {
+    const injectedCleanupFailure =
+      request.passEnvValues[TEST_CLEANUP_FAILURE_ENV] ===
+      "inject-cleanup-failure";
+    const injectedHandshakeFailure =
+      request.passEnvValues[TEST_HANDSHAKE_FAILURE_ENV] ===
+      "inject-handshake-cleanup-failure";
+    const finalizationGapMs = Number(
+      request.passEnvValues[TEST_FINALIZATION_GAP_ENV] || 0,
+    );
+    const injectedTerminalMetadataFailure =
+      request.passEnvValues[TEST_TERMINAL_METADATA_FAILURE_ENV] ===
+      "inject-terminal-metadata-failure";
+    const runtimeDependencies = {
+      ...(injectedCleanupFailure || injectedHandshakeFailure
+        ? {
+            cleanupProcessTree: async (pid, graceMs) => {
+              const actual = await cleanupProcessTree(pid, graceMs);
+              return {
+                ...actual,
+                actualStoppedBeforeInjection: actual.stopped,
+                stopped: false,
+                injectedForTest: true,
+              };
+            },
+          }
+        : {}),
+      ...(injectedHandshakeFailure
+        ? { injectSupervisorStartFailure: true }
+        : {}),
+      ...(Number.isSafeInteger(finalizationGapMs) && finalizationGapMs > 0
+        ? { finalizationGapMs }
+        : {}),
+      ...(injectedTerminalMetadataFailure
+        ? { injectTerminalMetadataFailure: true }
+        : {}),
+    };
+    const hasRuntimeDependencies = Object.keys(runtimeDependencies).length > 0;
+    result =
+      request.mode === "detached"
+        ? await executeDetachedRequest(
+            request,
+            hasRuntimeDependencies ? runtimeDependencies : undefined,
+          )
+        : await executeSyncRequest(
+            request,
+            hasRuntimeDependencies ? runtimeDependencies : undefined,
+          );
+  } catch (error) {
+    result = createResult(request, {
+      status: "spawn-error",
+      error: error.message,
+    });
+    writeJsonAtomic(request.resultPath, result);
+  }
+  if (request.mode === "sync") writeJsonAtomic(request.resultPath, result);
+};
+
+if (require.main === module) {
+  main().catch((error) => {
+    // WSH has no terminal; request/result files are the only public error channel.
+    process.exitCode = 1;
+  });
+}
+
+module.exports = {
+  buildChildEnvironment,
+  cleanupProcessTree,
+  cleanupOutcome,
+  consumePassEnvironment,
+  createExactValueRedactor,
+  executeDetachedRequest,
+  executeSyncRequest,
+  isPidAlive,
+  resolveCommand,
+};

--- a/.agents/skills/windows-electron-debugging/scripts/run-hidden-windows-worker.node-test.cjs
+++ b/.agents/skills/windows-electron-debugging/scripts/run-hidden-windows-worker.node-test.cjs
@@ -1,0 +1,676 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const crypto = require("node:crypto");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { spawn } = require("node:child_process");
+const test = require("node:test");
+
+const {
+  cleanupProcessTree,
+  executeDetachedRequest,
+  executeSyncRequest,
+  isPidAlive,
+} = require("./run-hidden-windows-worker.cjs");
+
+const WORKER_PATH = path.join(__dirname, "run-hidden-windows-worker.cjs");
+const FIXTURE_PATH = path.join(__dirname, "run-hidden-windows-fixture.cjs");
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+const tempDirectories = [];
+
+const createRun = (mode, overrides = {}) => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "hidden-runner-"));
+  tempDirectories.push(directory);
+  const runId = `${Date.now()}-${crypto.randomBytes(6).toString("hex")}`;
+  return {
+    schemaVersion: 1,
+    mode,
+    runId,
+    ownerToken: crypto.randomBytes(32).toString("hex"),
+    argv: ["@node", FIXTURE_PATH, "echo", "0"],
+    cwd: directory,
+    literalEnv: {},
+    passEnvNames: [],
+    passEnvValues: {},
+    timeoutMs: mode === "sync" ? 5000 : 0,
+    cleanupGraceMs: 750,
+    stdoutPath: path.join(directory, "stdout.log"),
+    stderrPath: path.join(directory, "stderr.log"),
+    metadataPath: path.join(directory, "metadata.json"),
+    controlPath: path.join(directory, "control.json"),
+    resultPath: path.join(directory, "result.json"),
+    ...overrides,
+  };
+};
+
+const writeJson = (filePath, value) =>
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+
+const readJson = (filePath) => JSON.parse(fs.readFileSync(filePath, "utf8"));
+
+const readIfPresent = (filePath) =>
+  fs.existsSync(filePath) ? fs.readFileSync(filePath, "utf8") : "<missing>";
+
+const diagnostics = (request) =>
+  [
+    `metadata=${request.metadataPath}: ${readIfPresent(request.metadataPath)}`,
+    `result=${request.resultPath}: ${readIfPresent(request.resultPath)}`,
+    `stdout=${request.stdoutPath}: ${readIfPresent(request.stdoutPath).slice(0, 1000)}`,
+    `stderr=${request.stderrPath}: ${readIfPresent(request.stderrPath).slice(0, 1000)}`,
+  ].join("\n");
+
+const waitForStep = async (name, predicate, request, timeoutMs = 5000) => {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await sleep(25);
+  }
+  throw new Error(
+    `${name} was not observed within ${timeoutMs}ms.\n${diagnostics(request)}`,
+  );
+};
+
+const startDetachedOwner = (request, extraEnv = {}) => {
+  const requestPath = path.join(
+    path.dirname(request.resultPath),
+    "request.json",
+  );
+  const persistedRequest = { ...request };
+  delete persistedRequest.passEnvValues;
+  writeJson(requestPath, persistedRequest);
+  const worker = spawn(
+    process.execPath,
+    [WORKER_PATH, "--request", requestPath],
+    {
+      shell: false,
+      windowsHide: true,
+      stdio: "ignore",
+      env: { ...process.env, ...extraEnv },
+    },
+  );
+  return { worker, requestPath };
+};
+
+const stopDetachedOwner = async (request, ownerToken = request.ownerToken) => {
+  writeJson(request.controlPath, {
+    schemaVersion: 1,
+    action: "stop",
+    runId: request.runId,
+    ownerToken,
+  });
+  await waitForStep(
+    "stop result",
+    () => fs.existsSync(request.resultPath),
+    request,
+    8000,
+  );
+  return readJson(request.resultPath);
+};
+
+const cleanupOwnerAndAssert = async (workerPid, childPid) => {
+  if (isPidAlive(workerPid)) await cleanupProcessTree(workerPid, 750);
+  if (childPid && isPidAlive(childPid)) {
+    await cleanupProcessTree(childPid, 750);
+  }
+  await waitForStep(
+    "worker exit after cleanup",
+    () => !isPidAlive(workerPid),
+    {
+      metadataPath: "",
+      resultPath: "",
+      stdoutPath: "",
+      stderrPath: "",
+    },
+    5000,
+  );
+  assert.equal(isPidAlive(workerPid), false);
+  if (childPid) assert.equal(isPidAlive(childPid), false);
+};
+
+test.after(() => {
+  for (const directory of tempDirectories) {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("sync preserves argv, cwd, non-secret literal env, stdout, stderr, and exit code", async () => {
+  const request = createRun("sync", {
+    argv: [
+      "@node",
+      FIXTURE_PATH,
+      "echo",
+      "7",
+      "argument with spaces",
+      "$literal&value",
+    ],
+    literalEnv: { RUNNER_EXPLICIT_ENV: "explicit value" },
+  });
+
+  const result = await executeSyncRequest(request);
+
+  assert.equal(result.status, "exited");
+  assert.equal(result.exitCode, 7);
+  assert.equal(result.signal, null);
+  const stdout = fs.readFileSync(request.stdoutPath, "utf8");
+  const payload = JSON.parse(stdout.trim());
+  assert.deepEqual(payload.argv, ["argument with spaces", "$literal&value"]);
+  assert.equal(path.normalize(payload.cwd), path.normalize(request.cwd));
+  assert.equal(payload.explicitEnv, "explicit value");
+  assert.equal(fs.readFileSync(request.stderrPath, "utf8"), "fixture-stderr\n");
+});
+
+test("sync redacts named secret values split across stdout and stderr chunks", async () => {
+  const secret = `split-secret-${crypto.randomBytes(16).toString("hex")}`;
+  const request = createRun("sync", {
+    argv: ["@node", FIXTURE_PATH, "split-secret"],
+    passEnvValues: { RUNNER_SECRET_MARKER: secret },
+  });
+
+  const result = await executeSyncRequest(request);
+
+  assert.equal(result.status, "exited");
+  assert.equal(result.exitCode, 0);
+  for (const filePath of [request.stdoutPath, request.stderrPath]) {
+    const output = fs.readFileSync(filePath, "utf8");
+    assert.doesNotMatch(output, new RegExp(secret));
+    assert.match(output, /<redacted>/);
+  }
+});
+
+test(
+  "sync natural target exit closes its Job and kills a held grandchild",
+  { timeout: 15_000 },
+  async () => {
+    const request = createRun("sync");
+    const pidPath = path.join(
+      path.dirname(request.resultPath),
+      "natural-sync-pids.json",
+    );
+    request.argv = ["@node", FIXTURE_PATH, "orphan-exit", pidPath];
+    let pids;
+    try {
+      const result = await executeSyncRequest(request);
+      pids = readJson(pidPath);
+
+      assert.equal(result.status, "exited");
+      assert.equal(result.exitCode, 0);
+      assert.equal(isPidAlive(result.pid), false);
+      assert.equal(isPidAlive(pids.parentPid), false);
+      assert.equal(isPidAlive(pids.grandchildPid), false);
+    } finally {
+      if (pids?.grandchildPid && isPidAlive(pids.grandchildPid)) {
+        await cleanupProcessTree(pids.grandchildPid, 750);
+      }
+      if (pids?.grandchildPid) {
+        assert.equal(isPidAlive(pids.grandchildPid), false);
+      }
+    }
+  },
+);
+
+test("sync timeout cleans the exact owned parent and grandchild tree", async () => {
+  const request = createRun("sync");
+  const pidPath = path.join(path.dirname(request.resultPath), "tree-pids.json");
+  request.argv = ["@node", FIXTURE_PATH, "tree", pidPath];
+  request.timeoutMs = 500;
+
+  const result = await executeSyncRequest(request);
+  const pids = readJson(pidPath);
+
+  assert.equal(result.status, "timed-out");
+  assert.equal(result.timedOut, true);
+  assert.equal(result.cleanup.stopped, true);
+  assert.equal(result.childAliveAfterCleanup, false);
+  assert.equal(isPidAlive(pids.parentPid), false);
+  assert.equal(isPidAlive(pids.grandchildPid), false);
+});
+
+test("sync timeout reports cleanup-failed when exact-tree death cannot be verified", async () => {
+  const request = createRun("sync", {
+    argv: ["@node", FIXTURE_PATH, "hold"],
+    timeoutMs: 100,
+  });
+  let supervisorPid;
+  const startedAt = Date.now();
+  const result = await executeSyncRequest(request, {
+    cleanupProcessTree: async (pid) => {
+      supervisorPid = pid;
+      return { stopped: false, forced: true };
+    },
+    isPidAlive: (pid) => pid !== supervisorPid,
+    outputDoneNeverSettles: true,
+  });
+  try {
+    assert.ok(Date.now() - startedAt < 3000);
+    assert.equal(result.status, "cleanup-failed");
+    assert.equal(result.cleanup.stopped, false);
+    assert.equal(result.childAliveAfterCleanup, false);
+    assert.equal(result.targetAliveAfterCleanup, true);
+  } finally {
+    await cleanupProcessTree(result.pid, 750);
+    assert.equal(isPidAlive(result.pid), false);
+    assert.equal(isPidAlive(result.targetPid), false);
+  }
+});
+
+test("immediate target exit waits for supervisor handshake before finalizing", async () => {
+  const request = createRun("detached", {
+    argv: ["@node", FIXTURE_PATH, "immediate-exit", "0"],
+  });
+
+  const result = await executeDetachedRequest(request);
+
+  assert.equal(result.status, "exited");
+  assert.equal(result.exitCode, 0);
+  assert.ok(Number.isInteger(result.pid));
+  assert.ok(Number.isInteger(result.targetPid));
+  assert.equal(result.cleanup.stopped, true);
+  assert.equal(result.childAliveAfterCleanup, false);
+  assert.equal(result.targetAliveAfterCleanup, false);
+  const metadata = readJson(request.metadataPath);
+  assert.equal(metadata.childPid, result.pid);
+  assert.equal(metadata.targetPid, result.targetPid);
+  assert.match(result.finalizationId, /^[a-f0-9]{32}$/);
+  assert.equal(metadata.finalizationId, result.finalizationId);
+});
+
+test("detached finalization writes result before terminal metadata", async () => {
+  const request = createRun("detached", {
+    argv: ["@node", FIXTURE_PATH, "immediate-exit", "0"],
+  });
+  const writes = [];
+  const result = await executeDetachedRequest(request, {
+    cleanupProcessTree,
+    writeJsonAtomic: (filePath, value) => {
+      writes.push({ filePath, status: value.status });
+      writeJson(filePath, value);
+    },
+  });
+
+  assert.equal(result.status, "exited");
+  const resultIndex = writes.findIndex(
+    (write) =>
+      write.filePath === request.resultPath && write.status === "exited",
+  );
+  const terminalMetadataIndex = writes.findIndex(
+    (write) =>
+      write.filePath === request.metadataPath && write.status === "exited",
+  );
+  assert.ok(resultIndex >= 0);
+  assert.ok(terminalMetadataIndex > resultIndex);
+  const persistedResult = readJson(request.resultPath);
+  const terminalMetadata = readJson(request.metadataPath);
+  assert.equal(terminalMetadata.finalizationId, persistedResult.finalizationId);
+});
+
+test("supervisor handshake cleanup failure preserves typed cleanup and liveness", async () => {
+  for (const mode of ["sync", "detached"]) {
+    const request = createRun(mode, {
+      argv: ["@node", FIXTURE_PATH, "hold"],
+    });
+    const result = await (mode === "sync"
+      ? executeSyncRequest(request, {
+          injectSupervisorStartFailure: true,
+          cleanupProcessTree: async (pid, graceMs) => {
+            const actual = await cleanupProcessTree(pid, graceMs);
+            return { ...actual, stopped: false, injectedForTest: true };
+          },
+        })
+      : executeDetachedRequest(request, {
+          injectSupervisorStartFailure: true,
+          cleanupProcessTree: async (pid, graceMs) => {
+            const actual = await cleanupProcessTree(pid, graceMs);
+            return { ...actual, stopped: false, injectedForTest: true };
+          },
+        }));
+
+    assert.equal(result.status, "cleanup-failed", mode);
+    assert.equal(result.cleanup.stopped, false, mode);
+    assert.equal(result.cleanup.injectedForTest, true, mode);
+    assert.equal(result.childAliveAfterCleanup, false, mode);
+    assert.equal(result.targetAliveAfterCleanup, false, mode);
+    assert.match(result.error, /supervisor start handshake failure/i, mode);
+    assert.equal(isPidAlive(result.pid), false, mode);
+    assert.equal(isPidAlive(result.targetPid), false, mode);
+  }
+});
+
+test("worker consumes named secret, deletes request, redacts metadata, and stops exactly", async () => {
+  const secret = `secret-${crypto.randomBytes(12).toString("hex")}`;
+  const request = createRun("detached", {
+    passEnvNames: ["RUNNER_SECRET_MARKER"],
+  });
+  const readyPath = path.join(path.dirname(request.resultPath), "ready.json");
+  request.argv = ["@node", FIXTURE_PATH, "secret-check", readyPath];
+  request.readiness = {
+    kind: "file",
+    value: readyPath,
+    timeoutMs: 3000,
+    intervalMs: 25,
+  };
+  const { worker, requestPath } = startDetachedOwner(request, {
+    RUNNER_SECRET_MARKER: secret,
+  });
+  let childPid;
+  try {
+    await waitForStep(
+      "metadata creation",
+      () => fs.existsSync(request.metadataPath),
+      request,
+      5000,
+    );
+    await waitForStep(
+      "readiness artifact",
+      () => fs.existsSync(readyPath),
+      request,
+      5000,
+    );
+    await waitForStep(
+      "running metadata",
+      () => readJson(request.metadataPath).status === "running",
+      request,
+      8000,
+    );
+    const metadata = readJson(request.metadataPath);
+    childPid = metadata.childPid;
+    assert.equal(metadata.workerPid, worker.pid);
+    assert.equal(metadata.command.basename, "@node");
+    assert.match(metadata.command.argvSha256, /^[a-f0-9]{64}$/);
+    assert.equal("argv" in metadata, false);
+    assert.equal(fs.existsSync(requestPath), false);
+    assert.equal(readJson(readyPath).secretPresent, true);
+
+    const result = await stopDetachedOwner(request);
+    assert.equal(result.status, "stopped");
+    assert.equal(result.cleanup.stopped, true);
+    assert.equal(result.childAliveAfterCleanup, false);
+    await waitForStep(
+      "worker natural exit",
+      () => !isPidAlive(worker.pid),
+      request,
+      5000,
+    );
+
+    const persisted = [
+      requestPath,
+      request.metadataPath,
+      request.resultPath,
+      request.stdoutPath,
+      request.stderrPath,
+    ]
+      .map(readIfPresent)
+      .join("\n");
+    assert.doesNotMatch(persisted, new RegExp(secret));
+  } finally {
+    await cleanupOwnerAndAssert(worker.pid, childPid);
+  }
+});
+
+test("detached rejects wrong ownership then stops its exact tree", async () => {
+  const request = createRun("detached");
+  const readyPath = path.join(path.dirname(request.resultPath), "ready.json");
+  request.argv = ["@node", FIXTURE_PATH, "hold", readyPath];
+  request.readiness = {
+    kind: "file",
+    value: readyPath,
+    timeoutMs: 3000,
+    intervalMs: 25,
+  };
+  const { worker } = startDetachedOwner(request);
+  let childPid;
+  try {
+    await waitForStep(
+      "metadata creation",
+      () => fs.existsSync(request.metadataPath),
+      request,
+      5000,
+    );
+    await waitForStep(
+      "readiness artifact",
+      () => fs.existsSync(readyPath),
+      request,
+      5000,
+    );
+    await waitForStep(
+      "running metadata",
+      () => readJson(request.metadataPath).status === "running",
+      request,
+      8000,
+    );
+    const metadata = readJson(request.metadataPath);
+    childPid = metadata.childPid;
+
+    writeJson(request.controlPath, {
+      schemaVersion: 1,
+      action: "stop",
+      runId: request.runId,
+      ownerToken: "0".repeat(64),
+    });
+    await waitForStep(
+      "ownership mismatch metadata",
+      () =>
+        readJson(request.metadataPath).lastControlError ===
+        "ownership-mismatch",
+      request,
+      5000,
+    );
+    assert.equal(isPidAlive(childPid), true);
+
+    const result = await stopDetachedOwner(request);
+    assert.equal(result.status, "stopped");
+    assert.equal(result.cleanup.stopped, true);
+    assert.equal(result.childAliveAfterCleanup, false);
+  } finally {
+    await cleanupOwnerAndAssert(worker.pid, childPid);
+  }
+});
+
+test("detached cleanup failure is fail-closed for readiness, timeout, and stop", async () => {
+  const cases = ["readiness", "timeout", "stop"];
+  for (const scenario of cases) {
+    const request = createRun("detached", {
+      argv: ["@node", FIXTURE_PATH, "hold"],
+      timeoutMs: scenario === "timeout" ? 100 : 0,
+    });
+    if (scenario === "readiness") {
+      request.readiness = {
+        kind: "file",
+        value: path.join(path.dirname(request.resultPath), "never-ready"),
+        timeoutMs: 100,
+        intervalMs: 25,
+      };
+    }
+    const execution = executeDetachedRequest(request, {
+      cleanupProcessTree: async () => ({ stopped: false, forced: true }),
+    });
+    try {
+      await waitForStep(
+        `${scenario} metadata creation`,
+        () => fs.existsSync(request.metadataPath),
+        request,
+        3000,
+      );
+      const childPid = readJson(request.metadataPath).childPid;
+      if (scenario === "stop") {
+        writeJson(request.controlPath, {
+          schemaVersion: 1,
+          action: "stop",
+          runId: request.runId,
+          ownerToken: request.ownerToken,
+        });
+      }
+      const result = await execution;
+      assert.equal(result.status, "cleanup-failed", scenario);
+      assert.equal(result.cleanup.stopped, false, scenario);
+      assert.equal(result.childAliveAfterCleanup, true, scenario);
+      assert.equal(readJson(request.metadataPath).status, "cleanup-failed");
+      await cleanupProcessTree(childPid, 750);
+      assert.equal(isPidAlive(childPid), false);
+    } finally {
+      if (fs.existsSync(request.metadataPath)) {
+        const childPid = readJson(request.metadataPath).childPid;
+        if (isPidAlive(childPid)) await cleanupProcessTree(childPid, 750);
+        assert.equal(isPidAlive(childPid), false);
+      }
+    }
+  }
+});
+
+test("initial detached metadata write failure cleans the spawned supervisor and target", async () => {
+  const request = createRun("detached", {
+    argv: ["@node", FIXTURE_PATH, "hold"],
+  });
+  let injected = false;
+  const result = await executeDetachedRequest(request, {
+    cleanupProcessTree,
+    writeJsonAtomic: (filePath, value) => {
+      if (!injected && filePath === request.metadataPath) {
+        injected = true;
+        throw new Error("injected initial metadata failure");
+      }
+      writeJson(filePath, value);
+    },
+  });
+
+  assert.equal(injected, true);
+  assert.equal(result.status, "metadata-error");
+  assert.equal(result.cleanup.stopped, true);
+  assert.equal(result.childAliveAfterCleanup, false);
+  assert.equal(isPidAlive(result.pid), false);
+  assert.equal(isPidAlive(result.targetPid), false);
+  assert.equal(readJson(request.resultPath).status, "metadata-error");
+});
+
+test(
+  "detached natural target exit closes its Job and kills a held grandchild",
+  { timeout: 15_000 },
+  async () => {
+    const request = createRun("detached");
+    const pidPath = path.join(
+      path.dirname(request.resultPath),
+      "natural-detached-pids.json",
+    );
+    request.argv = ["@node", FIXTURE_PATH, "orphan-exit", pidPath];
+    let pids;
+    try {
+      const result = await executeDetachedRequest(request);
+      pids = readJson(pidPath);
+
+      assert.equal(result.status, "exited");
+      assert.equal(result.exitCode, 0);
+      assert.equal(isPidAlive(result.pid), false);
+      assert.equal(isPidAlive(pids.parentPid), false);
+      assert.equal(isPidAlive(pids.grandchildPid), false);
+    } finally {
+      if (pids?.grandchildPid && isPidAlive(pids.grandchildPid)) {
+        await cleanupProcessTree(pids.grandchildPid, 750);
+      }
+      if (pids?.grandchildPid) {
+        assert.equal(isPidAlive(pids.grandchildPid), false);
+      }
+    }
+  },
+);
+
+test(
+  "detached stop closes its Job and kills target plus held grandchild",
+  { timeout: 15_000 },
+  async () => {
+    const request = createRun("detached");
+    const pidPath = path.join(
+      path.dirname(request.resultPath),
+      "stopped-detached-pids.json",
+    );
+    request.argv = ["@node", FIXTURE_PATH, "tree", pidPath];
+    request.readiness = {
+      kind: "file",
+      value: pidPath,
+      timeoutMs: 3000,
+      intervalMs: 25,
+    };
+    let pids;
+    try {
+      const execution = executeDetachedRequest(request);
+      await waitForStep(
+        "detached tree readiness",
+        () => fs.existsSync(pidPath),
+        request,
+        5000,
+      );
+      pids = readJson(pidPath);
+      writeJson(request.controlPath, {
+        schemaVersion: 1,
+        action: "stop",
+        runId: request.runId,
+        ownerToken: request.ownerToken,
+      });
+
+      const result = await execution;
+      assert.equal(result.status, "stopped");
+      assert.equal(result.cleanup.stopped, true);
+      assert.equal(result.childAliveAfterCleanup, false);
+      assert.equal(isPidAlive(result.pid), false);
+      assert.equal(isPidAlive(pids.parentPid), false);
+      assert.equal(isPidAlive(pids.grandchildPid), false);
+    } finally {
+      if (pids?.grandchildPid && isPidAlive(pids.grandchildPid)) {
+        await cleanupProcessTree(pids.grandchildPid, 750);
+      }
+      if (pids?.grandchildPid) {
+        assert.equal(isPidAlive(pids.grandchildPid), false);
+      }
+    }
+  },
+);
+
+test("detached natural exit fully flushes large logs before result becomes visible", async () => {
+  const byteCount = 512 * 1024;
+  const request = createRun("detached", {
+    argv: ["@node", FIXTURE_PATH, "large-exit", String(byteCount)],
+  });
+
+  const result = await executeDetachedRequest(request);
+
+  assert.equal(result.status, "exited");
+  assert.equal(result.exitCode, 0);
+  assert.equal(fs.readFileSync(request.stdoutPath).length, byteCount);
+  assert.equal(fs.readFileSync(request.stderrPath).length, byteCount);
+  assert.equal(readJson(request.resultPath).finishedAt, result.finishedAt);
+  assert.equal(readJson(request.metadataPath).status, "exited");
+  assert.equal(isPidAlive(result.pid), false);
+});
+
+test("concurrent detached runs keep metadata, logs, and ownership isolated", async () => {
+  const requests = [createRun("detached"), createRun("detached")];
+  const owners = requests.map((request) => {
+    request.argv = ["@node", FIXTURE_PATH, "hold"];
+    return startDetachedOwner(request);
+  });
+  const childPids = [];
+  try {
+    for (const request of requests) {
+      await waitForStep(
+        "concurrent metadata",
+        () => fs.existsSync(request.metadataPath),
+        request,
+        5000,
+      );
+      childPids.push(readJson(request.metadataPath).childPid);
+    }
+    assert.notEqual(requests[0].runId, requests[1].runId);
+    assert.notEqual(childPids[0], childPids[1]);
+    assert.notEqual(requests[0].stdoutPath, requests[1].stdoutPath);
+
+    const firstResult = await stopDetachedOwner(requests[0]);
+    assert.equal(firstResult.status, "stopped");
+    assert.equal(isPidAlive(childPids[1]), true);
+    const secondResult = await stopDetachedOwner(requests[1]);
+    assert.equal(secondResult.status, "stopped");
+  } finally {
+    for (let index = 0; index < owners.length; index += 1) {
+      await cleanupOwnerAndAssert(owners[index].worker.pid, childPids[index]);
+    }
+  }
+});

--- a/.agents/skills/windows-electron-debugging/scripts/run-hidden-windows.cjs
+++ b/.agents/skills/windows-electron-debugging/scripts/run-hidden-windows.cjs
@@ -1,0 +1,940 @@
+#!/usr/bin/env node
+"use strict";
+
+const crypto = require("node:crypto");
+const fs = require("node:fs");
+const path = require("node:path");
+const { spawn } = require("node:child_process");
+
+const SCHEMA_VERSION = 1;
+const CLEANUP_FAILURE_EXIT_CODE = 125;
+const DEFAULT_TIMEOUT_MS = 5 * 60 * 1000;
+const DEFAULT_BOOTSTRAP_TIMEOUT_MS = 20 * 1000;
+const POLL_MS = 50;
+const SCRIPT_DIR = __dirname;
+const BOOTSTRAP_PATH = path.join(SCRIPT_DIR, "run-hidden-windows-bootstrap.js");
+const WORKER_PATH = path.join(SCRIPT_DIR, "run-hidden-windows-worker.cjs");
+const DEFAULT_RUN_ROOT = path.resolve(process.cwd(), ".tmp", "windows-runner");
+
+const usage = `Usage:
+  node run-hidden-windows.cjs sync [options] -- <command> [args...]
+  node run-hidden-windows.cjs detached --stdout <path> --stderr <path> [options] -- <command> [args...]
+  node run-hidden-windows.cjs stop --metadata <path> [--timeout-ms <ms>]
+
+Options:
+  --cwd <path>              Windows child working directory (default: current directory)
+  --timeout-ms <ms>         Bounded child runtime; 0 means no detached runtime timeout
+  --cleanup-grace-ms <ms>   Grace period before force tree cleanup (default: 3000)
+  --literal-env <NAME=VALUE> Non-secret child environment value (repeatable; persisted transiently)
+  --env-path <NAME=PATH>    Convert one mounted WSL path for child env (repeatable)
+  --pass-env <NAME>         Pass one sensitive named WSL value without persisting it (repeatable)
+  --stdout <path>           Detached stdout log (mandatory; {runId} supported)
+  --stderr <path>           Detached stderr log (mandatory; {runId} supported)
+  --metadata <path>         Detached metadata path; stop mode requires it
+  --run-root <path>         Request/result root (default: .tmp/windows-runner)
+  --ready-url <url>         Detached HTTP(S) readiness probe
+  --ready-file <path>       Detached readiness file probe
+  --ready-timeout-ms <ms>   Readiness deadline (default: 30000)
+  --ready-interval-ms <ms>  Readiness polling interval (default: 250)
+
+Reserved commands:
+  @node                    Windows Node executable used by the hidden worker
+  @pwsh                    Installed PowerShell 7, with Windows PowerShell fallback
+`;
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const parsePositiveInteger = (value, name, { allowZero = false } = {}) => {
+  if (!/^\d+$/.test(String(value))) {
+    throw new Error(`${name} must be an integer.`);
+  }
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed < (allowZero ? 0 : 1)) {
+    throw new Error(`${name} is out of range.`);
+  }
+  return parsed;
+};
+
+const assertEnvName = (name) => {
+  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(name)) {
+    throw new Error(`Invalid environment name: ${name}`);
+  }
+};
+
+const parseArgs = (argv) => {
+  const [mode, ...rest] = argv;
+  if (!["sync", "detached", "stop"].includes(mode)) {
+    throw new Error(`Expected mode sync, detached, or stop.\n${usage}`);
+  }
+
+  const options = {
+    mode,
+    cwd: process.cwd(),
+    timeoutMs:
+      mode === "detached"
+        ? 0
+        : mode === "stop"
+          ? DEFAULT_BOOTSTRAP_TIMEOUT_MS
+          : DEFAULT_TIMEOUT_MS,
+    cleanupGraceMs: 3000,
+    literalEnv: {},
+    pathEnv: {},
+    passEnv: [],
+    readyTimeoutMs: 30_000,
+    readyIntervalMs: 250,
+    runRoot: DEFAULT_RUN_ROOT,
+    argv: [],
+  };
+
+  let index = 0;
+  while (index < rest.length) {
+    const token = rest[index];
+    if (token === "--") {
+      options.argv = rest.slice(index + 1);
+      index = rest.length;
+      break;
+    }
+
+    const readValue = () => {
+      index += 1;
+      if (index >= rest.length) throw new Error(`Missing value for ${token}.`);
+      return rest[index];
+    };
+
+    switch (token) {
+      case "--cwd":
+        options.cwd = readValue();
+        break;
+      case "--timeout-ms":
+        options.timeoutMs = parsePositiveInteger(readValue(), token, {
+          allowZero: mode === "detached",
+        });
+        break;
+      case "--cleanup-grace-ms":
+        options.cleanupGraceMs = parsePositiveInteger(readValue(), token);
+        break;
+      case "--env":
+        throw new Error(
+          "--env was retired. Use --literal-env only for non-secret values or --pass-env NAME for sensitive values.",
+        );
+      case "--literal-env": {
+        const assignment = readValue();
+        const separator = assignment.indexOf("=");
+        if (separator <= 0)
+          throw new Error("--literal-env must be NAME=VALUE.");
+        const name = assignment.slice(0, separator);
+        assertEnvName(name);
+        options.literalEnv[name] = assignment.slice(separator + 1);
+        break;
+      }
+      case "--env-path": {
+        const assignment = readValue();
+        const separator = assignment.indexOf("=");
+        if (separator <= 0) throw new Error("--env-path must be NAME=PATH.");
+        const name = assignment.slice(0, separator);
+        assertEnvName(name);
+        options.pathEnv[name] = assignment.slice(separator + 1);
+        break;
+      }
+      case "--pass-env": {
+        const name = readValue();
+        assertEnvName(name);
+        options.passEnv.push(name);
+        break;
+      }
+      case "--stdout":
+        options.stdoutPath = readValue();
+        break;
+      case "--stderr":
+        options.stderrPath = readValue();
+        break;
+      case "--metadata":
+        options.metadataPath = readValue();
+        break;
+      case "--run-root":
+        options.runRoot = readValue();
+        break;
+      case "--ready-url":
+        options.readyUrl = readValue();
+        break;
+      case "--ready-file":
+        options.readyFile = readValue();
+        break;
+      case "--ready-timeout-ms":
+        options.readyTimeoutMs = parsePositiveInteger(readValue(), token);
+        break;
+      case "--ready-interval-ms":
+        options.readyIntervalMs = parsePositiveInteger(readValue(), token);
+        break;
+      default:
+        throw new Error(`Unknown option: ${token}`);
+    }
+    index += 1;
+  }
+
+  if (mode === "stop") {
+    if (!options.metadataPath) throw new Error("stop requires --metadata.");
+    if (options.argv.length > 0)
+      throw new Error("stop does not accept a command.");
+  } else {
+    if (options.argv.length === 0)
+      throw new Error(`${mode} requires -- <command>.`);
+    if (mode === "detached" && (!options.stdoutPath || !options.stderrPath)) {
+      throw new Error("detached requires both --stdout and --stderr.");
+    }
+    if (options.readyUrl && options.readyFile) {
+      throw new Error(
+        "Use only one readiness probe: --ready-url or --ready-file.",
+      );
+    }
+    if ((options.readyUrl || options.readyFile) && mode !== "detached") {
+      throw new Error("Readiness probes are supported only in detached mode.");
+    }
+    if (options.readyUrl) {
+      let url;
+      try {
+        url = new URL(options.readyUrl);
+      } catch {
+        throw new Error("--ready-url must be an absolute HTTP(S) URL.");
+      }
+      if (!["http:", "https:"].includes(url.protocol)) {
+        throw new Error("--ready-url must use HTTP or HTTPS.");
+      }
+    }
+  }
+
+  return options;
+};
+
+const toWindowsPath = (inputPath, basePath = process.cwd()) => {
+  const resolved = path.isAbsolute(inputPath)
+    ? path.normalize(inputPath)
+    : path.resolve(basePath, inputPath);
+  const match = /^\/mnt\/([a-zA-Z])(?:\/(.*))?$/.exec(resolved);
+  if (!match) {
+    if (/^[a-zA-Z]:[\\/]/.test(inputPath)) {
+      return inputPath.replace(/\//g, "\\");
+    }
+    throw new Error(`Path is not on a Windows-mounted drive: ${resolved}`);
+  }
+  const suffix = match[2] ? `\\${match[2].replace(/\//g, "\\")}` : "\\";
+  return `${match[1].toUpperCase()}:${suffix}`;
+};
+
+const fromWindowsPath = (windowsPath) => {
+  const match = /^([a-zA-Z]):[\\/](.*)$/.exec(windowsPath);
+  if (!match) throw new Error(`Not an absolute Windows path: ${windowsPath}`);
+  return `/mnt/${match[1].toLowerCase()}/${match[2].replace(/\\/g, "/")}`;
+};
+
+const expandRunId = (value, runId) => value.replaceAll("{runId}", runId);
+
+const resolvePathOption = (value, runId, basePath = process.cwd()) => {
+  const expanded = expandRunId(value, runId);
+  return path.isAbsolute(expanded)
+    ? path.normalize(expanded)
+    : path.resolve(basePath, expanded);
+};
+
+const resolvePublicPathOption = (value, runId, basePath = process.cwd()) =>
+  resolvePathOption(
+    /^[a-zA-Z]:[\\/]/.test(value) ? fromWindowsPath(value) : value,
+    runId,
+    basePath,
+  );
+
+const findWindowsNode = () => {
+  const configured = process.env.CODEX_WINDOWS_NODE_EXE;
+  const candidates = [
+    configured,
+    "/mnt/d/Program Files/nodejs/node.exe",
+    "/mnt/c/Program Files/nodejs/node.exe",
+  ].filter(Boolean);
+  const found = candidates.find((candidate) => fs.existsSync(candidate));
+  if (!found) {
+    throw new Error(
+      "Windows Node was not found. Set CODEX_WINDOWS_NODE_EXE to its /mnt/<drive>/... path.",
+    );
+  }
+  return toWindowsPath(found);
+};
+
+const buildLiteralEnv = (options, runId) => {
+  const env = Object.fromEntries(
+    Object.entries(options.literalEnv).map(([name, value]) => [
+      name,
+      expandRunId(value, runId),
+    ]),
+  );
+  for (const [name, value] of Object.entries(options.pathEnv)) {
+    env[name] = toWindowsPath(expandRunId(value, runId));
+  }
+  return env;
+};
+
+const getPassEnvValues = (names) => {
+  const values = {};
+  for (const name of names) {
+    if (!Object.prototype.hasOwnProperty.call(process.env, name)) {
+      throw new Error(`Requested pass-through environment is not set: ${name}`);
+    }
+    values[name] = process.env[name];
+  }
+  return values;
+};
+
+const assertSecretsAbsentFromArgv = (argv, passEnvValues) => {
+  for (const value of Object.values(passEnvValues)) {
+    if (value && argv.some((argument) => argument.includes(value))) {
+      throw new Error(
+        "A --pass-env value appears in child argv. Secrets in argv are forbidden.",
+      );
+    }
+  }
+};
+
+const createRunId = () =>
+  `${new Date().toISOString().replace(/[-:.TZ]/g, "")}-${process.pid}-${crypto.randomBytes(8).toString("hex")}`;
+
+const writeJsonAtomic = (filePath, value) => {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  const temporaryPath = `${filePath}.${process.pid}.${crypto.randomBytes(4).toString("hex")}.tmp`;
+  fs.writeFileSync(temporaryPath, `${JSON.stringify(value, null, 2)}\n`, {
+    encoding: "utf8",
+    mode: 0o600,
+  });
+  try {
+    fs.renameSync(temporaryPath, filePath);
+  } catch (error) {
+    if (!["EEXIST", "EPERM", "EACCES"].includes(error?.code)) throw error;
+    fs.rmSync(filePath, { force: true, maxRetries: 10, retryDelay: 10 });
+    fs.renameSync(temporaryPath, filePath);
+  }
+};
+
+const buildRequest = (options) => {
+  const runId = createRunId();
+  const expandedArgv = options.argv.map((argument) =>
+    expandRunId(argument, runId),
+  );
+  const passEnvValues = getPassEnvValues(options.passEnv);
+  assertSecretsAbsentFromArgv(expandedArgv, passEnvValues);
+  const runRoot = resolvePathOption(options.runRoot, runId);
+  const runDirectory = path.join(runRoot, runId);
+  fs.mkdirSync(runRoot, { recursive: true, mode: 0o700 });
+  fs.mkdirSync(runDirectory, { recursive: false, mode: 0o700 });
+
+  const stdoutPath = options.stdoutPath
+    ? resolvePathOption(options.stdoutPath, runId)
+    : path.join(runDirectory, "stdout.log");
+  const stderrPath = options.stderrPath
+    ? resolvePathOption(options.stderrPath, runId)
+    : path.join(runDirectory, "stderr.log");
+  if (path.normalize(stdoutPath) === path.normalize(stderrPath)) {
+    throw new Error("stdout and stderr log paths must be different.");
+  }
+
+  const metadataPath = options.metadataPath
+    ? resolvePathOption(options.metadataPath, runId)
+    : path.join(runDirectory, "metadata.json");
+  const readyFilePath = options.readyFile
+    ? resolvePathOption(options.readyFile, runId)
+    : null;
+  const requestPath = path.join(runDirectory, "request.json");
+  const resultPath = path.join(runDirectory, "result.json");
+  const controlPath = path.join(runDirectory, "control.json");
+  const bootstrapLogPath = path.join(runDirectory, "bootstrap.log");
+  const request = {
+    schemaVersion: SCHEMA_VERSION,
+    mode: options.mode,
+    runId,
+    ownerToken: crypto.randomBytes(32).toString("hex"),
+    argv: expandedArgv,
+    cwd: toWindowsPath(expandRunId(options.cwd, runId)),
+    literalEnv: buildLiteralEnv(options, runId),
+    passEnvNames: options.passEnv,
+    timeoutMs: options.timeoutMs,
+    cleanupGraceMs: options.cleanupGraceMs,
+    stdoutPath: toWindowsPath(stdoutPath),
+    stderrPath: toWindowsPath(stderrPath),
+    metadataPath: toWindowsPath(metadataPath),
+    controlPath: toWindowsPath(controlPath),
+    bootstrapLogPath: toWindowsPath(bootstrapLogPath),
+    readiness: options.readyUrl
+      ? {
+          kind: "url",
+          value: expandRunId(options.readyUrl, runId),
+          timeoutMs: options.readyTimeoutMs,
+          intervalMs: options.readyIntervalMs,
+        }
+      : readyFilePath
+        ? {
+            kind: "file",
+            value: toWindowsPath(readyFilePath),
+            timeoutMs: options.readyTimeoutMs,
+            intervalMs: options.readyIntervalMs,
+          }
+        : null,
+    resultPath: toWindowsPath(resultPath),
+    requestPath: toWindowsPath(requestPath),
+    workerPath: toWindowsPath(WORKER_PATH),
+    windowsNodeExe: findWindowsNode(),
+    createdAt: new Date().toISOString(),
+  };
+  writeJsonAtomic(requestPath, request);
+  return {
+    request,
+    requestPath,
+    resultPath,
+    stdoutPath,
+    stderrPath,
+    metadataPath,
+    controlPath,
+    passEnvValues,
+  };
+};
+
+const getWscriptPath = () => {
+  const candidate = "/mnt/c/Windows/System32/wscript.exe";
+  if (!fs.existsSync(candidate)) {
+    throw new Error(`GUI bootstrap is unavailable: ${candidate}`);
+  }
+  return candidate;
+};
+
+const buildInteropEnvironment = (passEnvValues) => {
+  const additions = Object.keys(passEnvValues);
+  const existing = (process.env.WSLENV || "")
+    .split(":")
+    .filter(Boolean)
+    .filter((entry) => !additions.includes(entry.split("/")[0]));
+  return {
+    ...process.env,
+    ...passEnvValues,
+    WSLENV: [...existing, ...additions].join(":"),
+  };
+};
+
+const launchGuiBootstrap = ({ requestPath, passEnvValues }) =>
+  new Promise((resolve, reject) => {
+    const bootstrap = spawn(
+      getWscriptPath(),
+      [
+        "//B",
+        "//NoLogo",
+        toWindowsPath(BOOTSTRAP_PATH),
+        toWindowsPath(requestPath),
+      ],
+      {
+        shell: false,
+        stdio: "ignore",
+        windowsHide: true,
+        env: buildInteropEnvironment(passEnvValues),
+      },
+    );
+    bootstrap.once("error", reject);
+    bootstrap.once("close", (code, signal) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+      reject(
+        new Error(
+          `GUI bootstrap exited before worker launch (exitCode=${code ?? "none"}, signal=${signal ?? "none"}).`,
+        ),
+      );
+    });
+  });
+
+const relayNewBytes = (filePath, stream, state) => {
+  if (!fs.existsSync(filePath)) return;
+  const size = fs.statSync(filePath).size;
+  if (size <= state.offset) return;
+  const length = size - state.offset;
+  const buffer = Buffer.alloc(length);
+  const descriptor = fs.openSync(filePath, "r");
+  try {
+    fs.readSync(descriptor, buffer, 0, length, state.offset);
+  } finally {
+    fs.closeSync(descriptor);
+  }
+  state.offset = size;
+  stream.write(buffer);
+};
+
+const readJson = (filePath) => JSON.parse(fs.readFileSync(filePath, "utf8"));
+
+const readJsonTransient = (filePath) => {
+  try {
+    return readJson(filePath);
+  } catch (error) {
+    if (
+      error?.code === "ENOENT" ||
+      error instanceof SyntaxError ||
+      /Unexpected end of JSON input/.test(error?.message || "")
+    ) {
+      return null;
+    }
+    throw error;
+  }
+};
+
+const waitForJson = async (filePath, deadline, predicate = () => true) => {
+  while (Date.now() < deadline) {
+    const value = readJsonTransient(filePath);
+    if (value && predicate(value)) return value;
+    await sleep(POLL_MS);
+  }
+  return null;
+};
+
+const sanitizeResultForOutput = (result) => ({
+  schemaVersion: result.schemaVersion,
+  runId: result.runId,
+  status: result.status,
+  exitCode: result.exitCode,
+  signal: result.signal,
+  timedOut: result.timedOut,
+  workerPid: result.workerPid,
+  pid: result.pid,
+  targetPid: result.targetPid,
+  cleanup: result.cleanup,
+  childAliveAfterCleanup: result.childAliveAfterCleanup,
+  targetAliveAfterCleanup: result.targetAliveAfterCleanup,
+  finalizationId: result.finalizationId,
+  terminalMetadataError: result.terminalMetadataError,
+  error: result.error,
+  finishedAt: result.finishedAt,
+});
+
+const finalizedIdentityMatches = (metadata, result, expectedStatus) =>
+  result.runId === metadata.runId &&
+  result.status === expectedStatus &&
+  typeof result.finalizationId === "string" &&
+  result.finalizationId.length >= 32 &&
+  result.finalizationId === metadata.finalizationId &&
+  result.workerPid === metadata.workerPid &&
+  result.pid === metadata.childPid &&
+  result.targetPid === metadata.targetPid &&
+  result.cleanup?.stopped === true &&
+  result.childAliveAfterCleanup === false &&
+  result.targetAliveAfterCleanup === false;
+
+const unlinkRequestBestEffort = (run) => {
+  if (run?.requestPath) fs.rmSync(run.requestPath, { force: true });
+};
+
+const waitForResult = async (run) => {
+  const stdoutState = { offset: 0 };
+  const stderrState = { offset: 0 };
+  const outerTimeout =
+    (run.request.timeoutMs > 0 ? run.request.timeoutMs : DEFAULT_TIMEOUT_MS) +
+    DEFAULT_BOOTSTRAP_TIMEOUT_MS +
+    run.request.cleanupGraceMs * 2;
+  const deadline = Date.now() + outerTimeout;
+
+  while (!fs.existsSync(run.resultPath)) {
+    relayNewBytes(run.stdoutPath, process.stdout, stdoutState);
+    relayNewBytes(run.stderrPath, process.stderr, stderrState);
+    if (Date.now() >= deadline) {
+      const bootstrapLogPath = path.join(
+        path.dirname(run.requestPath),
+        "bootstrap.log",
+      );
+      const bootstrapDetail = fs.existsSync(bootstrapLogPath)
+        ? ` Bootstrap: ${fs.readFileSync(bootstrapLogPath, "utf8").trim()}`
+        : " Bootstrap produced no log.";
+      throw new Error(
+        `Hidden Windows worker did not produce a result within ${outerTimeout}ms (run ${run.request.runId}).${bootstrapDetail}`,
+      );
+    }
+    await sleep(POLL_MS);
+  }
+
+  relayNewBytes(run.stdoutPath, process.stdout, stdoutState);
+  relayNewBytes(run.stderrPath, process.stderr, stderrState);
+  const result = await waitForJson(run.resultPath, deadline);
+  if (!result) {
+    throw new Error(
+      `Hidden Windows worker result was not readable before its bounded deadline (run ${run.request.runId}).`,
+    );
+  }
+  return result;
+};
+
+const sanitizeMetadataForOutput = (metadata) => ({
+  schemaVersion: metadata.schemaVersion,
+  runId: metadata.runId,
+  status: metadata.status,
+  workerPid: metadata.workerPid,
+  childPid: metadata.childPid,
+  targetPid: metadata.targetPid,
+  command: metadata.command,
+  cwd: fromWindowsPath(metadata.cwd),
+  stdoutPath: fromWindowsPath(metadata.stdoutPath),
+  stderrPath: fromWindowsPath(metadata.stderrPath),
+  metadataPath: fromWindowsPath(metadata.metadataPath),
+  startedAt: metadata.startedAt,
+});
+
+const waitForDetachedMetadata = async (run) => {
+  const deadline =
+    Date.now() +
+    DEFAULT_BOOTSTRAP_TIMEOUT_MS +
+    (run.request.readiness?.timeoutMs ?? 0);
+  while (true) {
+    if (fs.existsSync(run.metadataPath)) {
+      const metadata = readJsonTransient(run.metadataPath);
+      if (!metadata) {
+        await sleep(POLL_MS);
+        continue;
+      }
+      if (metadata.status === "running") return metadata;
+      if (
+        [
+          "exited",
+          "spawn-error",
+          "metadata-error",
+          "readiness-failed",
+        ].includes(metadata.status)
+      ) {
+        throw new Error(
+          `Detached run ${run.request.runId} ended before becoming ready: ${metadata.status}.`,
+        );
+      }
+    }
+    if (fs.existsSync(run.resultPath)) {
+      const result = readJsonTransient(run.resultPath);
+      if (!result) {
+        await sleep(POLL_MS);
+        continue;
+      }
+      if (result.status === "cleanup-failed") {
+        return { cleanupFailure: result };
+      }
+      if (
+        [
+          "spawn-error",
+          "bootstrap-error",
+          "metadata-error",
+          "readiness-failed",
+          "exited",
+        ].includes(result.status)
+      ) {
+        throw new Error(
+          result.error ||
+            `Detached run ${run.request.runId} ended before becoming ready: ${result.status}.`,
+        );
+      }
+    }
+    if (Date.now() >= deadline) {
+      throw new Error(
+        `Detached hidden Windows worker did not become ready within the bounded deadline (run ${run.request.runId}).`,
+      );
+    }
+    await sleep(POLL_MS);
+  }
+};
+
+const normalizeWindowsPath = (value) =>
+  value.replace(/\//g, "\\").toLowerCase();
+
+const validateStopMetadata = (metadataPath, metadata) => {
+  if (metadata.schemaVersion !== SCHEMA_VERSION) {
+    throw new Error("Unsupported or missing runner metadata schema.");
+  }
+  if (!/^[0-9A-Za-z-]+$/.test(metadata.runId || "")) {
+    throw new Error("Runner metadata has an invalid run ID.");
+  }
+  if (!/^[a-f0-9]{64}$/.test(metadata.ownerToken || "")) {
+    throw new Error("Runner metadata ownership token is invalid.");
+  }
+  if (!Number.isInteger(metadata.workerPid) || metadata.workerPid <= 0) {
+    throw new Error("Runner metadata worker PID is invalid.");
+  }
+  if (!Number.isInteger(metadata.childPid) || metadata.childPid <= 0) {
+    throw new Error("Runner metadata child PID is invalid.");
+  }
+  if (!Number.isInteger(metadata.targetPid) || metadata.targetPid <= 0) {
+    throw new Error("Runner metadata target PID is invalid.");
+  }
+  const expectedMetadataPath = toWindowsPath(metadataPath);
+  if (
+    normalizeWindowsPath(expectedMetadataPath) !==
+    normalizeWindowsPath(metadata.metadataPath || "")
+  ) {
+    throw new Error(
+      "Runner metadata path does not match its ownership record.",
+    );
+  }
+  for (const field of ["controlPath", "resultPath"]) {
+    if (typeof metadata[field] !== "string") {
+      throw new Error(`Runner metadata ${field} is missing.`);
+    }
+  }
+  return metadata;
+};
+
+const stopDetached = async (options) => {
+  const metadataPath = resolvePublicPathOption(options.metadataPath, "stop");
+  const metadataDeadline = Date.now() + options.timeoutMs;
+  const rawMetadata = await waitForJson(metadataPath, metadataDeadline);
+  if (!rawMetadata) {
+    throw new Error(
+      `Runner metadata was not readable within the bounded deadline: ${metadataPath}`,
+    );
+  }
+  const metadata = validateStopMetadata(metadataPath, rawMetadata);
+  if (metadata.status === "cleanup-failed") {
+    const resultPath = fromWindowsPath(metadata.resultPath);
+    const result = (await waitForJson(
+      resultPath,
+      metadataDeadline,
+      (candidate) => candidate.runId === metadata.runId,
+    )) || {
+      schemaVersion: metadata.schemaVersion,
+      runId: metadata.runId,
+      status: metadata.status,
+      exitCode: metadata.exitCode ?? null,
+      signal: metadata.signal ?? null,
+      timedOut: Boolean(metadata.timedOut),
+      cleanup: metadata.cleanup,
+      childAliveAfterCleanup: metadata.childAliveAfterCleanup,
+      targetAliveAfterCleanup: metadata.targetAliveAfterCleanup,
+      error:
+        metadata.error ||
+        "Owned cleanup failed and no finalized result artifact is available.",
+    };
+    process.stdout.write(
+      `${JSON.stringify(sanitizeResultForOutput(result), null, 2)}\n`,
+    );
+    return CLEANUP_FAILURE_EXIT_CODE;
+  }
+  if (metadata.status === "stopped") {
+    const resultPath = fromWindowsPath(metadata.resultPath);
+    const result = await waitForJson(
+      resultPath,
+      metadataDeadline,
+      (candidate) => candidate.runId === metadata.runId,
+    );
+    if (!result) throw new Error(`Stopped metadata has no matching result.`);
+    const cleanupVerified = finalizedIdentityMatches(
+      metadata,
+      result,
+      "stopped",
+    );
+    process.stdout.write(
+      `${JSON.stringify(sanitizeResultForOutput(result), null, 2)}\n`,
+    );
+    return cleanupVerified ? 0 : CLEANUP_FAILURE_EXIT_CODE;
+  }
+  if (metadata.status === "exited") {
+    const resultPath = fromWindowsPath(metadata.resultPath);
+    const result = await waitForJson(
+      resultPath,
+      metadataDeadline,
+      (candidate) => candidate.runId === metadata.runId,
+    );
+    if (!result) {
+      throw new Error(
+        `Exited metadata has no finalized result within the bounded deadline: ${resultPath}`,
+      );
+    }
+    const cleanupVerified = finalizedIdentityMatches(
+      metadata,
+      result,
+      "exited",
+    );
+    process.stdout.write(
+      `${JSON.stringify(sanitizeResultForOutput(result), null, 2)}\n`,
+    );
+    return cleanupVerified ? 0 : CLEANUP_FAILURE_EXIT_CODE;
+  }
+  if (metadata.status === "spawn-error") {
+    process.stdout.write(
+      `${JSON.stringify(sanitizeMetadataForOutput(metadata), null, 2)}\n`,
+    );
+    return 1;
+  }
+  if (metadata.status !== "running") {
+    throw new Error(
+      `Runner metadata is not stoppable: status=${metadata.status}`,
+    );
+  }
+
+  const controlPath = fromWindowsPath(metadata.controlPath);
+  const resultPath = fromWindowsPath(metadata.resultPath);
+  const alreadyFinalized = readJsonTransient(resultPath);
+  if (
+    alreadyFinalized?.runId === metadata.runId &&
+    ["stopped", "exited", "cleanup-failed"].includes(alreadyFinalized.status)
+  ) {
+    const terminalMetadata = await waitForJson(
+      metadataPath,
+      metadataDeadline,
+      (candidate) =>
+        candidate.runId === metadata.runId &&
+        candidate.status === alreadyFinalized.status &&
+        candidate.finalizationId === alreadyFinalized.finalizationId,
+    );
+    const latestFinalized = readJsonTransient(resultPath);
+    const outputResult =
+      latestFinalized?.runId === alreadyFinalized.runId &&
+      latestFinalized.finalizationId === alreadyFinalized.finalizationId
+        ? latestFinalized
+        : alreadyFinalized;
+    process.stdout.write(
+      `${JSON.stringify(sanitizeResultForOutput(outputResult), null, 2)}\n`,
+    );
+    if (outputResult.status === "cleanup-failed" || !terminalMetadata) {
+      return CLEANUP_FAILURE_EXIT_CODE;
+    }
+    return finalizedIdentityMatches(
+      terminalMetadata,
+      outputResult,
+      outputResult.status,
+    )
+      ? 0
+      : CLEANUP_FAILURE_EXIT_CODE;
+  }
+  writeJsonAtomic(controlPath, {
+    schemaVersion: SCHEMA_VERSION,
+    action: "stop",
+    runId: metadata.runId,
+    ownerToken: metadata.ownerToken,
+    requestedAt: new Date().toISOString(),
+  });
+
+  const deadline = Date.now() + options.timeoutMs + options.cleanupGraceMs * 2;
+  while (Date.now() < deadline) {
+    if (fs.existsSync(resultPath)) {
+      const result = readJsonTransient(resultPath);
+      if (!result) {
+        await sleep(POLL_MS);
+        continue;
+      }
+      if (result.runId === metadata.runId) {
+        if (["stopped", "exited", "cleanup-failed"].includes(result.status)) {
+          const terminalMetadata = await waitForJson(
+            metadataPath,
+            deadline,
+            (candidate) =>
+              candidate.runId === metadata.runId &&
+              candidate.status === result.status &&
+              candidate.finalizationId === result.finalizationId,
+          );
+          const latestResult = readJsonTransient(resultPath);
+          const outputResult =
+            latestResult?.runId === result.runId &&
+            latestResult.finalizationId === result.finalizationId
+              ? latestResult
+              : result;
+          process.stdout.write(
+            `${JSON.stringify(sanitizeResultForOutput(outputResult), null, 2)}\n`,
+          );
+          if (!terminalMetadata || outputResult.status === "cleanup-failed") {
+            return CLEANUP_FAILURE_EXIT_CODE;
+          }
+          return finalizedIdentityMatches(
+            terminalMetadata,
+            outputResult,
+            outputResult.status,
+          )
+            ? 0
+            : CLEANUP_FAILURE_EXIT_CODE;
+        }
+      }
+    }
+    await sleep(POLL_MS);
+  }
+  throw new Error(`Timed out stopping owned run ${metadata.runId}.`);
+};
+
+const main = async () => {
+  const options = parseArgs(process.argv.slice(2));
+  if (options.mode === "stop") {
+    process.exitCode = await stopDetached(options);
+    return;
+  }
+
+  const run = buildRequest(options);
+  try {
+    await launchGuiBootstrap(run);
+
+    if (options.mode === "detached") {
+      const detachedOutcome = await waitForDetachedMetadata(run);
+      if (detachedOutcome.cleanupFailure) {
+        process.stdout.write(
+          `${JSON.stringify(detachedOutcome.cleanupFailure, null, 2)}\n`,
+        );
+        process.exitCode = CLEANUP_FAILURE_EXIT_CODE;
+        return;
+      }
+      const metadata = detachedOutcome;
+      process.stdout.write(
+        `${JSON.stringify(sanitizeMetadataForOutput(metadata), null, 2)}\n`,
+      );
+      return;
+    }
+
+    const result = await waitForResult(run);
+    if (
+      result.status === "bootstrap-error" ||
+      result.status === "spawn-error"
+    ) {
+      throw new Error(
+        result.error || `Hidden Windows run ${result.runId} failed.`,
+      );
+    }
+    if (result.status === "cleanup-failed") {
+      process.stdout.write(
+        `${JSON.stringify(sanitizeResultForOutput(result), null, 2)}\n`,
+      );
+      process.exitCode = CLEANUP_FAILURE_EXIT_CODE;
+      return;
+    }
+    if (result.timedOut) {
+      process.stderr.write(
+        `Hidden Windows run timed out after ${run.request.timeoutMs}ms and its owned tree was verified stopped (run ${run.request.runId}).\n`,
+      );
+      process.exitCode = 124;
+      return;
+    }
+    if (typeof result.exitCode === "number") {
+      process.exitCode = result.exitCode;
+      return;
+    }
+    process.stderr.write(
+      `Hidden Windows child exited by signal ${result.signal || "unknown"} (run ${run.request.runId}).\n`,
+    );
+    process.exitCode = 1;
+  } catch (error) {
+    unlinkRequestBestEffort(run);
+    throw error;
+  }
+};
+
+if (require.main === module) {
+  main().catch((error) => {
+    process.stderr.write(`run-hidden-windows: ${error.message}\n`);
+    process.exitCode = 1;
+  });
+}
+
+module.exports = {
+  SCHEMA_VERSION,
+  CLEANUP_FAILURE_EXIT_CODE,
+  assertSecretsAbsentFromArgv,
+  buildInteropEnvironment,
+  buildRequest,
+  createRunId,
+  fromWindowsPath,
+  parseArgs,
+  resolvePublicPathOption,
+  finalizedIdentityMatches,
+  readJsonTransient,
+  sanitizeMetadataForOutput,
+  sanitizeResultForOutput,
+  toWindowsPath,
+  validateStopMetadata,
+};

--- a/.agents/skills/windows-electron-debugging/scripts/run-hidden-windows.node-test.cjs
+++ b/.agents/skills/windows-electron-debugging/scripts/run-hidden-windows.node-test.cjs
@@ -1,0 +1,394 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+const { Readable } = require("node:stream");
+
+const {
+  assertSecretsAbsentFromArgv,
+  buildRequest,
+  createRunId,
+  finalizedIdentityMatches,
+  fromWindowsPath,
+  parseArgs,
+  resolvePublicPathOption,
+  sanitizeMetadataForOutput,
+  toWindowsPath,
+  validateStopMetadata,
+} = require("./run-hidden-windows.cjs");
+const { createExactValueRedactor } = require("./run-hidden-windows-worker.cjs");
+
+test("parses exact argv, cwd, non-secret literal env, and named secret pass-through", () => {
+  const options = parseArgs([
+    "sync",
+    "--cwd",
+    "/mnt/d/project with spaces",
+    "--literal-env",
+    "ONE=value with spaces",
+    "--pass-env",
+    "PATH",
+    "--env-path",
+    "PROFILE_PATH=.tmp/profile-{runId}",
+    "--timeout-ms",
+    "1234",
+    "--",
+    "@node",
+    "script with spaces.cjs",
+    "--literal=$x&y",
+  ]);
+
+  assert.deepEqual(options.argv, [
+    "@node",
+    "script with spaces.cjs",
+    "--literal=$x&y",
+  ]);
+  assert.equal(options.cwd, "/mnt/d/project with spaces");
+  assert.deepEqual(options.literalEnv, { ONE: "value with spaces" });
+  assert.deepEqual(options.passEnv, ["PATH"]);
+  assert.deepEqual(options.pathEnv, {
+    PROFILE_PATH: ".tmp/profile-{runId}",
+  });
+  assert.equal(options.timeoutMs, 1234);
+});
+
+test("retires ambiguous literal env and forbids named secrets in argv", () => {
+  assert.throws(
+    () => parseArgs(["sync", "--env", "TOKEN=value", "--", "@node"]),
+    /--env was retired/,
+  );
+  assert.throws(
+    () =>
+      assertSecretsAbsentFromArgv(
+        ["@node", "app.cjs", "--token=secret-marker"],
+        { TOKEN: "secret-marker" },
+      ),
+    /Secrets in argv are forbidden/,
+  );
+});
+
+test("requires detached logs and rejects shell-shaped missing command boundaries", () => {
+  assert.throws(
+    () => parseArgs(["detached", "--", "@node", "app.cjs"]),
+    /requires both --stdout and --stderr/,
+  );
+  assert.throws(() => parseArgs(["sync", "@node"]), /Unknown option/);
+});
+
+test("converts mounted WSL and absolute Windows paths without shell interpolation", () => {
+  assert.equal(
+    toWindowsPath("/mnt/d/project with spaces/file.js"),
+    "D:\\project with spaces\\file.js",
+  );
+  assert.equal(
+    fromWindowsPath("D:\\project with spaces\\file.js"),
+    "/mnt/d/project with spaces/file.js",
+  );
+  assert.equal(
+    resolvePublicPathOption("D:\\project with spaces\\file.js", "unused"),
+    "/mnt/d/project with spaces/file.js",
+  );
+});
+
+test("returns detached public filesystem paths in copy-paste-safe WSL form", () => {
+  const metadata = sanitizeMetadataForOutput({
+    schemaVersion: 1,
+    runId: "run-1",
+    status: "running",
+    workerPid: 10,
+    childPid: 11,
+    targetPid: 12,
+    command: { basename: "@node", argvSha256: "a".repeat(64) },
+    cwd: "D:\\project",
+    stdoutPath: "D:\\project\\out.log",
+    stderrPath: "D:\\project\\err.log",
+    metadataPath: "D:\\project\\metadata.json",
+    startedAt: "now",
+  });
+
+  assert.equal(metadata.cwd, "/mnt/d/project");
+  assert.equal(metadata.stdoutPath, "/mnt/d/project/out.log");
+  assert.equal(metadata.stderrPath, "/mnt/d/project/err.log");
+  assert.equal(metadata.metadataPath, "/mnt/d/project/metadata.json");
+  assert.equal("argv" in metadata, false);
+});
+
+test("persists pass-through names but never their sensitive values", () => {
+  const marker = "unit-secret-marker";
+  const previous = process.env.RUNNER_UNIT_SECRET;
+  process.env.RUNNER_UNIT_SECRET = marker;
+  const temporaryRoot = fs.mkdtempSync(
+    path.join(process.cwd(), ".tmp", "hidden-runner-request-"),
+  );
+  try {
+    const options = parseArgs([
+      "sync",
+      "--run-root",
+      temporaryRoot,
+      "--pass-env",
+      "RUNNER_UNIT_SECRET",
+      "--",
+      "@node",
+      "fixture.cjs",
+    ]);
+    const run = buildRequest(options);
+    const persisted = fs.readFileSync(run.requestPath, "utf8");
+    assert.match(persisted, /RUNNER_UNIT_SECRET/);
+    assert.doesNotMatch(persisted, new RegExp(marker));
+    assert.deepEqual(run.request.passEnvNames, ["RUNNER_UNIT_SECRET"]);
+    assert.equal("env" in run.request, false);
+  } finally {
+    if (previous === undefined) delete process.env.RUNNER_UNIT_SECRET;
+    else process.env.RUNNER_UNIT_SECRET = previous;
+    fs.rmSync(temporaryRoot, { recursive: true, force: true });
+  }
+});
+
+test("expands one run ID across ready-file, child argv, cwd, and environment", () => {
+  const temporaryRoot = fs.mkdtempSync(
+    path.join(process.cwd(), ".tmp", "hidden-runner-expansion-"),
+  );
+  try {
+    const options = parseArgs([
+      "detached",
+      "--cwd",
+      process.cwd(),
+      "--run-root",
+      temporaryRoot,
+      "--stdout",
+      path.join(temporaryRoot, "{runId}.stdout.log"),
+      "--stderr",
+      path.join(temporaryRoot, "{runId}.stderr.log"),
+      "--ready-file",
+      ".tmp/ready-{runId}.json",
+      "--literal-env",
+      "RUN_LABEL=label-{runId}",
+      "--env-path",
+      "RUN_PATH=.tmp/path-{runId}",
+      "--",
+      "@node",
+      "fixture.cjs",
+      "hold",
+      ".tmp/ready-{runId}.json",
+    ]);
+
+    const run = buildRequest(options);
+    const { runId } = run.request;
+    assert.doesNotMatch(JSON.stringify(run.request), /\{runId\}/);
+    assert.equal(
+      fromWindowsPath(run.request.readiness.value),
+      path.resolve(`.tmp/ready-${runId}.json`),
+    );
+    assert.equal(
+      path.resolve(run.request.argv.at(-1)),
+      fromWindowsPath(run.request.readiness.value),
+    );
+    assert.equal(run.request.literalEnv.RUN_LABEL, `label-${runId}`);
+    assert.equal(
+      fromWindowsPath(run.request.literalEnv.RUN_PATH),
+      path.resolve(`.tmp/path-${runId}`),
+    );
+  } finally {
+    fs.rmSync(temporaryRoot, { recursive: true, force: true });
+  }
+});
+
+test("redacts exact UTF-8 secret bytes across arbitrary stream chunks", async () => {
+  const secret = "한글-secret-marker";
+  const redactor = createExactValueRedactor({ SECRET: secret });
+  const chunks = [];
+  redactor.on("data", (chunk) => chunks.push(Buffer.from(chunk)));
+  Readable.from([
+    Buffer.from("before:한", "utf8"),
+    Buffer.from("글-secret-", "utf8"),
+    Buffer.from("marker:after", "utf8"),
+  ]).pipe(redactor);
+  await new Promise((resolve, reject) => {
+    redactor.once("end", resolve);
+    redactor.once("error", reject);
+  });
+  const output = Buffer.concat(chunks).toString("utf8");
+  assert.equal(output, "before:<redacted>:after");
+  assert.doesNotMatch(output, new RegExp(secret));
+});
+
+test("creates collision-safe run IDs", () => {
+  const ids = new Set(Array.from({ length: 100 }, createRunId));
+  assert.equal(ids.size, 100);
+});
+
+test("keeps the reusable runner and skill free of project-specific recipes", () => {
+  const files = [
+    "SKILL.md",
+    "scripts/run-hidden-windows.cjs",
+    "scripts/run-hidden-windows-bootstrap.js",
+    "scripts/run-hidden-windows-worker.cjs",
+    "scripts/run-hidden-windows-job-supervisor.ps1",
+  ].map((relativePath) =>
+    fs.readFileSync(path.join(__dirname, "..", relativePath), "utf8"),
+  );
+  for (const source of files) {
+    assert.doesNotMatch(
+      source,
+      /project_poe2|POE2|Kakao|localhost:54321|\b9222\b|npm run/i,
+    );
+  }
+});
+
+test("keeps the GUI bootstrap and descendant launches statically hidden", () => {
+  const publicRunner = fs.readFileSync(
+    path.join(__dirname, "run-hidden-windows.cjs"),
+    "utf8",
+  );
+  const bootstrap = fs.readFileSync(
+    path.join(__dirname, "run-hidden-windows-bootstrap.js"),
+    "utf8",
+  );
+  const worker = fs.readFileSync(
+    path.join(__dirname, "run-hidden-windows-worker.cjs"),
+    "utf8",
+  );
+  const supervisor = fs.readFileSync(
+    path.join(__dirname, "run-hidden-windows-job-supervisor.ps1"),
+    "utf8",
+  );
+
+  assert.match(publicRunner, /"\/\/B"/);
+  assert.match(publicRunner, /"\/\/NoLogo"/);
+  assert.match(publicRunner, /shell: false/);
+  assert.match(publicRunner, /windowsHide: true/);
+  assert.match(bootstrap, /shell\.Run\(command, 0, false\)/);
+  assert.doesNotMatch(bootstrap, /,\s*\)/);
+  assert.match(worker, /shell: false/);
+  assert.match(worker, /windowsHide: true/);
+  assert.match(supervisor, /CREATE_SUSPENDED/);
+  assert.match(supervisor, /CREATE_NO_WINDOW/);
+  assert.match(supervisor, /AssignProcessToJobObject/);
+  assert.match(supervisor, /JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE/);
+  assert.ok(
+    supervisor.indexOf("if (!AssignProcessToJobObject") <
+      supervisor.indexOf("ResumeThread(process.hThread)"),
+  );
+});
+
+test("visibility probe uses a high-frequency native ownership monitor", () => {
+  const probe = fs.readFileSync(
+    path.join(__dirname, "run-hidden-windows-visibility-probe.cjs"),
+    "utf8",
+  );
+
+  assert.match(probe, /CreateToolhelp32Snapshot/);
+  assert.match(probe, /Process32FirstW/);
+  assert.match(probe, /EnumWindows/);
+  assert.match(probe, /IsWindowVisible/);
+  assert.match(probe, /GetForegroundWindow/);
+  assert.match(probe, /GetGUIThreadInfo/);
+  assert.doesNotMatch(probe, /Get-CimInstance|Get-Process/);
+});
+
+test("validates stop ownership metadata and rejects path/token mismatches", () => {
+  const temporaryRoot = path.join(process.cwd(), ".tmp");
+  fs.mkdirSync(temporaryRoot, { recursive: true });
+  const directory = fs.mkdtempSync(
+    path.join(temporaryRoot, "hidden-runner-unit-"),
+  );
+  const metadataPath = path.join(directory, "metadata.json");
+  const metadata = {
+    schemaVersion: 1,
+    runId: "20260813-1234-abcdef",
+    ownerToken: "a".repeat(64),
+    workerPid: 10,
+    childPid: 11,
+    targetPid: 12,
+    metadataPath: toWindowsPath(metadataPath),
+    controlPath: toWindowsPath(path.join(directory, "control.json")),
+    resultPath: toWindowsPath(path.join(directory, "result.json")),
+  };
+
+  assert.equal(validateStopMetadata(metadataPath, metadata), metadata);
+  assert.throws(
+    () =>
+      validateStopMetadata(metadataPath, { ...metadata, ownerToken: "bad" }),
+    /ownership token/,
+  );
+  assert.throws(
+    () =>
+      validateStopMetadata(metadataPath, {
+        ...metadata,
+        metadataPath: "D:\\unrelated\\metadata.json",
+      }),
+    /does not match/,
+  );
+  fs.rmSync(directory, { recursive: true, force: true });
+});
+
+test("requires finalized stopped/exited identity and cleanup to match metadata", () => {
+  const metadata = {
+    runId: "run-identity",
+    finalizationId: "f".repeat(32),
+    workerPid: 10,
+    childPid: 11,
+    targetPid: 12,
+  };
+  const result = {
+    runId: "run-identity",
+    finalizationId: "f".repeat(32),
+    status: "stopped",
+    workerPid: 10,
+    pid: 11,
+    targetPid: 12,
+    cleanup: { stopped: true },
+    childAliveAfterCleanup: false,
+    targetAliveAfterCleanup: false,
+  };
+  assert.equal(finalizedIdentityMatches(metadata, result, "stopped"), true);
+  assert.equal(
+    finalizedIdentityMatches(
+      metadata,
+      { ...result, finalizationId: "e".repeat(32) },
+      "stopped",
+    ),
+    false,
+  );
+  assert.equal(
+    finalizedIdentityMatches(
+      metadata,
+      { ...result, runId: "other" },
+      "stopped",
+    ),
+    false,
+  );
+  assert.equal(
+    finalizedIdentityMatches(metadata, { ...result, pid: 99 }, "stopped"),
+    false,
+  );
+  assert.equal(
+    finalizedIdentityMatches(metadata, { ...result, targetPid: 99 }, "stopped"),
+    false,
+  );
+  assert.equal(
+    finalizedIdentityMatches(
+      metadata,
+      { ...result, status: "exited" },
+      "exited",
+    ),
+    true,
+  );
+  assert.equal(
+    finalizedIdentityMatches(
+      metadata,
+      { ...result, status: "exited", workerPid: 99 },
+      "exited",
+    ),
+    false,
+  );
+  assert.equal(
+    finalizedIdentityMatches(
+      metadata,
+      { ...result, status: "exited", targetPid: 99 },
+      "exited",
+    ),
+    false,
+  );
+});

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -166,31 +166,37 @@ in its area:
   `docs/Roadmap.md` (CI-synced to Issue #7 + gh-pages notice, public
   wording gate); dev-internal (tooling/build/CI/refactor/tech debt/agent
   workflow) → root `AGENTS-ROADMAP.md` (not CI-coupled).
-- `windows-electron-debugging` — debugging/visually verifying the launcher
-  (pwsh `npm run dev`, CDP capture, page dumps, real Electron screenshots —
-  never WSL/mock-browser verification).
+- `windows-electron-debugging` — **mandatory single owner** for every
+  WSL→Windows command (tests/lint/build/dev), hidden process lifecycle, Electron
+  runtime/CDP/screenshots and cleanup. Read it before any Windows execution.
 - `github-cli-token` — see above.
 
 ### Windows Electron QA visibility
 
-- Agent-driven Electron QA defaults to hidden, non-focus-stealing execution.
-  Set `ELECTRON_START_HIDDEN=true` and an isolated
-  `ELECTRON_QA_USER_DATA_DIR=<temporary absolute Windows path>` before
-  `npm run dev`, then use CDP against the real launcher target for
-  interaction, DOM inspection, and screenshots.
-- Never point `ELECTRON_QA_USER_DATA_DIR` at the user's normal launcher data
-  directory. Remove the temporary QA profile after the hidden instance exits.
-- Agent-started Windows QA terminals and console hosts must also stay hidden.
-  Run synchronous PowerShell commands through WSL interop without opening a
-  terminal UI. For detached or long-running Vite/Electron processes, use
-  `Start-Process -WindowStyle Hidden` and redirect stdout/stderr to temporary
-  log files so no PowerShell, cmd, or console window is shown or focused.
-- Hidden execution does not weaken the real-Windows requirement: Electron,
-  preload, IPC, terminal logs, and the actual renderer target must still be
-  used.
+- Agent-driven Windows commands and Electron QA must follow the mandatory
+  `windows-electron-debugging` skill from first WSL interop through exact owned
+  cleanup. Do not substitute a second launcher or direct Windows interop.
+- Electron QA must remain hidden, use the real app, and use an isolated
+  temporary profile rather than the user's launcher profile.
 - Show or focus a QA window only when the behavior cannot be verified while
   hidden. Explain why and obtain the user's confirmation before making it
   visible.
+
+Project-specific recipes (after reading the skill):
+
+- Repository cwd: `/mnt/d/project_poe2/POE2-unofficial-launcher` ↔
+  `D:\project_poe2\POE2-unofficial-launcher`.
+- Hidden launcher variables: `ELECTRON_START_HIDDEN`, `ELECTRON_QA_RUN_ID`,
+  `ELECTRON_REMOTE_DEBUGGING_PORT`, `ELECTRON_QA_USER_DATA_DIR`.
+- Renderer target: `http://localhost:54321/`; project CDP capture script:
+  `scripts/qa/cdp-capture.cjs` (`CDP_PORT`, `CDP_TARGET_URL`, `CDP_OUTPUT`).
+- `dev:wsl` uses `scripts/qa/hidden-electron-launch.cjs`; it selects a unique CDP
+  port and succeeds only when its owned child exposes the run-marked exact
+  renderer target. Its default isolated profile is outside the repository under
+  `%TEMP%\poe2-unofficial-launcher-codex-qa\<runId>`; ready evidence records the
+  absolute profile path and matching run ownership marker.
+- Kakao dump source: `%TEMP%\poe2-unofficial-launcher\kakao-page-dumps`;
+  preserve selected evidence only under this repository's `.tmp` directory.
 
 ## WSL execution rules (detect at session start)
 
@@ -199,19 +205,19 @@ development primary (edit/git/inspection) and Windows is the build/run
 primary (Electron + actual POE/POE2 game test, which Linux cannot run).
 Both OSes share the same `node_modules` under `D:\project_poe2\POE2-unofficial-launcher\`.
 
-Split commands by where they belong:
+Split work by where it belongs:
 
 - WSL bash, direct: pure Node scripts only (e.g. `node -e ...` hypothesis
   checks). **eslint/vitest both require Linux-native binaries
   (`unrs-resolver`, `@rolldown/binding-linux-x64-gnu`) that are absent in
   this shared `node_modules` — they fail in WSL; do not try.**
-- Windows PowerShell, never WSL: `npm install`, `npm ci`, `npm run build`,
-  `npm run build:check`, `npm run dev`, `npm run lint`, `npm run lint:fix`, `npm test`.
-  - Prefer `pwsh.exe` (PowerShell 7); fall back to `powershell.exe` (5.1) if absent.
-  - Detect: `command -v pwsh.exe >/dev/null && PS=pwsh.exe || PS=powershell.exe`
-  - Invoke: `"$PS" -NoProfile -Command "cd 'D:\project_poe2\POE2-unofficial-launcher'; npm run <script>"`
-  - On failure (e.g. native module mismatch), fall back to asking the user
-    to run it on Windows.
+- Windows: `npm install`, `npm ci`, tests, lint, build, dev, Electron, CDP and
+  Windows-only probes. From WSL, read and follow
+  `.agents/skills/windows-electron-debugging/SKILL.md`; it owns the exact
+  hidden runner invocation, sync/detached modes, logs, timeouts and cleanup.
+- Do not improvise a second WSL→Windows launcher or bypass the runner after a
+  failure. Report the actionable runner failure or ask the user to execute the
+  command in an already-visible Windows terminal.
 
 Why `npm install`/`npm ci` must not run in WSL: WSL's npm writes only POSIX
 symlinks under `node_modules/.bin/` and does not create the Windows wrappers
@@ -221,7 +227,8 @@ dependencies need reinstalling (lock conflict, native binding error,
 pre-commit hook failing on unrs-resolver, etc.), ask the user to run
 `npm ci` from Windows pwsh — do not auto-repair from WSL.
 
-The pre-commit hook works in WSL: `.husky/pre-commit` detects WSL and delegates
+The pre-commit hook is the sole direct-interop exception: `.husky/pre-commit`
+detects WSL and internally delegates
 lint-staged to Windows pwsh (path via `wslpath -w`), so `git commit` from WSL
 passes without `--no-verify` while still running eslint/prettier through the
 Windows `node_modules` (#241). If pwsh/`wslpath` are missing it fails closed

--- a/docs/work/2026-08-09-kakao-game-registry-path-diagnostics.md
+++ b/docs/work/2026-08-09-kakao-game-registry-path-diagnostics.md
@@ -1,0 +1,1321 @@
+# 카카오게임즈 게임 경로 진단 및 레지스트리 복구
+
+> 작성일: 2026-08-09 · 갱신: 2026-08-22 · 상태: PR candidate(자동 게이트·분리 리뷰 통과, 사용자 DoD 대기) · 브랜치: `fix/kakao-game-registry-path-diagnostics`
+
+## 배경과 목표
+
+카카오게임즈 스타터 전환 이후에도 런처의 POE1·POE2 설치 경로 진단은
+`DaumGames` 레지스트리만 조회한다. 새 `Kakaogames` 키만 존재하는 설치를
+찾지 못할 수 있고, 반대로 런처 설정 경로는 유효하지만 레지스트리 후보가
+모두 비어 있는 상태를 사용자가 알아차리기 어렵다. 진단 화면에서는 레지스트리
+키와 값 이름을 한 경로처럼 연결해 표시하는 오류도 있었다.
+
+이번 작업은 다음을 목표로 한다.
+
+1. 공식 후보 순서인 `Kakaogames` 우선, `DaumGames` fallback으로 설치 경로를
+   찾는다.
+2. 런처 설정 경로는 유효하지만 레지스트리 설치 정보가 없거나 읽히지 않을 때
+   실행을 막지 않는 경고를 표시하고, 클릭하면 해당 게임 경로 진단 모달을 연다.
+3. 사용자가 유효한 런처 설정 경로를 확인한 뒤 canonical `Kakaogames` 키에
+   `InstallPath`를 명시적으로 등록할 수 있게 한다.
+4. 경로 조작 뒤 설치 상태를 다시 계산하고, 늦게 끝난 과거 검사가 최신 상태를
+   덮어쓰지 않게 한다.
+
+## 공식 출처와 근거 경계
+
+2026-08-09에 아래 퍼블리셔 CDN 문서를 조회했다.
+
+- POE1:
+  <https://common.gdn.gamecdn.net/live/config/kakaogames/poe.gamestarter.json>
+- POE2:
+  <https://common.gdn.gamecdn.net/live/config/kakaogames/poe2.gamestarter.json>
+
+당일 POE1의 `{ poe: { live: { ... } } }`, POE2의
+`{ poe2: { live: { ... } } }` 구조에서 확인한 값은 다음과 같다.
+
+| 게임 | 필드 접두사 | `RegistryRoot` | `RegistryPath` (우선순위 순)                          |
+| ---- | ----------- | -------------- | ----------------------------------------------------- |
+| POE1 | `poe.live`  | `HKCU`         | `SOFTWARE\Kakaogames\POE`, `SOFTWARE\DaumGames\POE`   |
+| POE2 | `poe2.live` | `HKCU`         | `SOFTWARE\Kakaogames\POE2`, `SOFTWARE\DaumGames\POE2` |
+
+근거의 경계는 다음과 같다.
+
+- 공식 JSON은 레지스트리 루트와 후보 키·순서를 명시한다.
+- 공식 JSON은 레지스트리 **값 이름 `InstallPath`를 명시하지 않는다.** 이 값
+  이름은 기존 런처 동작과 실제 설치 환경 관찰에 근거한다. 따라서 신규
+  `Kakaogames` 설치 환경에서의 실제 값 이름 확인은 사용자 실동작 DoD로 남긴다.
+- 퍼블리셔는 JSON 구조와 값을 바꿀 수 있다. 런처는 이 문서를 런타임에
+  요청하거나 자동 반영하지 않는다.
+
+### 현재 PC 읽기 전용 관찰 스냅샷
+
+2026-08-09 읽기 전용 점검에서는 새 `KakaogamesStarter`가 설치되어 있고 구
+`DaumGameStarter`는 제거된 상태였지만, POE1·POE2 게임 경로 키는 모두
+`DaumGames` 아래에만 남아 있었다. 개인 설치 경로는 이 문서에 기록하지 않는다.
+
+따라서 스타터가 전환된 기존 사용자에게 신·구 게임 키가 모두 존재한다고
+가정할 수 없다. 새 키 우선과 구 키 fallback을 동시에 유지해야 한다.
+
+## 소스 계약 관리 정책
+
+- 제품 런타임은 저장소에 버전 관리되는 정적 후보 목록만 사용한다.
+- 런타임, 시작 검사, 진단 모달에서 CDN을 요청하지 않는다.
+- 기본 `npm test`, build, CI에는 외부 CDN 검사를 연결하지 않는다.
+- `npm run audit:kakao-registry-source`는 개발자가 명시적으로 실행하는 opt-in
+  네트워크 감사다. `poe.live.RegistryRoot`/`poe.live.RegistryPath`와
+  `poe2.live.RegistryRoot`/`poe2.live.RegistryPath`의 구조·값·순서 drift 및
+  네트워크 실패를 검출한다.
+- 감사 실패는 런타임 매핑을 자동 수정하지 않는다. 사람이 퍼블리셔 변경을
+  검토한 뒤 코드·문서·오프라인 테스트를 함께 갱신한다.
+- 정적 후보 선택과 fallback 동작은 네트워크 없는 단위 테스트로 검증한다.
+
+## 아키텍처와 안전 경계
+
+### 생명주기와 상태 소유권
+
+- 레지스트리 후보 탐색은 bootstrap/post-init 설치 경로 reconciliation과 사용자
+  진단 동작에서 사용한다.
+- `GameStatusStore`의 런타임/프로세스 상태가 설치 검사 상태보다 강하다.
+  reconciliation은 `preparing`, `processing`, `authenticating`, `ready`,
+  `running`을 임의로 낮추지 않는다.
+- 경로 선택·등록·삭제·동기화 성공 뒤 해당 게임 설치 상태를 명시적으로 다시
+  계산한다.
+- 겹친 설치 검사는 generation/token을 비교해 오래된 결과가 최신 결과를
+  덮어쓰지 못하게 한다.
+
+### IPC와 정확한 대상 조작
+
+- 새 EventBus를 만들지 않고 기존 게임 경로 진단 흐름을 확장한다.
+- Renderer가 임의의 레지스트리 경로를 전달해 쓰게 하지 않는다. Main이
+  `serviceId`, `gameId`, 진단한 후보 identity로 허용 목록의 정확한 키를 다시
+  해석한다.
+- sync/delete/register는 사용자가 모달에서 확인한 정확한 후보만 대상으로 하며,
+  쓰기 직전 상태를 다시 읽어 TOCTOU 변경을 검사한다.
+- `read-failed`는 키 없음/빈 값과 구분한다. 읽기 실패가 하나라도 있으면 자동
+  fallback 등록이나 덮어쓰기를 허용하지 않는다.
+
+### 외부 레지스트리 변경 권한
+
+- 제품 기능 구현 범위에는 사용자 선택으로 수행되는 HKCU 레지스트리
+  등록·동기화·삭제와 이에 필요한 IPC 계약 보강이 승인되어 있다.
+- 실제 변경은 모달에서 대상 키·값 이름·경로를 표시하고 사용자가 확인한 뒤에만
+  수행한다.
+- 수동 등록 대상은 `HKCU:\Software\Kakaogames\POE{,2}`의 `InstallPath`
+  하나다. `DaumGames` 키를 새로 만들거나 미러링하지 않고, 다른 값 또는 키
+  컨테이너를 삭제하지 않는다.
+- 두 후보가 확정적으로 키 없음/값 없음/빈 값이고 런처 설정 경로 및
+  `PathOfExile_KG.exe`가 쓰기 직전에도 유효할 때만 등록한다. 기존에 비어 있지
+  않은 값이 생겼으면 덮어쓰지 않고 중단한다.
+- 에이전트의 자동 검증은 mock/격리된 키를 사용한다. 사용자 PC의 실제 게임
+  레지스트리를 변경하는 검증은 별도 명시 승인 없이 수행하지 않으며 최종 확인은
+  `[사용자]` DoD로 남긴다.
+
+## Blast radius
+
+- 게임 설치 경로 조회가 기존 단일 `DaumGames` 키에서 신·구 후보 탐색으로
+  넓어진다.
+- 경로 진단 결과와 IPC payload가 선택된 후보 identity를 보존하도록 확장된다.
+- 알림 UI에 실행을 막지 않는 typed 운영 경고가 추가되고 클릭 시 기존 진단
+  모달을 연다.
+- 사용자 확인 후 canonical HKCU 값 하나를 생성·수정하거나 선택된 기존 값을
+  삭제할 수 있다.
+- 경로 조작 후 설치 상태 reconciliation의 실행 순서가 보강된다.
+- AppConfig schema, 설정 migration, 의존성, updater/release flow는 변경하지
+  않는다.
+- CDN 가용성이나 JSON 변경은 제품 런타임과 기본 CI에 영향을 주지 않는다.
+
+## 마일스톤과 DoD
+
+### MS1 — 출처 계약과 작업 기준 고정
+
+- [WSL] 본 문서에 공식 URL, 2026-08-09 계약 값, 근거 경계, 현재 PC 관찰,
+  runtime no-fetch 정책과 안전 경계가 기록되어 있다.
+- [WSL] Node built-in만 사용하는 opt-in CDN drift 감사 명령이 있고 기본
+  test/build/CI에서 호출되지 않는다.
+- [WSL] 감사의 JSON 추출·비교 로직을 네트워크 없이 import하여 검사할 수 있다.
+
+### MS2 — 정적 후보 탐색, exact-target 경계와 상태 reconciliation
+
+- [Windows-pwsh] POE1·POE2 모두 `Kakaogames` 유효 후보를 우선 선택하고,
+  누락·빈 값·무효 경로이면 `DaumGames`의 유효 후보로 fallback한다.
+- [Windows-pwsh] 둘 다 유효하면 `Kakaogames`를 선택하며 실제 선택 키가 진단
+  결과에 보존된다.
+- [Windows-pwsh] 런처 설정 경로 우선순위와 GGG 동작에는 회귀가 없다.
+- [Windows-pwsh] conflict keep/sync와 registry clear는 모달이 본 allowlisted
+  candidate identity 및 expected 현재 경로를 전달한다. sync/delete는 Main의
+  단일 PowerShell 실행 안에서 fresh read·정규화 비교·mutation을 순서대로
+  수행하며, 일치할 때만 정확한 후보 하나를 조작한다.
+- [Windows-pwsh] conflict keep/sync는 모달이 본 launcher config path도 전달하고,
+  Main의 fresh config path 및 실행 파일 검증과 일치해야 진행한다.
+- [Windows-pwsh] target mismatch/missing/read-failed 또는 비허용 identity이면
+  registry/config mutation 없이 최신 진단을 반환한다.
+- [Windows-pwsh] 경로 조작 뒤 상태를 다시 계산하고 늦은 과거 검사 결과는 최신
+  상태를 덮어쓰지 않는다.
+- [Windows-pwsh] 성공한 경로 조작 뒤 reconciliation이 실패해도 이미 성공한
+  action result는 유지하고 실패 동작은 reconciliation을 시작하지 않는다.
+
+### MS3 — 경고 알림, 진단 후보 UI와 명시적 canonical 등록
+
+- [Windows-pwsh] 런처 설정 경로가 유효하지만 유효한 레지스트리 후보가 없으면
+  amber warn 알림이 한 건만 유지되고 게임 실행은 계속 가능하다.
+- [Windows-pwsh] 키 없음/빈 값과 `read-failed`의 안내 문구가 구분된다.
+- [Windows-pwsh] 알림 클릭 시 해당 서비스·게임의 경로 진단 모달이 열린다.
+- [Windows-pwsh] 모달은 레지스트리 키와 값 이름을 별도 필드로 표시하고,
+  후보·검증 상태·조작 대상을 모호하지 않게 보여준다.
+- [Windows-pwsh] 유효한 런처 설정 경로와 두 후보의 확정적 부재가 확인된 경우에만
+  사용자가 canonical `Kakaogames`의 `InstallPath` 등록 확인창을 열 수 있다.
+- [Windows-pwsh] 확인창에 정확한 키·값 이름·등록 경로가 표시된다.
+- [Windows-pwsh] 값이 생겼거나 후보 읽기가 실패하면 덮어쓰지 않고 재진단을
+  요구한다.
+- [Windows-pwsh] register도 MS2 exact-target 허용 목록·fresh-read 경계를
+  재사용하며 렌더러가 전달한 임의 경로는 거부한다.
+- [Windows-pwsh] 등록 성공 뒤 설치 상태와 진단·경고를 다시 계산하고, 실패 시
+  최신 진단을 표시한다.
+
+### MS4 — 통합 검증과 실제 Electron 시각 QA
+
+- [Windows-pwsh] 관련 단위/UI 테스트, 전체 lint, `npm run build:check`가
+  통과한다.
+- [Windows-pwsh] hidden 실제 Electron의 POE1·POE2 진단 상태를 각각 캡처하고
+  터미널 로그·CDP fatal 여부와 함께 사용자에게 브리핑한다.
+- [Windows-pwsh] isolated profile을 사용한 hidden 실제 Electron에서 알림 클릭,
+  진단, 등록 확인 흐름에 fatal/IPC 오류가 없고 캡처가 확보된다.
+- [사용자] 실제 신규 `Kakaogames` 환경에서 값 이름·실행·진단 및 등록 결과를
+  확인한다.
+- [사용자] 실제 런처에서 경고 문구·모달·등록 동작을 확인한다.
+- [WSL] 분리 리뷰가 work 문서, `git diff master...HEAD`, 이전 지적을 기준으로
+  `통과` 또는 `조건부 통과` 판정을 내린다.
+
+## 결정 로그
+
+| 날짜       | 결정                                                                        | 이유                                                                                      |
+| ---------- | --------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| 2026-08-09 | `Kakaogames` 우선, `DaumGames` fallback을 정적 정책으로 채택                | 공식 스타터 JSON의 후보 순서와 기존 사용자 호환성을 함께 보존                             |
+| 2026-08-09 | CDN은 런타임과 기본 CI에서 참조하지 않고 opt-in drift 감사에만 사용         | 퍼블리셔 구조 변경과 네트워크 장애가 제품 실행·필수 게이트를 깨지 않게 함                 |
+| 2026-08-09 | 런처 설정 경로 유효 + 레지스트리 이상은 실행 차단이 아닌 warn 알림으로 처리 | 실제 게임 실행 가능성과 복구 안내를 분리                                                  |
+| 2026-08-09 | warn 클릭은 기존 게임 경로 진단 모달을 재사용                               | 새 UI 진입점과 EventBus 추가를 피하면서 정확한 복구 문맥 제공                             |
+| 2026-08-09 | 수동 등록은 canonical `Kakaogames` 키 하나에만 명시적으로 수행              | 구 키 재생성과 불필요한 미러링을 피하고 공식 우선순위에 맞춤                              |
+| 2026-08-09 | 레지스트리 조작 뒤 재조정과 오래된 검사 결과 차단을 함께 구현               | 등록만으로 가려질 수 있는 stale `uninstalled` 상태의 근본 원인을 해결                     |
+| 2026-08-09 | exact-target IPC 경계를 경고·등록 UI보다 먼저 구현                          | 표시용 후보를 mutation authority로 오용하지 않고 이후 UI가 안전한 계약 위에서 동작하게 함 |
+| 2026-08-09 | UI 변경 후 hidden 실제 Electron 캡처를 사용자에게 브리핑                    | Windows Electron 실제 렌더링과 클릭 흐름을 검증                                           |
+
+## 구현 및 검증 기록
+
+### MS1
+
+- 공식 CDN 계약 문서와 runtime no-fetch/opt-in 감사 정책을 기록했다.
+- `scripts/check-kakao-registry-source.cjs`와
+  `npm run audit:kakao-registry-source`를 추가했다. 기본 test/build/CI에는
+  연결하지 않았다.
+- 오프라인 계약 테스트는 실제 `poe.live`/`poe2.live` 중첩 fixture, 상위 게임
+  key 누락, `live` 누락, 후보 순서 drift를 고정한다.
+
+리뷰 기록:
+
+- Round 1 — `반려`: 최초 감사 스크립트가 공식 JSON의 상위 `poe`/`poe2`
+  객체를 건너뛰고 `document.live`를 읽는 구조 오류가 발견됐다.
+- 수정 — source별 `documentKey`를 계약에 포함하고 전체 필드 경로 기반 추출·오류
+  보고 및 중첩 fixture 테스트를 추가했다.
+- Round 2 — `통과`: 수정된 소스 계약과 MS1 DoD가 승인됐다.
+
+### MS2
+
+구현:
+
+- 카카오 POE1·POE2 레지스트리를 공식 순서의 정적 후보 배열로 확장했다.
+  후보마다 값을 읽고 정규화한 뒤 `PathOfExile_KG.exe`를 검증하며, 첫 유효
+  후보만 active로 선택한다. GGG는 기존 단일 후보와 `PathOfExile.exe` 검증을
+  유지한다.
+- 진단 결과에 후보별 path/state/verification/정확한 key/value name/active 여부와
+  aggregate `valid | absent | invalid | unknown`을 추가했다. 진단 getter는 설정이나
+  레지스트리를 변경하지 않는다.
+- 유효 후보가 없을 때 후보 read 실패 또는 실행 파일 검증 unknown이 하나라도
+  있으면 설치 상태를 `unknown`으로 유지한다.
+- 모든 성공한 수동 set/pick/conflict keep/sync/config clear/registry clear IPC
+  동작은 동일한 await 래퍼를 통해 해당 context 설치 상태를 명시적으로 다시
+  계산한다. 설정값이 동일하여 config-change 이벤트가 발생하지 않는 경우도
+  포함한다.
+- context별 generation guard를 추가해 먼저 시작한 비동기 설치 검사의 늦은
+  결과를 폐기한다. 기존 launch-blocking runtime 상태 보존 규칙은 유지한다.
+- conflict keep/sync와 registry clear는 typed target으로 후보 identity와 expected
+  현재 경로를 전달한다. Conflict target은 모달이 확인한 config path snapshot도
+  별도로 포함한다. Main은 service/game 정적 map으로 path/value name을 재해석하고
+  fresh config path·실행 파일 검증이 snapshot과 일치할 때만 conflict action을
+  진행한다. 표시용 `displayedCandidate` 자체는 mutation authority로 사용하지
+  않는다.
+- sync/delete는 레지스트리 read와 mutation 사이의 별도 App 프로세스 창을 없앴다.
+  한 PowerShell 실행 안에서 exact key/value를 읽고 현재 경로와 expected를
+  정규화 비교한 직후 `Set-ItemProperty` 또는 `Remove-ItemProperty`를 수행한다.
+  결과는 `mutated | changed | missing | read-failed | mutation-failed` marker로
+  구분하고 non-mutated 결과에는 최신 diagnostics를 다시 읽어 반환한다.
+- primary read-failed/verify-unknown과 무관하게 active legacy target 자체의 fresh
+  read가 expected와 일치하면 해당 legacy 후보 조작을 허용한다. 후보 전체의
+  clear/readable 조건은 후속 canonical register eligibility에서 적용한다.
+- 성공한 수동 action 뒤 reconciliation 예외는 warn으로 격리하여 성공 결과를
+  뒤집지 않는다. 실패 action은 reconciliation을 실행하지 않는다.
+
+검증:
+
+- [Windows Node] correction 관련 Vitest 5개 파일, 60개 테스트 통과.
+  - primary/fallback/둘 다 유효/primary missing·empty·invalid·read-failed·verify
+    unknown/aggregate unknown/config 우선/GGG 단일 후보 회귀
+  - POE1 primary missing 및 POE2 primary invalid/read-failed의 resolver 반환,
+    빈 config cache, installed status
+  - primary read-failed + legacy absent/invalid의 unknown 보존
+  - exact target allowlist/fresh match, mismatch·missing·read-failed mutation 0회,
+    primary read-failed 상태의 exact legacy sync
+  - conditional PowerShell 한 실행에 expected 비교와 set/delete가 함께 포함되는지,
+    changed marker overwrite/delete 0회, 잘못된 value name 거부
+  - config snapshot mismatch mutation 0회, clear missing/read-failed mutation 0회,
+    sync mutation-failed 최신 diagnostics 반환
+  - 동일 config 경로 재확인 후 stale 상태 회복, sync 후 회복, generation ordering,
+    launch-blocking 상태 보존, reconcile 예외 격리와 실패 action 0회
+  - MS1 오프라인 CDN 계약과 기존 모달 metadata 회귀
+- [Windows Node] `tsc --noEmit` 통과. shared ElectronAPI → preload → main → renderer
+  call-through의 typed target signature를 확인했다.
+- [Windows Node] Round 3 조건 보강 후 영향 대상 Vitest 1개 파일, 43개 테스트와
+  `tsc --noEmit`이 통과했다. PowerShell이 mutation marker를 출력했더라도 종료
+  코드가 0이 아니면 성공으로 인정하지 않으며, mutation 실패 뒤 재조회한 최신
+  diagnostics가 mutation 전 snapshot이 아닌 변경된 경로를 반환하는 것을 고정했다.
+- 전체 lint와 build는 MS4 통합 게이트까지 보류한다.
+
+리뷰 기록:
+
+- Round 1 — `반려`: 표시 후보를 암묵적 mutation 대상으로 재사용해 modal 확인
+  이후 후보 전환/값 변경을 막지 못했고, resolver/status/cache fallback evidence와
+  post-action reconcile 예외 격리가 부족했다.
+- correction — typed exact target, Main allowlist 재해석, fresh expected-value 비교,
+  최신 진단 실패 반환, resolver/status/cache 및 reconcile failure 회귀 테스트를
+  추가했다. exact-target 경계를 MS3 UI보다 선행하도록 마일스톤 순서를 고쳤다.
+- Round 2 — `반려`: sync/delete가 exact target을 fresh read한 뒤 별도 generic
+  PowerShell mutation을 실행하여 두 프로세스 사이 TOCTOU 창이 남았고, conflict
+  확인 시점의 launcher config path snapshot이 IPC 계약에 없었다.
+- correction — sync/delete를 한 PowerShell 실행의 conditional mutation marker
+  계약으로 교체하고 conflict target에 `expectedConfigPath`를 추가했다. Main은
+  fresh config path·verification 및 allowlisted registry identity를 검증한다.
+- Round 3 — `조건부 통과`: mutation marker와 비정상 종료 코드 조합의 보수적
+  실패 처리, mutation-failed 최신 diagnostics의 stale snapshot 구분 evidence를
+  경미 보강하는 조건으로 MS2 DoD가 승인됐다.
+- 조건 보강 — `__REG_CONDITIONAL_MUTATED__`는 PowerShell 종료 코드 0과 함께
+  반환될 때만 성공으로 분류하고, 비정상 종료 조합 테스트를 추가했다. mutation
+  실패 뒤 레지스트리 mock 경로를 변경해 반환 diagnostics가 fresh read임을
+  명시적으로 검증했다.
+- MS2 — 완료. MS3 경고 알림·진단 모달 UI 구현 전 안전 경계가 확정됐다.
+
+### MS3
+
+구현:
+
+- renderer가 config 로드·현재 서비스/게임 변경·설정 경로 변경 뒤 기존
+  `getGameInstallPathDiagnostics` invoke로 현재 context를 진단한다. 유효한 런처
+  설정 경로와 유효한 레지스트리 후보 부재가 함께 확인된 Kakao context에만
+  session-local amber warning 한 건을 만든다.
+- warning refresh에는 generation/cancel guard를 두어 이전 context의 늦은 응답이
+  최신 알림을 덮지 못하게 했다. 정상화·진단 실패 시 알림을 제거하며 append,
+  dismiss localStorage, 새 EventBus 또는 Main→Renderer push를 추가하지 않았다.
+- TitleBar/WindowControls는 기존 exception 알림을 그대로 유지하면서 typed
+  operational notification을 함께 표시한다. 헤더는 `알림`으로 일반화했고 경로
+  warning 클릭은 오류 제보 modal 대신 알림에 담긴 정확한 서비스/게임의
+  `openGamePathModal("diagnostic", ...)`을 호출한다.
+- 진단 모달은 `Kakaogames (기본)`과 `DaumGames (호환)` 후보 각각의 key/value
+  name/path 및 active/fallback/absent/read-failed 상태를 표시한다. 기존 요약의
+  레지스트리 키와 값 이름 분리 표시도 유지한다.
+- 유효한 config와 두 후보의 확정적 `key-missing | value-missing | value-empty`
+  상태가 동시에 확인된 경우만 등록 버튼을 활성화한다. read-failed/verify-unknown
+  또는 기존 nonempty 값이 있으면 비활성화하고 이유를 표시한다.
+- 등록 확인창은 canonical key, `InstallPath`, config path와 `DaumGames` 미변경을
+  명시한다. 전용 typed ElectronAPI/preload/Main IPC는 renderer가 registry target을
+  전달하지 않고 config snapshot만 전달하도록 했다.
+- Main은 Kakao static map의 canonical/legacy 후보를 다시 도출하고 fresh config
+  path 정규화·`PathOfExile_KG.exe` 검증 뒤, 한 PowerShell 실행에서 두 후보의
+  부재 확인 → canonical key/property `REG_SZ` 생성 → read-back 검증을 수행한다.
+  nonempty/read-failed/mutation-failed/readback-failed이면 성공으로 보고하지 않고
+  최신 diagnostics를 반환한다. legacy mirror, key rollback/delete, GGG 등록은
+  수행하지 않는다.
+- 등록을 포함한 성공한 경로 action은 기존 manual action wrapper reconciliation을
+  거친 뒤 현재 context warning을 다시 진단한다. 설치 시작 상태를 warning 로직이
+  변경하지 않는다.
+
+검증:
+
+- [Windows Node] targeted Vitest 7개 파일, 72개 테스트 통과.
+  - canonical-only atomic command, 두 후보 guard, config mismatch, nonempty,
+    read-failed, mutation/read-back failure, GGG 거부와 fresh diagnostics
+  - shared/preload/Main 전용 register channel 계약과 typed payload
+  - warning 조건·문구·dedupe·정상화 제거·async generation ordering
+  - WindowControls의 exact context click, exception notification 보존,
+    `SHOW_REPORT_MODAL` 미호출
+  - 모달 primary/fallback label·상태, key/value 분리, 등록 eligibility, 정확한
+    confirm 필드와 성공 후 fresh candidate 표시
+- [Windows Node] `tsc --noEmit` 통과.
+- 전체 lint, build와 hidden 실제 Electron 캡처는 MS4 통합 게이트로 남겼다.
+
+리뷰 기록:
+
+- Round 1 — `반려`: context 전환 commit과 passive effect 사이에 이전 warning이
+  잠시 노출될 수 있었고, register 비동기 응답이 닫히거나 다른 context로 바뀐
+  modal state를 덮을 수 있었다. busy 중 backdrop 닫기 차단, registered marker와
+  비정상 종료 코드 조합, nonempty invalid 후보의 직접 UI evidence도 부족했다.
+- correction — hook 반환값을 현재 owner context key로 동기 필터하여 새 진단이
+  unresolved인 전환 직후에도 이전 warning과 클릭 대상을 0건으로 만들었다.
+  register success/failure/catch updater는 캡처한 service/game identity와 현재 modal이
+  일치할 때만 diagnostics/error/busy/toast를 적용하며, 공용 modal backdrop은 busy
+  동안 닫히지 않는다.
+- correction evidence — [Windows Node] 영향 대상 Vitest 4개 파일, 63개 테스트
+  통과. 이전 warning 존재 후 context 전환 즉시 숨김, 닫힘/새 modal에 대한 late
+  success·failure 무효화, busy backdrop, nonempty invalid eligibility,
+  `__REG_REGISTERED__` + nonzero exit 실패를 고정했다. `tsc --noEmit`도 통과했다.
+- Round 2 — `통과`: correction이 Round 1 지적과 MS3 DoD를 충족했다.
+- MS3 — 완료. MS4 통합 검증과 실제 Electron 시각 QA를 진행한다.
+
+### MS4
+
+게이트 correction:
+
+- [Windows Node] 전체 Vitest 65개 파일, 376개 테스트가 통과했다.
+- 최초 lint는 CDN 계약 테스트의 import group, warning hook의
+  `react-hooks/set-state-in-effect`, modal 파일의 eligibility helper export에 대한
+  Fast Refresh 경고로 실패했다.
+- CDN 계약 테스트의 Node/Vitest import group을 분리했다. warning hook은 기존
+  owner-context 동기 반환 필터를 유지하고 effect가 외부 diagnostics Promise를
+  직접 구독하여 비동기 callback에서만 상태를 반영하도록 바꿨다.
+- 등록 eligibility type/helper는 React component 파일에서 renderer utility로
+  이동해 component 파일이 component만 export하도록 했다.
+
+검증:
+
+- [Windows Node v24.14] 최종 전체 Vitest 65개 파일, 376개 테스트 통과.
+- [Windows Node] 영향 대상 Vitest 3개 파일, 14개 테스트 통과.
+- [Windows Node] `eslint src` 전체 lint 통과. `npm.ps1` wrapper는 lint 실행 전에
+  미설정 `$LASTEXITCODE` 오류를 냈으므로 동일 Windows Node와 저장소 ESLint
+  entrypoint로 package script의 정확한 명령을 실행했다.
+- [Windows Node] `tsc`와 `vite build`가 통과해 `build:check`와 동등한 compile 및
+  renderer build를 확인했다. 기존과 같은 500 kB 초과 chunk 경고만 남았다.
+- [WSL] `git diff --check` 통과.
+
+Hidden 실제 Electron QA:
+
+- Windows Vite/Electron과 격리 profile `codex-kakao-registry-qa-5H1s4j`을 사용했다.
+  hidden 1440×960에서 POE1·POE2를 각각 확인하고 1024×683으로 resize한 POE2도
+  확인했다.
+- POE1·POE2 모두 `Kakaogames` primary가 `key-missing`, `DaumGames` fallback이
+  `found / valid / isActive`로 표시됐다. 두 후보의 키와 값 이름이 각각 분리된 두
+  행으로 표시됐고, modal body는 `clientHeight == scrollHeight == 534`로 clipping이
+  없었다.
+- capture의 fatal 상태는 `false`였고 Log/Runtime event 목록은 모두 비어 있었다.
+- 캡처:
+  - `.tmp/kakao-registry-ms4/poe1-diagnostic-1440x960.png`
+  - `.tmp/kakao-registry-ms4/poe2-diagnostic-1440x960.png`
+  - `.tmp/kakao-registry-ms4/poe2-diagnostic-1024x683.png`
+- 실제 PC에는 두 legacy 후보가 유효했으므로 warning과 register confirm 조건을
+  만들기 위해 사용자 HKCU를 변경하지 않았다. 이 두 실제 Electron 흐름은
+  `[사용자]` DoD로 남기며, 조건·클릭·confirm·backend 안전 경계는 단위/UI/backend
+  테스트로 검증했다.
+- 실행 소유 PID 56604 process tree를 종료했고 격리 QA profile은 제거했다. 캡처와
+  로그는 검토 evidence로 보존했다.
+
+MS4 상태:
+
+- 안전한 자동화 범위의 candidate 검증은 완료했다.
+- 실제 warning/register confirm 및 신규 `Kakaogames` 환경 검증은 `[사용자]` DoD
+  대기이며, MS4와 전체 작업의 최종 완료로 판정하지 않는다.
+
+분리 리뷰:
+
+- fresh complete-working-tree 리뷰에서 tracked 변경과 모든 untracked 파일을 함께
+  점검했다.
+- 판정 — `통과`: blocking finding 없음.
+- 리뷰는 자동화 evidence가 완료됐다는 사실과 실제 warning/register confirm 및
+  신규 `Kakaogames` 환경의 `[사용자]` DoD가 남았다는 경계를 유지했다. 따라서
+  자동화 candidate와 분리 리뷰는 완료됐지만 전체 작업 완료로 판정하지 않는다.
+- 리뷰어는 파일을 수정하거나 테스트를 실행하지 않았다.
+
+## MS5 — 설치 경로 상태 단일화와 여유 시점 재검사
+
+### 계획과 결정
+
+- 생명주기는 `bootstrap/post-init reconciliation`과 `runtime show/focus`로 한정한다.
+  Main의 `GameInstallStatusReconciler`가 context별 실행 가능 여부와 Kakao
+  레지스트리 advisory를 하나의 install-path-health snapshot으로 소유한다.
+- 기존 `GAME_STATUS_CHANGE` → `game-status-update` 계약의 optional health 필드만
+  확장한다. 새 EventType·IPC·preload 구독·서비스·AppConfig·주기 타이머는 만들지
+  않는다.
+- 앱 시작의 전체 context 강제 검사는 유지한다. show/focus는 마지막 성공한
+  install-path reconciliation 후 30분이 지난 현재 선택 context만 검사하며,
+  중복 show+focus는 context별 in-flight/generation으로 합친다. 수동 경로 동작
+  성공은 해당 context를 즉시 강제 검사하고 TTL 기준 시각도 갱신한다.
+- 런타임 상태가 install-check 상태보다 강하다는 기존 소유권을 유지한다. 일반
+  launch/update/error 상태 이벤트는 advisory를 보존하고, 완료된 install-path
+  reconciliation만 같은 context의 advisory를 교체하거나 제거한다.
+- Renderer의 별도 diagnostics invoke warning loop는 제거하고 활성
+  `GameStatusState`의 advisory만 표시한다. warning은 실행을 막지 않으며 active
+  context가 아니면 즉시 숨긴다.
+- 버튼은 `uninstalled → 설치하기`, 업데이트 필요 → `업데이트`,
+  `install_check_blocked → 경로 확인`, 그 외 → `게임 시작`으로 표시한다. blocked
+  클릭은 기존 경로 진단 모달 동작을 유지한다.
+- CDN 런타임 조회와 실제 레지스트리 변경 검증은 추가하지 않는다.
+
+### 관찰 가능한 DoD
+
+- [Windows-pwsh] startup은 전체 context를 강제 검사하고, show/focus는 30분 TTL
+  만료 후 현재 context만 검사한다. TTL 이내에는 생략하며 연속 show+focus는 한
+  검사로 합쳐진다. clock은 테스트에서 주입할 수 있다.
+- [Windows-pwsh] 늦은 과거 generation은 최신 status/advisory/TTL을 덮지 못하고,
+  성공한 수동 경로 동작은 즉시 강제 검사하여 TTL을 갱신한다.
+- [Windows-pwsh] Kakao에서 config 실행 파일이 유효하고 레지스트리가
+  `absent | invalid | unknown`이면 설치 상태는 `idle`인 채 해당 advisory가
+  전달된다. 신·구 후보 중 하나가 유효하면 advisory가 제거되고 GGG에는 생성되지
+  않는다. config가 무효인 경우 설치 판정도 사실대로 유지한다.
+- [Windows-pwsh] runtime `GAME_STATUS_CHANGE`는 같은 context의 advisory를
+  보존하며, install reconciliation 결과만 그 context advisory를 교체/제거한다.
+  다른 context snapshot은 전파되지 않는다.
+- [Windows-pwsh] Renderer는 활성 status advisory에서만 warning을 만들고 context
+  전환 직후 이전 warning을 표시하지 않는다. 클릭은 advisory의 정확한 context로
+  진단 모달을 열며 별도 diagnostics invoke loop가 없다.
+- [Windows-pwsh] `install_check_blocked` 버튼 문구는 `경로 확인`이고 클릭은 기존
+  진단 모달을 연다. `설치하기`·`업데이트`·`게임 시작` 매핑에는 회귀가 없다.
+- [Windows-pwsh] 관련 단위/UI 테스트, 전체 lint, typecheck와
+  `npm run build:check`가 통과한다.
+- [사용자] 장기간 미사용 후 런처를 다시 표시/포커스했을 때 현재 게임의 경로
+  상태와 warning/button 표시가 갱신되는지 확인한다.
+
+### Blast radius
+
+- 기존 게임 상태 payload/store에 optional advisory가 추가되고 show/focus에서
+  TTL 기반 현재 context 설치 경로 읽기가 발생한다.
+- AppConfig schema, migration, updater/release flow, Kakao 자동화 selector,
+  레지스트리 mutation 계약과 의존성은 변경하지 않는다.
+
+### 구현 및 검증 기록
+
+구현:
+
+- shared `GameStatusState`에 optional `installPathHealth`를 추가했다. snapshot은
+  설치 판정, 검사 시각, optional Kakao 레지스트리 advisory만 담으며 기존
+  `GAME_STATUS_CHANGE` → `game-status-update` 채널을 그대로 사용한다.
+- Main registry 모듈에 config 실행 파일과 registry 후보를 한 번의 흐름에서
+  검사하는 health getter를 추가했다. 유효한 config는 실행 가능 상태를 유지한
+  채 Kakao registry `absent | invalid | unknown`을 advisory로 반환한다. 신·구
+  후보 중 하나가 유효하거나 GGG이면 advisory를 만들지 않는다. config가
+  무효이면 기존 registry fallback/persist와 unknown/uninstalled 구분을 유지한다.
+- `GameStatusStore`는 runtime status 이벤트에서 기존 health를 보존하고,
+  `checkedAt`이 더 오래된 carried snapshot이 최신 reconciliation 결과를 되돌리지
+  못하게 했다. context key가 다른 snapshot은 공유하지 않는다.
+- reconciler에 30분 TTL, injectable clock, context별 passive in-flight map과 기존
+  generation guard를 결합했다. startup은 전체 context를 강제 검사하고 show/focus는
+  TTL이 지난 현재 context만 검사한다. 겹친 show+focus는 한 작업을 기다리며,
+  수동 경로 동작 성공은 기존 강제 reconciliation으로 TTL 기준도 갱신한다.
+- Renderer의 `useGamePathRegistryWarning`과 별도 diagnostics invoke loop를 제거했다.
+  활성 `GameStatusState` health에 advisory가 있을 때만 기존 amber operational
+  notification을 파생하며 exact context 클릭으로 진단 모달을 연다.
+- `install_check_blocked` 버튼 문구를 `경로 확인`으로 바꾸고, 기존처럼 missing
+  경로 진단 모달을 여는 click 분기를 pure helper로 고정했다.
+- 기존 `onGameStatusUpdate` preload 구독이 cleanup 함수를 반환하도록 보강했다.
+  새 IPC/EventType/preload channel/service/timer/AppConfig/dependency는 추가하지 않았다.
+
+검증:
+
+- [Windows Node v24.14] targeted Vitest 7개 파일, 100개 테스트 통과.
+  - startup 전체 force, current-only TTL 만료/미만, show+focus coalescing, manual
+    TTL refresh, stale generation
+  - config valid + registry absent/invalid/unknown advisory, primary/legacy valid clear,
+    GGG absent, config invalid unknown/uninstalled
+  - runtime health 보존, completed reconciliation 교체/clear, older snapshot 거부,
+    context 격리와 기존 status event renderer broadcast
+  - active-context warning/문구/dedupe/exact identity, no diagnostics warning hook,
+    blocked `경로 확인`과 diagnostic click 분기
+- [Windows Node] 전체 `eslint src` 통과.
+- [Windows Node] `tsc && vite build` (`build:check`과 동일 명령) 통과. 기존과 같은
+  500 kB 초과 chunk 경고만 남았다.
+- [WSL] `git diff --check` 통과.
+
+상태:
+
+- MS5 구현 candidate와 구현자 자동 게이트는 완료했다.
+- 분리 test/리뷰와 hidden Electron QA 및 `[사용자]` 장기 미사용 후 show/focus
+  실동작 확인은 아직 완료로 주장하지 않는다.
+
+## MS5-H — WSL→Windows 숨김 실행 하네스 교정
+
+### 교정 배경과 결정
+
+- 기존 WSL 실행 예시는 `pwsh.exe`/`powershell.exe` 또는 Windows console-subsystem
+  `node.exe`를 첫 interop 프로세스로 직접 실행했다. 이 경로는 agent 검증 중
+  console 창이 표시될 수 있어 hidden/non-focus-stealing 정책을 구조적으로
+  보장하지 못한다.
+- 공개 진입점은
+  `.agents/skills/windows-electron-debugging/scripts/run-hidden-windows.cjs`
+  하나로 고정한다. WSL Node가 collision-safe request를 만든 뒤 GUI-subsystem
+  `wscript.exe //B //NoLogo`만 첫 Windows interop으로 호출한다. WSH bootstrap은
+  Windows Node worker를 `windowstyle=0`으로 시작하고, worker만
+  `child_process.spawn({ shell: false, windowsHide: true })`로 실제 명령을 실행한다.
+- sync는 request/result/log 파일로 bounded wait하면서 stdout/stderr를 relay하고
+  child exit/signal/timeout을 호출자에게 전달한다. detached는 필수 stdout/stderr
+  경로, owner token, PID와 run metadata/control 파일로 격리한다. stop은 metadata와
+  owner token을 검증한 뒤 known root PID tree만 graceful→bounded force 순서로
+  정리한다.
+- 명령 argv는 배열 경계를 유지하고 cwd와 명시적 allowlist env만 전달한다. env
+  값과 token은 출력하지 않으며 새 dependency나 compiled binary를 추가하지 않는다.
+- agent는 WSL에서 Windows `pwsh.exe`/`cmd.exe`/`node.exe`를 직접 호출하지 않는다.
+  `.husky/pre-commit`의 내부 위임만 기존 명시적 예외로 유지한다.
+
+### 관찰 가능한 DoD
+
+- [WSL] parser/static tests가 sync/detached/stop 옵션, argv 경계, cwd 변환, env
+  allowlist, ownership validation과 collision-safe run isolation을 검증한다.
+- [Windows-runner] sync가 exact argv/cwd/env를 child에 전달하고 stdout/stderr를
+  각각 relay하며 exit code/signal을 보존한다.
+- [Windows-runner] timeout은 해당 run의 known root PID tree만 graceful 후 bounded
+  force 정리하고 actionable timeout result를 반환한다.
+- [Windows-runner] detached는 서로 다른 run ID/metadata/log를 만들고 stop은 owner
+  metadata가 일치하는 run만 종료한다. 잘못된 metadata/token은 process를 건드리지
+  않고 거부한다.
+- [Windows-runner] GUI bootstrap은 `//B //NoLogo`, WSH worker 시작은
+  `windowstyle=0`, worker child는 `shell:false/windowsHide:true`임이 정적으로
+  고정된다. native monitor가 held workload 전체를 100ms 이하 간격으로 20회 이상
+  관찰하며 owned visible top-level window, foreground, focus가 모두 0이다. owned
+  conhost는 PID/name과 visible handle 0을 정보성으로 기록하고 존재 자체로
+  실패시키지 않는다.
+- [WSL] 루트 `AGENTS.md`, Windows Electron skill과 `dev:wsl`이 단일 runner 사용법을
+  가리키며 direct Windows console interop 예시가 제거되어 있다.
+- [Windows-runner] runner targeted tests/probe 후 MS5 targeted tests, lint와
+  typecheck가 runner 경유로 통과한다.
+
+### MS5 분리 리뷰 correction
+
+- P1: runtime launch-blocking 상태나 이미 감지된 running process도 install-path
+  health 검사를 생략하지 않는다. 상태 소유권은 보존하면서 health/advisory와 TTL은
+  완료된 최신 검사로 갱신한다. startup과 수동 성공도 running/preparing 상태에서
+  warning을 refresh/clear할 수 있어야 한다.
+- P2: pending manual reconciliation 중 연속 show/focus는 passive health read를
+  추가하지 않는다. manual은 정확히 한 번 완료되고 guard counter가 해제되며 해당
+  결과의 TTL이 유지되는 직접 race test를 추가한다.
+- exact-target registry mutation, CDN runtime no-fetch, 기존 EventType/IPC/AppConfig
+  경계는 변경하지 않는다.
+
+### 구현 및 검증 기록
+
+하네스 구현:
+
+- reusable skill은 project cwd, URL, port, npm script, Kakao 경로를 하드코딩하지
+  않는다. project-specific cwd/env/renderer target/CDP script/dump path는 루트
+  `AGENTS.md`의 최소 recipe에만 남겼다. skill 본문은 100줄이며 Windows command,
+  tests/lint/typecheck/build, process lifecycle과 Electron/CDP/screenshot/cleanup의
+  단일 owner로 갱신했다.
+- 공개 CJS가 request/result/log를 만들고 `wscript.exe //B //NoLogo`로만 Windows에
+  진입한다. WSH bootstrap은 worker를 `windowstyle=0`으로 실행하며 worker는 exact
+  argv/cwd/allowlisted env, `shell:false`, `windowsHide:true`로 child를 소유한다.
+- sync stdout/stderr/exit/timeout, detached 필수 로그·metadata·readiness, collision-safe
+  run ID, owner token 검증 stop과 exact tree graceful→bounded force cleanup을
+  dependency 없이 구현했다. env 값과 owner token은 public output에 포함하지 않는다.
+- `scripts/qa/cdp-capture.cjs`로 project-specific CDP capture를 분리했고,
+  `dev:wsl`은 PowerShell/npm wrapper 대신 public runner의 Windows Node가 Vite를
+  직접 실행한다.
+
+MS5 review correction:
+
+- reconciler는 cached `running/preparing/processing/authenticating/ready` 또는 실제
+  process가 감지되어도 health 조회를 끝까지 수행한다. 완료 시 runtime/process
+  status는 그대로 보존하고 최신 health/advisory를 같은 event에 실으며 TTL을
+  갱신한다. 이로써 startup force와 running 중 수동 성공도 advisory를 refresh/clear
+  할 수 있다.
+- manual guard count를 action 완료 뒤가 아니라 action 호출 전부터 잡는다. pending
+  action 중 연속 show/focus는 passive read를 시작하지 않고, 성공한 manual만 한 번
+  force reconcile한다. `finally`에서 count를 해제하고 성공 health 시각을 TTL
+  baseline으로 사용한다.
+
+검증:
+
+- [WSL] runner parser/static tests 8/8 통과: argv/cwd/env/path 변환, detached 필수
+  로그, collision-safe ID, stop ownership, genericity, WSH/worker hidden flags와 native
+  Toolhelp/user32 monitor 계약을 검사했다.
+- [WSL] skill-creator `quick_validate.py` 통과, `git diff --check` 통과.
+- [Windows-runner] native visibility run
+  `20260812160920689-397023-dc5e05a37352f3dc` 통과: worker PID 125292,
+  2553ms 동안 41 samples, first 0ms/last 2490ms, max gap 64ms, visible owned
+  top-level 0, owned foreground 0, owned focus 0. 첫 sample 뒤 생성된 sentinel PID
+  35684가 2303ms 전 sample까지 소유 계보에 관찰됐다. conhost 4개는 모두 visible
+  handle 없이 정보성으로 기록됐다.
+- 첫 visibility 시도 `20260812160457479-396726-ed48bbc33416244f`는 visible/foreground/
+  focus가 0이었지만 WMI 병목으로 3577ms 동안 3 samples뿐이어서 빈도 DoD 실패로
+  판정했다. 이후 C# Toolhelp32Snapshot/EnumWindows/GetGUIThreadInfo monitor로
+  교체하고 승인된 재검증 1회에서 위 native 기준을 통과했다.
+- [Windows-runner] worker integration 4/4 통과: exact argv/cwd/env/stdout/stderr/exit,
+  timeout parent+grandchild cleanup, file readiness + metadata + wrong ownership rejection
+  - stop, concurrent detached isolation을 검사했다. 최초 readiness test는 test와
+    worker deadline이 같은 5초라 경계에서 실패했고, 잔존 exact runner/fixture
+    process 0을 public runner로 확인한 뒤 bounded wait와 failure `finally` exact worker
+    cleanup을 보강해 재검증했다.
+- [Windows-runner] MS5 관련 Vitest 10개 파일, 114개 테스트 통과. running/preparing
+  health+TTL, process-detected startup, running manual advisory clear, pending manual 대
+  연속 show/focus race와 기존 registry/store/renderer/modal/button 계약을 포함한다.
+- [Windows-runner] `eslint src`, `tsc --noEmit` 통과.
+- [Windows-runner] `vite build` 통과. `npm run build:check`의 PowerShell wrapper
+  시도는 설치된 `npm.ps1`이 strict-mode 미설정 `$LASTEXITCODE` 오류를 내면서도
+  exit 0을 반환해 유효 evidence에서 제외했다. 동일 runner에서 build:check의 두
+  구성 요소인 TypeScript와 Vite를 각각 Windows Node entrypoint로 실행했고, 기존
+  500kB chunk warning 외 실패는 없었다.
+
+현재 상태:
+
+- 하네스와 MS5 P1/P2 correction은 구현자 candidate 및 자동 게이트까지 완료했다.
+- 이 기록은 fresh 분리 리뷰, full suite, hidden Electron QA 또는 `[사용자]` 장기
+  미사용 show/focus 실동작 통과를 주장하지 않는다.
+
+### Round 2 fresh test·forward-review — `반려`
+
+반려 사유:
+
+- detached public output의 filesystem path가 Windows 형식이라 WSL 사용자가 출력된
+  `metadataPath`를 그대로 `stop --metadata`에 붙여 넣으면 WSL `path.resolve`에서
+  잘못 해석된다.
+- cleanup 결과가 `stopped:false`여도 timeout/stop/readiness failure가 성공적인
+  정리처럼 보고될 수 있고 public stop이 child 종료와 cleanup true를 독립적으로
+  검증하지 않는다.
+- sensitive env 값이 CLI `--env NAME=VALUE`, request JSON과 Windows child env
+  snapshot에 남고, argv도 metadata/public output에 그대로 보존된다.
+- detached 자연 종료와 log close/result write 사이에 completion flag가 먼저
+  보이는 race가 있으며 readiness test의 단계별 진단과 실패 시 orphan assertion이
+  부족하다.
+- 첫 WSL→`wscript.exe` spawn에 `windowsHide:true`가 명시되지 않았고 project
+  `dev:wsl` detached recipe에 실제 renderer/CDP readiness gate가 없다.
+
+Round 2 correction 결정과 관찰 가능한 DoD:
+
+- [WSL] public detached output은 cwd/stdout/stderr/metadata를 WSL copy-paste-safe
+  path로 반환하고, stop은 WSL path와 absolute Windows path를 모두 정확히
+  해석한다. 출력의 `metadataPath`를 그대로 stop에 전달하는 public E2E가 통과한다.
+- [WSL/Windows-runner] secret은 이름 기반 `--pass-env NAME`으로만 전달하며 값은
+  CLI argument/request/result/metadata/public output에 기록하지 않는다. safe literal
+  env는 명시적으로 구분하고 secret 사용을 금지한다. persisted/public argv는
+  redacted command summary만 보존하고 secret marker absence test를 둔다.
+- [Windows-runner] cleanup `stopped:false`는 sync/detached 어느 경로에서도
+  `stopped`, exit 0 또는 단순 124로 축약되지 않고 `cleanup-failed`와 actionable
+  nonzero로 귀결된다. result/metadata는 cleanup detail을 보존하며 public stop은
+  cleanup true와 child dead를 모두 확인해야 성공한다.
+- [Windows-runner] detached finalization은 log close와 result/metadata atomic write를
+  완료한 Promise를 monitor loop가 await한다. large/slow log natural-exit test에서
+  결과·로그가 완전하며 orphan이 없다.
+- [Windows-runner] readiness test는 metadata creation, ready artifact, running status를
+  별도 deadline과 diagnostics로 검사한다. 모든 실패 finally가 exact worker tree를
+  정리하고 child/worker dead를 assert한다. fixed port를 사용하지 않는다.
+- [WSL] public bootstrap spawn도 `shell:false/windowsHide:true`가 정적으로 고정된다.
+  generic skill은 copy-paste detached→returned metadata→stop, secret/env 계약과 cleanup
+  failure semantics를 설명한다.
+- [Windows-runner] project `dev:wsl`은 project-owned renderer readiness URL을
+  제공하여 즉시 Vite/Electron 실패를 detached 성공으로 반환하지 않는다.
+- 검증은 WSL syntax/static/quick_validate 뒤 public runner의 worker/integration 및
+  public detached→stop E2E만 수행한다. project tests/build/Electron은 Round 2 fresh
+  harness review 전 실행하지 않는다.
+
+Round 2/3 correction 구현 및 제한된 검증:
+
+- public detached output의 cwd/stdout/stderr/metadata를 WSL path로 변환하고 stop은
+  반환된 WSL path와 absolute Windows path를 모두 해석한다. metadata에는 full argv
+  대신 command basename과 SHA-256 fingerprint만 남긴다.
+- `--env`를 폐기하고 non-secret `--literal-env`와 sensitive named
+  `--pass-env NAME`을 분리했다. public runner는 request에 pass-env 이름만 0600으로
+  기록하고 WSLENV/inherited env로 값을 전달한다. worker는 값을 consume한 직후
+  request를 삭제하고 child env를 구성한다. bootstrap/public failure도 request
+  best-effort unlink를 수행한다. pass-env 값이 child argv에 있으면 실행 전 거부한다.
+- sync timeout, detached readiness/timeout/stop에서 cleanup true와 child dead를 함께
+  검증한다. 실패하면 result/metadata에 cleanup detail과
+  `childAliveAfterCleanup`을 남기고 `cleanup-failed`/public exit 125로 fail-closed한다.
+  public stop도 두 조건을 다시 확인해야 exit 0을 반환한다.
+- detached finalization을 단일 Promise로 직렬화해 log close와 metadata/result atomic
+  write가 끝나기 전 monitor loop가 결과를 읽지 않는다. Windows atomic update는
+  기존 target을 exact-path remove 후 temp file rename으로 처리한다.
+- worker tests는 metadata creation/readiness/running을 별도 deadline으로 진단하고,
+  모든 failure `finally`가 worker뿐 아니라 known child PID도 exact cleanup 후 dead를
+  assert한다. large stdout/stderr natural-exit, cleanup failure 3경로, concurrent run
+  격리와 secret marker 부재를 포함한다.
+- 첫 WSL→wscript spawn에 `shell:false`, `stdio:'ignore'`, `windowsHide:true`를
+  명시했다. `dev:wsl`은 hidden start, runId별 isolated profile, CDP port와
+  `http://localhost:9222/json/version` readiness timeout을 project recipe로 지정한다.
+
+검증 evidence:
+
+- [WSL] final parser/static tests 11/11 통과, Node syntax checks 통과,
+  skill `quick_validate.py` 통과, scoped Prettier check와 `git diff --check` 통과.
+- [Windows-runner] worker integration outer run
+  `20260812164437894-403033-bc01581a52165eee`가 child PID 17576, exit 0으로 종료했고
+  8/8 통과했다: sync exact contract, timeout exact tree, injected cleanup failure,
+  named secret consume/request deletion/redaction, wrong owner rejection, detached
+  readiness/timeout/stop cleanup fail-closed, 512KiB stdout+stderr flush, concurrent
+  isolation을 검증했다.
+- [Windows-runner] public E2E inner run
+  `20260812164613430-403437-62b61b49f10a2f71`은 worker PID 132120/child PID 22280으로
+  시작했다. detached output의 WSL metadata path를 그대로 stop에 전달해
+  `status=stopped`, `cleanup.stopped=true`, `childAliveAfterCleanup=false`를 받았고,
+  별도 public PID probe가 child dead를 확인했다. request는 consume되어 없고 secret
+  marker는 metadata/result/stdout/stderr/public output 어디에도 남지 않았다. evidence는
+  `.tmp/windows-runner-public-evidence/public-e2e-Rg5uKc/`에 보존했다.
+- 최초 corrected worker 실행 `20260812164201031-402616-9f785c51ba159bc4`는 WSH
+  JScript가 trailing call comma를 거부해 worker child 생성 전에 종료됐다. error
+  호출을 구형 JScript 호환 형태로 교정하고 static guard를 추가했다. 다음 run
+  `20260812164303828-402831-dfceca9eb0d55cea`은 6/8이었으며 실패 `finally` exact
+  cleanup 후, Windows metadata replace와 cleanup finalization race를 교정해 위 final
+  8/8을 얻었다.
+
+Round 2/3 상태:
+
+- harness correction candidate와 제한된 runner-only evidence까지 완료했다.
+- project MS5 tests/full suite/build/Electron은 이번 correction 뒤 실행하지 않았고,
+  fresh 분리 test/review 통과를 주장하지 않는다.
+
+### Round 3 fresh review — `반려`
+
+반려 사유:
+
+- detached가 readiness 단계에서 `cleanup-failed`로 끝나면 public entrypoint가
+  structured result를 전달하지 않고 일반 예외/exit 1로 축약할 수 있다.
+- worker가 직접 소유한 target root가 자연 종료하면 이미 분리된 descendant를
+  이후 exact tree cleanup으로 회수할 수 없다. 초기 metadata write 실패도 spawn된
+  child를 정리하지 않는 경로가 있다.
+- named pass-env 값은 argv/artifact에서는 숨겨지지만 target stdout/stderr가 그 값을
+  출력하면 log 및 sync relay에 그대로 남는다. chunk 경계에서 분할 출력된 값도
+  누출되지 않는 stream-level redaction이 필요하다.
+
+Round 3 correction 결정과 관찰 가능한 DoD:
+
+- [WSL/Windows-runner] detached startup/readiness 중 cleanup 검증 실패는 public
+  output에 `status=cleanup-failed`, cleanup detail,
+  `childAliveAfterCleanup`을 구조화해 남기고 정확히 exit 125로 끝난다. public E2E가
+  injected cleanup false 경로를 직접 검증한다.
+- [Windows-runner] generic PowerShell/C# supervisor가 target을
+  `CREATE_SUSPENDED`로 생성하고 `KILL_ON_JOB_CLOSE` Job에 assign한 뒤에만 resume한다.
+  worker는 supervisor PID를 exact root로 소유한다. target root 자연 종료, stop,
+  timeout 또는 supervisor 종료 시 Job close가 모든 descendant를 회수한다. 이
+  race-free 할당을 no-dependency 도구로 구현할 수 없으면 optimistic fallback 없이
+  설계 장벽으로 중단한다.
+- [Windows-runner] sync·detached fixture에서 target root가 held grandchild를 만든 뒤
+  자연 종료해도 grandchild가 남지 않는다. 초기 metadata write failure도 spawned
+  supervisor/target tree를 exact cleanup하고 child dead를 검증한다.
+- [WSL/Windows-runner] worker는 named pass-env의 exact UTF-8 byte 값을 stdout/stderr
+  양쪽에서 cross-chunk-safe하게 `<redacted>`로 교체한 뒤에만 log와 public sync
+  relay에 노출한다. split-chunk fixture는 raw marker가 request/metadata/result/log/
+  public output 어디에도 없고 replacement가 있음을 검증한다. 변형·인코딩된 값은
+  검출할 수 없으므로 child가 secret을 출력하지 않는 원칙을 유지한다.
+- 검증은 WSL syntax/static/skill quick validation 뒤 public runner를 통한 runner
+  unit/integration만 수행한다. MS5 product source/test, full suite/build/Electron은
+  변경하거나 실행하지 않는다.
+
+Round 3 correction 구현:
+
+- generic PowerShell/C# supervisor는 target을 `CREATE_SUSPENDED |
+CREATE_NO_WINDOW`로 생성하고 kill-on-close Job에 assign한 뒤에만 resume한다.
+  supervisor는 worker owner handle과 target handle을 함께 기다리며 worker가 먼저
+  사라져도 Job을 닫는다. worker가 소유·정리하는 root PID는 supervisor이고 실제
+  target PID도 metadata/result에 별도로 남긴다.
+- supervisor stdin/stdout/stderr는 shell interpolation 없이 inherited pipe로 연결한다.
+  worker가 named pass-env의 exact UTF-8 byte 값을 stdout/stderr 독립 transform에서
+  chunk 경계까지 보존해 `<redacted>`로 교체한 뒤 log를 쓴다. sync public relay는
+  이미 redacted된 log만 읽는다. 변형·인코딩·opaque binary 표현은 보장하지 않는다.
+- initial detached metadata write가 실패하면 이미 spawn된 supervisor tree를 exact
+  cleanup하고 output close와 child-death 검증 뒤 structured result를 남긴다. 자연
+  target exit와 explicit stop 모두 Job close 뒤 descendant pipe EOF까지 기다린다.
+- detached startup/stop의 cleanup false는 public entry가 structured result를 stdout에
+  내고 exit 125를 반환한다. integration 전용 named injection은 실제 exact cleanup을
+  먼저 수행하되 검증 결과만 false로 바꿔 orphan 없이 public contract를 시험하도록
+  격리했다.
+- fixture/test는 split secret stdout/stderr, root-exit held grandchild, metadata write
+  failure, public cleanup-failed 125를 추가했다. 자연 종료 회귀는 15초 test-local
+  timeout과 failure `finally` exact grandchild cleanup을 둬 outer runner timeout보다
+  먼저 진단한다.
+
+Round 3 제한 검증 evidence:
+
+- [WSL] parser/static 12/12, 관련 JS/CJS syntax, skill `quick_validate.py`, scoped
+  Prettier와 `git diff --check`가 통과했다. static은 exact UTF-8 cross-chunk redaction,
+  `CREATE_SUSPENDED → AssignProcessToJobObject → ResumeThread`, hidden flags와 genericity를
+  포함한다.
+- 첫 Windows integration run
+  `20260812172113655-419373-59c5a319645dd809`은 supervisor PID 86172/target PID
+  124748에서 synchronous pipe handle을 async `FileStream`으로 연 오류로 exit 1했다.
+  Job-assigned target은 supervisor `finally`에서 종료됐다. pipe copy를 synchronous
+  handle용 task로 교정했다.
+- 다음 run `20260812172209618-419747-e3e752bd2cb7f6fe`은 supervisor PID
+  131204/target PID 104304였다. fixture `orphan-exit`가 grandchild handle을
+  `unref()`하지 않아 자연 종료하지 못했고 outer 240초 timeout에 도달했다. public
+  runner가 graceful code 128 뒤 force code 0으로 exact tree를 정리했고
+  `cleanup.stopped=true`, `childAliveAfterCleanup=false`를 기록했다. fixture를
+  independent held grandchild로 교정하고 local timeout을 추가했다.
+- 승인된 단일 integration 재시도
+  `20260812172843890-423408-f7a4fc346763364d`는 supervisor PID 102056/target PID
+  116796, exit 0, 13/13 통과했다. sync split-secret redaction, sync/detached 자연 root
+  exit descendant 회수, detached stop descendant 회수, timeout/cleanup-false,
+  metadata-write failure, large-log finalization과 concurrent isolation을 포함한다.
+- public cleanup-failed exit-125 및 public split-secret E2E test 코드는 추가했지만,
+  owner가 허용한 단일 integration 재시도를 소진해 Round 3에서는 실행하지 않았다.
+  따라서 public E2E 동작 통과를 주장하지 않으며 fresh review 전 잔여 gate로 남긴다.
+- 이번 Round 3에서는 MS5 product source/test, full suite/build/Electron을 변경하거나
+  실행하지 않았다. commit/stage도 수행하지 않았다.
+
+### Round 4 fresh review — `반려`
+
+반려 사유:
+
+- public cleanup-failed E2E가 detached startup/readiness 실패가 아니라 정상 기동 뒤
+  `stop`에서만 exit 125를 확인해 `waitForDetachedMetadata()` 자체의 structured
+  failure 계약을 검증하지 않는다.
+- detached target이 held grandchild를 만든 뒤 자연 종료할 때 supervisor Job close가
+  descendant를 회수하더라도 final metadata/result에 cleanup 검증이 없다. public
+  `stop`은 `status=exited` metadata만 보고 exit 0을 반환해 cleanup 증거 없이 성공을
+  주장할 수 있다.
+
+Round 4 correction 결정과 관찰 가능한 DoD:
+
+- [Windows-runner] safe named test injection을 readiness timeout에 적용한다. 실제 exact
+  cleanup은 수행하되 검증 결과만 false로 만들어 `waitForDetachedMetadata()`가
+  structured `cleanup-failed` result와 cleanup/child-alive detail을 출력하고 정확히
+  exit 125를 반환하는 public E2E를 둔다.
+- [Windows-runner] detached natural target exit는 supervisor close 시점에 Job close가
+  완료됐고 supervisor/target PID가 모두 dead인지 result/metadata에 기록한다. 하나라도
+  확인할 수 없으면 `cleanup-failed`로 fail-closed한다.
+- [Windows-runner] public `stop`의 `status=exited` 경로는 matching finalized result의
+  `status=exited`, `cleanup.stopped=true`, supervisor dead, target dead를 모두 확인할
+  때만 exit 0을 반환한다. 자연 종료 fixture의 held grandchild PID도 public probe로
+  dead임을 확인한다.
+- 검증은 WSL syntax/static/skill validation 뒤 public runner의 public E2E test만
+  실행한다. product gates/full build/Electron은 실행하지 않는다.
+
+Round 4 correction 및 검증 evidence:
+
+- detached supervisor 자연 종료 시 worker는 Job close 뒤 supervisor/target PID가 모두
+  dead인지 확인해 `cleanup.mechanism=job-close`, `cleanup.stopped`,
+  `childAliveAfterCleanup`, `targetAliveAfterCleanup`을 result/metadata에 남긴다. 어느
+  PID라도 살아 있으면 `cleanup-failed`로 fail-closed한다.
+- public `stop`의 `status=exited` 경로는 bounded하게 finalized result를 기다린 뒤
+  matching run ID, exited status, cleanup true, supervisor/target dead를 모두 확인할
+  때만 exit 0을 반환한다. stopped 경로도 target-dead 조건을 함께 요구한다.
+- readiness public E2E는 존재하지 않는 ready file과 safe named injection을 사용한다.
+  실제 exact cleanup은 먼저 성공시키고 verification flag만 false로 바꿔
+  `waitForDetachedMetadata()`가 cleanup detail을 포함한 JSON과 exit 125를 반환하게
+  하며 orphan을 만들지 않는다.
+- [WSL] 관련 JS/CJS syntax, parser/static 12/12, skill `quick_validate.py`, Prettier와
+  `git diff --check`가 통과했다.
+- public test 파일을 outer Windows target으로 한 번 더 감싼 잘못된 호출 run
+  `20260812174333711-430998-c6d1838044787007`은 supervisor PID 122156/target PID
+  116368에서 내부 public entry가 WSL mount Windows Node를 찾지 못해 4개 테스트가
+  child 기동 전에 exit 1했다. outer Job close result는 cleanup true,
+  supervisor/target dead를 기록했다. 테스트 드라이버는 WSL pure Node로, 각 Windows
+  동작은 public runner로만 진입해야 한다는 호출 경계를 바로잡았다.
+- 교정된 public E2E는 4/4, exit 0으로 통과했다. copy-paste detached stop run
+  `20260812174406857-431309-9fa22c06053788e0`은 worker PID 124140/supervisor PID
+  108760, cleanup true/child dead였다. split-secret public relay/log도 통과했다.
+- readiness cleanup-failure run
+  `20260812174416643-431383-41864e39bd01e97f`은 worker PID 68936/supervisor PID
+  54956/target PID 128372에서 startup 성공 전에 structured
+  `status=cleanup-failed`, cleanup detail, supervisor/target dead를 출력하고 정확히
+  exit 125를 반환했다.
+- natural-exit run `20260812174428317-431488-07b5716bd6ddf4a0`은 worker PID
+  109768/supervisor PID 101944/target PID 124108/held grandchild PID 43972였다.
+  finalized metadata/result는 `status=exited`, `cleanup.stopped=true`, supervisor/
+  target dead를 기록했고 public `stop`은 이를 검증해 exit 0을 반환했다. 별도 public
+  PID probe가 worker/supervisor/target/grandchild 네 PID 모두 dead임을 확인했다.
+- 이번 Round 4에서도 product gates/full build/Electron은 실행하지 않았고 product
+  source를 변경하지 않았다. commit/stage도 수행하지 않았다.
+
+### Round 5 fresh review — `반려`
+
+반려 사유:
+
+- cleanup false에서 supervisor가 죽었지만 target/descendant pipe가 살아 있으면
+  redactor `outputDone`을 무기한 기다려 structured exit 125 자체가 나오지 않을 수
+  있다. sync cleanup failure도 JSON detail 대신 stderr 요약만 낸다.
+- `dev:wsl`이 고정 CDP port의 `/json/version`만 readiness로 사용해 기존 프로세스의
+  응답을 새 Electron 기동 성공으로 오인할 수 있다. readiness는 새 Job descendant와
+  그 run이 소유한 unique port의 정확한 renderer target을 함께 증명해야 한다.
+- detached finalization이 terminal metadata를 result보다 먼저 쓰고 atomic replace가
+  기존 metadata 삭제 gap을 만든다. public stop은 transient missing/partial JSON 및
+  metadata/result identity mismatch를 충분히 fail-closed하지 않는다.
+- fast-exit supervisor가 start handshake 전에 close되면 terminal handler가 target PID
+  미확정 상태를 성공 종료로 finalize할 수 있다. stopped/exited 성공 결과도 metadata의
+  supervisor/target identity와 일치하는지 검증하지 않는다.
+
+Round 5 correction 결정과 관찰 가능한 DoD:
+
+- [Windows-runner] cleanup false이며 supervisor 또는 target이 살아 있으면 bounded
+  output drain 뒤 stdout/stderr/redactor를 force-close하고 sanitized structured
+  `cleanup-failed`를 result에 남긴다. sync public output도 동일 JSON과 exit 125를
+  반환하며 어떤 stream도 무기한 기다리지 않는다.
+- [Windows-runner] supervisor start handshake가 target PID를 확정하기 전 close/error는
+  terminal finalize를 하지 않는다. handshake 실패는 exact supervisor cleanup 뒤
+  fail-closed한다. delay 없는 immediate-exit fixture가 정상 exited cleanup result를
+  만든다.
+- [WSL/Windows-runner] detached는 finalized result를 먼저 atomic replace하고 terminal
+  metadata를 마지막에 쓴다. public stop은 transient missing/JSON parse를 bounded retry하고
+  matching result를 기다린다. stopped/exited success는 run ID, supervisor PID, target PID
+  identity 일치, cleanup true, 양 PID dead를 모두 요구한다.
+- [Windows-runner] project `scripts/qa/hidden-electron-launch.cjs`가 unique available
+  Windows port를 선택·검증하고 Vite를 자신의 Job descendant로 spawn한다. hidden flag,
+  run별 isolated profile, selected port를 전달한 뒤 own child alive와 해당 port
+  `/json/list`의 exact renderer target을 모두 확인해야 per-run ready file을 쓴다.
+  기존 포트 false-positive와 child early-exit 테스트를 둔다. generic runner는 ready-file만
+  사용하고 project URL/port/recipe는 `scripts/qa`, package와 AGENTS에만 둔다.
+- 검증은 WSL syntax/static/skill validation 뒤 public runner를 통한 worker/public/project
+  QA launcher targeted tests만 수행한다. product full gates/build/Electron은 fresh review 전
+  실행하지 않는다.
+
+Round 5 correction 구현:
+
+- cleanup 종료 뒤 output drain은 500ms로 제한했다. supervisor 또는 target liveness가
+  남거나 pipe가 닫히지 않으면 child stdout/stderr를 unpipe/destroy하고 redactor와 log를
+  bounded 종료해 `outputDone`을 무기한 기다리지 않는다. sync public entry는 sanitized
+  structured `cleanup-failed` JSON을 출력하고 정확히 exit 125를 반환한다.
+- supervisor의 close/error는 target start handshake 전에는 terminal 후보만 기록한다.
+  target PID가 확인된 뒤에만 자연 종료를 finalize하고, handshake 실패는 supervisor
+  exact cleanup 뒤 fail-closed한다. delay 없는 `immediate-exit` fixture를 추가했다.
+- detached finalization은 result를 먼저 쓰고 terminal metadata를 마지막에 쓴다. atomic
+  replace는 우선 delete 없는 rename을 사용하고 Windows replace 제한 때만 compatibility
+  fallback을 사용한다. public entry는 transient missing/partial JSON을 bounded retry하며,
+  result/metadata의 run ID, worker PID, supervisor PID, target PID와 cleanup/dead 상태가
+  모두 일치해야 stopped/exited 성공을 반환한다.
+- project 전용 `scripts/qa/hidden-electron-launch.cjs`는 매 run에 사용 가능한 loopback
+  port를 예약·선택하고 Vite/Electron child에 hidden flag, 격리 profile, 선택 port를
+  전달한다. own child alive와 그 port의 `/json/list` exact renderer target을 함께 확인한
+  뒤에만 per-run ready file을 쓴다. generic runner/skill에는 project URL, port, npm script를
+  넣지 않았다. `dev:wsl`은 이 launcher와 ready-file contract를 사용한다.
+- fixture/test는 target-alive pipe hang, immediate exit, result-before-metadata, transient
+  metadata gap/partial JSON, stopped/exited identity mismatch, sync structured 125, 기존 port
+  false-positive와 child early exit를 추가했다.
+
+Round 5 제한 검증 evidence:
+
+- [WSL] 관련 JS/CJS syntax, runner static 13/13, skill `quick_validate.py`, scoped Prettier와
+  `git diff --check`가 통과했다.
+- target-alive pipe hang test를 처음 추가한 Windows worker run
+  `20260812180528107-440830-0a5af5079e367292`은 supervisor PID 121172/target PID
+  112500/worker PID 30964에서 abandoned stream promise의
+  `ERR_STREAM_PREMATURE_CLOSE` rejection으로 14/15, exit 1이었다. 해당 promise에 explicit
+  rejection sink를 두고 exact Job cleanup true, supervisor/target dead를 유지했다.
+- 교정한 Windows worker integration run
+  `20260812180647032-441559-b6fb4abe03729f17`은 worker PID 6276/supervisor PID
+  120504/target PID 130736, 15/15, exit 0이었다. final result는
+  `cleanup.mechanism=job-close`, `cleanup.stopped=true`, supervisor/target dead를 기록했다.
+- public E2E 첫 시도는 sync child relay 뒤 structured JSON을 단일 stdout JSON으로
+  parse해 5/6이었다. trailing structured JSON parser로 실제 public contract에 맞춘 뒤
+  6/6, exit 0으로 통과했다. copy-stop run
+  `20260812180806292-442263-7aa7d2efe24ae7e8`은 worker PID 129116/supervisor PID
+  132464/target PID 38540, cleanup true였다. startup readiness cleanup-failed run
+  `20260812180822325-442463-06d99658e60ab113`은 worker PID 85424/supervisor PID
+  125256/target PID 123588, structured exit 125를 확인했다. sync cleanup-failed run
+  `20260812180815972-442420-fff43538046131d9`도 structured exit 125를 확인했다.
+- natural-exit identity/probe run
+  `20260812180831285-442529-45645541cd0d656f`은 worker PID 103676/supervisor PID
+  129432/target PID 78692/held grandchild PID 88380이었다. cleanup true와 identity 일치를
+  확인했고 별도 public probes가 네 PID 모두 dead임을 확인했다. stopped/exited identity
+  mismatch는 exit 125 후 원본 result를 복구했으며 transient metadata missing/partial JSON
+  stop도 bounded retry로 통과했다.
+- project QA launcher targeted run
+  `20260812180853050-442734-dd30bd06739d76a0`은 worker PID 126148/supervisor PID
+  119744/target PID 127236, 4/4, exit 0, cleanup true였다. package recipe, pre-existing port
+  false-positive 거부, child early-exit 거부, unique port exact-target readiness를 검증했다.
+  실제 Electron은 기동하지 않았고 Node HTTP fixture만 사용했다.
+- 모든 Windows 동작은 public runner로만 진입했고 direct Windows interop은 0회였다. 위
+  결과와 public PID probes 기준 owned live PID는 0이다. 이번 Round 5에서는 MS5 product
+  source/test, full suite/build/Electron을 변경하거나 실행하지 않았고 commit/stage도 하지
+  않았다. fresh separated review 전 candidate evidence로만 기록한다.
+
+### Round 6 fresh review — `반려`
+
+반려 사유:
+
+- public `stop`의 running 분기에서 stopped result가 먼저 보이면 terminal metadata와 같은
+  finalization인지 증명하기 전에 성공 또는 기존 running metadata 기반 판정을 할 수 있다.
+  result-first는 기록 순서일 뿐 성공 증거가 아니며, terminal metadata 누락·쓰기 실패는
+  bounded nonzero로 끝나야 한다.
+- supervisor start handshake 실패의 cleanup detail이 문자열 error로 축약된다. cleanup
+  검증도 실패하면 sync/detached public contract가 structured `cleanup-failed`와 정확한
+  exit 125를 반환해야 한다.
+- project hidden Electron launcher가 port reservation을 child spawn 전에 닫고 own child
+  alive와 renderer URL을 독립 확인해, reservation 직후 다른 responder가 같은 base target을
+  제공하면 그 endpoint를 own renderer로 오인할 수 있다.
+
+Round 6 correction 결정과 관찰 가능한 DoD:
+
+- [WSL/Windows-runner] worker가 detached finalization마다 collision-safe
+  `finalizationId`를 생성해 result와 마지막 terminal metadata에 함께 기록한다. public
+  stopped/exited 성공은 finalizationId, run ID, worker/supervisor/target identity,
+  cleanup true와 dead 상태가 모두 일치할 때만 가능하다.
+- [Windows-runner] running metadata에서 finalized result를 먼저 관찰해도 matching terminal
+  metadata를 bounded하게 기다린다. result→terminal gap은 기다린 뒤 성공하고, terminal
+  metadata write failure/gap 만료는 result만으로 성공하지 않고 nonzero를 반환한다.
+- [Windows-runner] supervisor start handshake error는 cleanup, supervisor/target PID,
+  post-cleanup liveness를 담은 typed error다. cleanup true/dead면 spawn-error를 유지하고,
+  cleanup false면 worker result와 public sync/detached output이 structured
+  `cleanup-failed`, exit 125로 fail-closed한다.
+- public E2E는 result→terminal gap, terminal metadata write failure, sync/detached handshake
+  cleanup-false를 직접 검증하고 각 owned PID가 dead임을 확인한다. WSL syntax/static 뒤
+  runner worker/public tests만 실행하며 product gates/full build/Electron은 실행하지 않는다.
+- [Windows-runner] project launcher는 non-secret `ELECTRON_QA_RUN_ID`를 owned child에
+  전달한다. Main은 dev URL이며 `ELECTRON_START_HIDDEN=true`인 QA에만 기존 query를 보존해
+  `codexQaRun=<runId>`를 추가한다. readiness는 base URL이 아니라 자기 marker를 포함한 exact
+  target만 인정한다. base target, 다른 run marker는 own child가 살아 있어도 실패하고 exact
+  own marker만 성공한다. 일반 dev/prod renderer URL은 변경하지 않는다.
+
+Round 6 correction 구현:
+
+- detached terminal finalization마다 128-bit random `finalizationId`를 생성해 result에 먼저,
+  terminal metadata에 마지막으로 기록한다. public stopped/exited success는 같은
+  finalizationId와 run/worker/supervisor/target identity, cleanup true, supervisor/target dead가
+  모두 맞아야 한다. running metadata에서 result를 먼저 봐도 matching terminal metadata를
+  bounded wait하고 result만으로는 성공하지 않는다.
+- worker test injection으로 result→terminal gap과 terminal metadata write failure를 분리했다.
+  metadata write가 실패하면 result에 sanitized `terminalMetadataError`를 보강하지만 running
+  metadata를 성공 증거로 승격하지 않는다. public stop은 gap 뒤 matching metadata가 오면
+  성공하고 끝내 오지 않으면 exact exit 125로 fail-closed한다.
+- `SupervisorStartError`가 spawn/handshake 원인과 exact cleanup, supervisor/target PID,
+  post-cleanup liveness를 함께 운반한다. cleanup 검증 실패는 sync/detached worker 양쪽에서
+  `cleanup-failed` result로 보존되어 public entry가 structured detail과 exit 125를 반환한다.
+- project hidden launcher는 child env에 `ELECTRON_QA_RUN_ID`를 전달하고 base renderer target에
+  자기 `codexQaRun` marker를 붙인 exact CDP target만 ready로 인정한다. Main은 dev URL,
+  hidden=true, nonempty QA run ID 세 조건에서만 기존 query에 marker를 추가하며 그 외 dev/prod
+  URL 문자열은 그대로 load한다. base target과 다른 run marker는 own child alive 상태에서도
+  거부하고 exact-own marker만 수락한다.
+
+Round 6 제한 검증 evidence:
+
+- [WSL] 관련 JS/CJS syntax, runner static 13/13, scoped Prettier와 `git diff --check`가
+  통과했다.
+- public runner를 통한 worker integration run
+  `20260812183339728-446933-308706563764f9c1`은 worker PID 125100/supervisor PID
+  57364/target PID 125408, 16/16, exit 0이었다. handshake cleanup-false typed detail,
+  finalizationId result/metadata 결합을 포함했고 outer cleanup true, supervisor/target dead였다.
+- public E2E 첫 전체 run은 기존 7개와 새 handshake sync/detached exit-125가 통과했지만,
+  새 finalization gap/write-failure 두 테스트의 stop deadline을 detached owner의 3초 cleanup
+  grace보다 짧게 잡아 7/9였다. 산출물은 두 owned tree 모두 cleanup true/dead를 기록했다.
+  stop deadline을 owner cleanup 이후 terminal evidence wait까지 포함하도록 10초로 교정했고
+  두 테스트 targeted retry가 2/2, exit 0으로 통과했다.
+- result→terminal gap run `20260812183711535-448474-6ccf299bf3b645f1`은 worker PID
+  121940/supervisor PID 128228/target PID 46044, finalizationId
+  `780c8d9f38285e8b68cde6831d6024ce`, cleanup true/dead였다. public stop은 result-first 동안
+  running metadata를 관찰한 뒤 같은 terminal finalization을 기다려 성공했다.
+- terminal metadata failure run `20260812183719319-448591-477b06ed93fc16ad`은 worker PID
+  18576/supervisor PID 54896/target PID 38724, cleanup true/dead와 structured
+  `terminalMetadataError`를 남겼으며 public stop은 result만으로 성공하지 않고 exit 125였다.
+- handshake cleanup-false sync run `20260812183605013-447792-4ad6fc8b9887589b`과 detached
+  run `20260812183615798-447867-5907f452105b38e0`은 각각 worker/supervisor/target PID
+  75060/131288/56580, 128820/17492/16468이었다. 실제 exact cleanup은 성공해 양 PID dead였고
+  injected verification false가 structured cleanup-failed와 exact exit 125로 보존됐다.
+- Main의 non-QA dev URL 문자열 보존까지 반영한 최종 project QA marker targeted run
+  `20260812183905247-449397-e880234fddfede2a`은 worker PID 128352/supervisor PID
+  94628/target PID 125248, 6/6, exit 0, outer cleanup true/dead였다.
+  기존 port reservation 거부, child early exit, unmarked base, 다른 run marker 거부와 exact-own
+  marker 성공을 검증했다. 실제 Electron은 기동하지 않고 Node HTTP fixture만 사용했다.
+- 모든 Windows 동작은 public runner로만 진입했고 direct Windows interop은 0회였다. 결과와
+  public PID probe 기준 owned live PID는 0이다. product full gates/build/실제 Electron,
+  commit/stage는 수행하지 않았으며 fresh separated review 전 candidate evidence다.
+
+### Runner test collection integration review — `반려`
+
+반려 사유:
+
+- generic runner의 Node `node:test` harness 세 파일과 project QA launcher harness 한 파일이
+  `*.test.cjs` 이름을 사용해 표준 Vitest collection에 함께 잡힌다. Node 전용 harness가
+  Vitest worker 안에서 public Windows runner와 process fixture를 기동해 product test gate의
+  소유권과 종료 조건을 오염시킬 수 있다.
+
+Correction 결정과 관찰 가능한 DoD:
+
+- [WSL] runner static/worker/public 및 project QA launcher harness 네 파일을
+  `*.node-test.cjs`로 rename한다. broad Vitest exclude는 추가하지 않으며 product test 파일과
+  Vitest config는 변경하지 않는다.
+- [WSL] skill과 repository 내 모든 직접 참조는 새 파일명으로 갱신한다. public runner는
+  Windows integration에서 이 파일을 여전히 explicit Node argv로 실행할 수 있다.
+- [WSL] rename 뒤 old `*.test.cjs` 참조와 Node harness가 표준 `*.test.*` 패턴에 남아 있지
+  않음을 확인하고, 새 경로의 syntax/static, skill validation, Prettier, `git diff --check`를
+  실행한다. Windows/product gate는 separated tester가 다시 수행하므로 여기서는 실행하지
+  않는다.
+
+Correction 및 제한 검증 evidence:
+
+- generic runner harness를 `run-hidden-windows.node-test.cjs`,
+  `run-hidden-windows-worker.node-test.cjs`,
+  `run-hidden-windows-public.node-test.cjs`로, project QA harness를
+  `scripts/qa/hidden-electron-launch.node-test.cjs`로 rename했다. Node `node:test` 코드와
+  public runner argv 계약은 변경하지 않았다.
+- skill의 WSL static 명령은 새 `run-hidden-windows.node-test.cjs` 경로를 사용한다.
+  AGENTS, package scripts와 다른 repository scripts/tests에는 네 old harness filename의
+  직접 참조가 없어 추가 동작 변경이 필요하지 않았다. broad Vitest exclude와 Vitest config는
+  추가·수정하지 않았다.
+- [WSL] 새 네 파일의 `node --check`, renamed static harness 13/13, skill
+  `quick_validate.py`, scoped Prettier와 `git diff --check`가 통과했다. repository scope에서
+  old 네 `*.test.cjs` 파일명/참조가 0이고 Node harness 네 파일이 표준 Vitest-style 이름과
+  일치하지 않음을 확인했다.
+- 이 integration correction에서는 Windows/public runner, product tests/build, 실제 Electron을
+  실행하지 않았다. product runtime code, commit/stage도 변경하거나 수행하지 않았다.
+
+### Project QA profile isolation review — `반려`
+
+반려 사유:
+
+- project hidden Electron launcher의 기본 `ELECTRON_QA_USER_DATA_DIR`가 Vite cwd 아래
+  `.tmp/electron/profile-<runId>`를 사용한다. Vite file watching/build input 경계와 QA browser
+  state가 같은 repository tree에 있어 launcher가 생성한 profile 변동이 dev runtime을 교란할
+  수 있고, ready evidence만으로 어느 run이 어느 profile을 소유하는지도 명시적이지 않다.
+
+Correction 결정과 관찰 가능한 DoD:
+
+- [Windows-runner] 기본 QA profile은 Windows `os.tmpdir()` 아래 project 전용 root와 run ID로
+  생성한다. launcher는 최종 profile이 absolute이고 Vite cwd 바깥인지 spawn 전에 fail-closed
+  검증한다.
+- [Windows-runner] optional `--profile-path`는 `{runId}` 치환을 지원하되 absolute outside-cwd
+  경로만 허용한다. relative 또는 cwd 내부 경로는 child를 기동하지 않고 실패한다.
+- [Windows-runner] ready JSON은 `profilePath`, `runId`, exact renderer ownership marker를 함께
+  기록한다. default outside-cwd, explicit outside 경로, invalid relative/inside 경로와 ready
+  ownership을 project launcher Node harness로 검증한다.
+- package `dev:wsl`에는 repository profile 경로/env를 넣지 않고 launcher default를 사용한다.
+  AGENTS에는 project temp root와 ownership evidence만 기록한다. generic runner/skill, MS5/product
+  runtime은 변경하지 않는다.
+
+Correction 구현 및 제한 검증 evidence:
+
+- project launcher 기본 profile을
+  `%TEMP%\poe2-unofficial-launcher-codex-qa\<runId>`로 옮겼다. optional
+  `--profile-path`는 `{runId}`를 치환하며, 최종 경로가 absolute가 아니거나 Vite cwd와 같거나
+  그 아래이면 port reservation/child spawn 전에 실패한다.
+- ready JSON은 absolute `profilePath`, `runId`, `{ name: "codexQaRun", value: runId }`
+  ownership marker와 그 marker가 포함된 exact renderer target을 함께 기록한다. child env의
+  `ELECTRON_QA_USER_DATA_DIR`와 ready evidence가 같은 validated profile을 가리킨다.
+- package `dev:wsl`은 repository profile path나 `ELECTRON_QA_USER_DATA_DIR`를 직접 지정하지
+  않고 project launcher default를 사용한다. AGENTS에 Windows temp root와 ready ownership
+  evidence를 기록했다. generic runner/skill과 MS5/product runtime은 변경하지 않았다.
+- [WSL] launcher/harness syntax, package recipe static contract, scoped Prettier와
+  `git diff --check`가 통과했다.
+- public runner를 통한 project launcher targeted run
+  `20260812190430601-459556-ab6bbfd3afec7edb`은 worker PID 38784/supervisor PID
+  22856/target PID 113348, 8/8, exit 0이었다. default outside-cwd Windows temp profile,
+  explicit absolute outside profile, relative/inside-cwd 거부, ready profile/run marker ownership,
+  기존 unique port/exact target 조건을 검증했다. outer Job cleanup true이며 supervisor/target은
+  모두 dead였다.
+- direct Windows interop은 0회이고 확인된 owned live PID는 0이다. full product gates/build,
+  실제 Electron, commit/stage는 수행하지 않았다.
+
+### Public ready-file run ID expansion review — `반려`
+
+반려 사유:
+
+- public runner가 stdout/stderr/metadata path와 literal/path env에는 `{runId}`를 치환하지만,
+  `--ready-file` readiness path와 child argv에는 raw placeholder를 남긴다. package `dev:wsl`은
+  같은 ready-file template을 public option과 project launcher child argument에 함께 사용하므로
+  worker와 child가 서로 다른 literal path를 관찰하거나 WSL→Windows path 변환 전에 placeholder가
+  고정될 수 있다.
+
+Correction 결정과 관찰 가능한 DoD:
+
+- [WSL] `buildRequest`에서 한 run ID로 child argv, literal/path env, ready URL/file을 중앙 치환한다.
+  `--ready-file`은 치환 후 absolute WSL path로 resolve하고 그 결과를 Windows readiness path로
+  변환한다. child argv/env에는 같은 run ID가 들어간다.
+- [WSL] static contract는 placeholder ready-file, child argv와 env에 `{runId}`가 남지 않고
+  readiness와 child 경로가 같은 run artifact를 가리키는지 검증한다.
+- [Windows-runner] public detached E2E는 placeholder ready-file을 option과 child argv 양쪽에
+  전달한다. child가 치환된 동일 파일을 쓰면 runner가 ready를 반환하고, public stop이 exact
+  cleanup/dead를 확인한다.
+- generic runner만 외과적으로 수정하며 product/MS5/project launcher 동작, full gates/build,
+  실제 Electron은 변경하거나 실행하지 않는다.
+
+Correction 구현 및 제한 검증 evidence:
+
+- public `buildRequest`가 단일 `expandRunId` 경계에서 child argv, cwd, literal/path env,
+  ready URL/file을 치환한다. secret-in-argv 검증도 expanded argv를 대상으로 수행한다.
+  ready-file은 치환 후 WSL absolute path로 resolve한 다음 Windows path로 변환하고, child argv는
+  같은 run ID가 치환된 값을 받는다.
+- [WSL] 관련 syntax, scoped Prettier, `git diff --check`와 static harness 14/14가 통과했다.
+  static은 request JSON 전체에 raw `{runId}`가 남지 않고 readiness Windows path, child relative
+  argv와 literal/path env가 같은 generated run ID를 사용하는지 확인한다.
+- targeted public E2E run `20260812192041707-464668-c64bbccff11e9748`은 worker PID
+  127316/supervisor PID 105112/target PID 112420이었다. detached option과 child argv 양쪽에
+  `ready-{runId}.json`을 전달했고 child가 쓴 expanded file로 worker readiness가 성공했다.
+  이어 public stop이 `status=stopped`, cleanup true, supervisor/target dead를 확인했으며
+  finalizationId는 `eecde6239dd3b1fec3d455d36daa50f2`였다. targeted E2E는 1/1, exit 0이다.
+- direct Windows interop은 0회이고 public PID probes/result 기준 owned live PID는 0이다.
+  product/MS5/project launcher, full gates/build, 실제 Electron, commit/stage는 변경하거나
+  수행하지 않았다.
+
+### MS5 / MS5-H 최종 candidate 종합 evidence
+
+리뷰 상태:
+
+- Round 6 이전의 stale fork-none review 결과는 이후 correction을 반영하지 못한 이력으로
+  supersede한다. Round 7 separated review와 후속 외과적 correction 뒤 lightweight review는
+  blocking 지적 없이 통과했다. 이 판정은 자동화 candidate에 한정하며 아래 `[사용자]` DoD를
+  대신하지 않는다.
+
+Fresh gate evidence:
+
+- 최종 Node harness rename/update 직전 fresh runner gate는 static 13/13, worker 16/16,
+  public 9/9, project launcher 6/6으로 통과했다. 이후 profile isolation correction은 project
+  launcher 8/8, ready-file `{runId}` correction은 static 14/14와 public E2E 1/1로 각각 다시
+  닫았다.
+- final full product gates는 public hidden runner로만 실행했다. Vitest run
+  `20260812185702143-456616-9a910a4a42136b0d`가 65 files / 402 tests, ESLint run
+  `20260812185741340-456870-5d45c3fe4e0fd694`, TypeScript run
+  `20260812185818341-457061-9bcf24765c678cc0`, Vite build run
+  `20260812185825446-456869-f917c2f53316da5e`가 모두 exit 0이었다. 각 runner 결과는 exact
+  owned cleanup true와 supervisor/target dead를 기록했다. electron-builder packaging은 이
+  Vite build evidence에 포함하지 않는다.
+
+Hidden native Electron QA evidence:
+
+- owner run `20260812191234983-462680-50e830187cf52d9d`의 exact CDP target
+  `http://localhost:54321/?codexQaRun=20260812191234983-462680-50e830187cf52d9d`에서 실제
+  Electron main/preload/renderer를 검사했다. fatal renderer text 없이 launcher main 화면과
+  두 게임의 경로 진단 modal이 열렸다.
+- main screenshot:
+  `/mnt/d/project_poe2/POE2-unofficial-launcher/.tmp/ms5-electron-final/main-20260812191234983.png`
+- POE1 modal screenshot:
+  `/mnt/d/project_poe2/POE2-unofficial-launcher/.tmp/ms5-electron-final/modal-20260812191234983.png`
+- POE2 modal screenshot:
+  `/mnt/d/project_poe2/POE2-unofficial-launcher/.tmp/ms5-electron-final/modal-poe2-20260812191234983.png`
+- warning 확인 screenshot:
+  `/mnt/d/project_poe2/POE2-unofficial-launcher/.tmp/ms5-electron-final/modal-poe2-warning-check.png`
+- POE1/POE2 modal은 각각 canonical `HKCU:\Software\Kakaogames\POE` / `POE2` key missing을
+  표시하면서 legacy `HKCU:\Software\DaumGames\POE` / `POE2`의 유효 경로를 fallback으로
+  선택했다. config 경로와 선택 경로가 일치했고 register action도 노출됐다. mutation 안전을
+  위해 register/delete/sync action은 누르지 않아 이 QA의 HKCU mutation은 0이다.
+- 이 환경에는 유효한 DaumGames fallback이 있었으므로 registry warning은 의도대로 나타나지
+  않았다. 따라서 canonical/legacy 둘 다 absent/invalid/unknown일 때의 native warning,
+  `install_check_blocked`의 `경로 확인` 버튼, register write/read-back은 자동 native QA 공백으로
+  남는다.
+
+Final `dev:wsl` smoke evidence:
+
+- run `20260812192326357-465455-ca3e8061296037e6`은 ready-file을 약 6.2초 안에 만들었다.
+  worker PID 120904, supervisor PID 100608, project hidden launcher PID 67124, Vite child PID
+  51288였고 unique port 59463의 exact own-run renderer target만 ready로 인정했다.
+- visibility monitor는 전체 sentinel 구간에서 49 samples, max gap 64ms였으며
+  visible/foreground/focus ownership count가 모두 0이었다. hidden console host PID는
+  informational로만 관찰했고 visible/focus window는 없었다. CDP와 launcher logs에는 fatal
+  runtime event가 없었다.
+- stop 결과는 cleanup true, supervisor/target dead였다. run에서 관찰한 13개 owned PID가 모두
+  dead임을 post-stop probe로 확인했고, Windows temp의 isolated QA profile도 제거됐다. QA는
+  registry mutation action을 호출하지 않아 HKCU mutation 0이었다.
+
+Candidate DoD 결론:
+
+- MS5와 MS5-H의 자동화·hidden Windows candidate DoD는 위 fresh gates, separated/lightweight
+  review, native modal 및 lifecycle smoke 기준으로 통과했다. work 문서는 아직 archive하지 않고
+  commit/stage도 하지 않는다.
+- 남은 `[사용자]` DoD는 (1) 실제 사용자 상태에서 설정 경로는 유효하지만 canonical/legacy
+  registry가 모두 absent/invalid/unknown일 때 warning과 exact modal click, `경로 확인` 버튼을
+  확인하고, 안전한 대상에서 register 후 read-back을 확인하는 것, (2) 30분 이상 장기 미사용 뒤
+  show/focus가 현재 context만 reconcile하며 TTL 미만에서는 skip되는 것을 확인하는 것이다.
+  이 두 항목 전에는 사용자 DoD 또는 전체 기능 완료를 주장하지 않는다.
+
+## 2026-08-22 PR candidate closeout
+
+- 제품 변경과 WSL→Windows 숨김 실행 하네스 변경을 각각 독립 커밋으로 분리해
+  `origin/master` 위에 재배치하고 PR로 상신한다.
+- 위키 raw 노트와 `/ingest`는 실행하지 않았다. 이 저장소에서 `/ingest`는
+  `.claude/commands/ingest.md`가 정의하는 승인형 Claude command이며, 먼저 영향 페이지를
+  제시하고 owner 승인을 받아야 한다. 현재 위키 worktree에는 대상
+  `wiki/projects/poe2-launcher.md`를 포함한 기존 사용자 수정이 있어 이 closeout에서 해당
+  페이지와 raw를 수정하거나 커밋하지 않았다.
+- 자동화 candidate와 분리 리뷰는 통과했지만 아래 사용자 DoD는 여전히 미완료다.
+  1. 실제 `Kakaogames` 단독 설치 또는 두 registry 후보 모두 비정상인 안전한 HKCU에서
+     후보 우선순위, warning, 진단 modal, canonical 등록과 read-back을 확인한다.
+  2. 30분 이상 장기 미사용 뒤 show/focus가 현재 context만 재검사하고 TTL 미만에서는
+     생략하는지 확인한다.
+- 위 두 항목 전에는 사용자 DoD 또는 전체 기능 완료를 주장하지 않는다. 따라서 이 문서는
+  `docs/work/`에 유지하고 미완료 사용자 검증을 PR 검증 경계로 추적한다.

--- a/docs/work/2026-08-09-kakao-game-registry-path-diagnostics.md
+++ b/docs/work/2026-08-09-kakao-game-registry-path-diagnostics.md
@@ -1,6 +1,6 @@
 # 카카오게임즈 게임 경로 진단 및 레지스트리 복구
 
-> 작성일: 2026-08-09 · 갱신: 2026-08-22 · 상태: PR candidate(자동 게이트·분리 리뷰 통과, 사용자 DoD 대기) · 브랜치: `fix/kakao-game-registry-path-diagnostics`
+> 작성일: 2026-08-09 · 갱신: 2026-08-27 · 상태: 진행 · 브랜치: `fix/kakao-game-registry-path-diagnostics`
 
 ## 배경과 목표
 
@@ -1319,3 +1319,540 @@ Candidate DoD 결론:
      생략하는지 확인한다.
 - 위 두 항목 전에는 사용자 DoD 또는 전체 기능 완료를 주장하지 않는다. 따라서 이 문서는
   `docs/work/`에 유지하고 미완료 사용자 검증을 PR 검증 경계로 추적한다.
+
+## MS6 — 수동 경로 다중 적용과 후보별 관리
+
+### 범위, 이전 결정과 변경 금지 경계
+
+- 진단 본문은 기존의 좌측 registry / 우측 launcher config 2열을 유지한다. MS6는
+  선택한 한 경로를 어느 저장 대상으로 적용할지 명시하게 할 뿐, 두 진단 열을 합치거나
+  launcher config를 registry의 하위 정보로 바꾸지 않는다.
+- 이전의 `DaumGames` 키 생성 금지 결정은 2026-08-27 사용자 요구로 **MS6 범위에서만
+  명시적으로 supersede**한다. 사용자가 `registry-compatibility`를 선택했을 때
+  `InstallPath` 생성 및 조건부 overwrite를 허용한다. 선택하지 않은 호환 키에는 쓰지
+  않으며, 이 변경은 다른 마일스톤의 자동 등록 정책을 소급 변경하지 않는다.
+- persistent `AppConfig` schema, EventBus, 의존성, updater/release flow, Kakao DOM
+  selector는 변경하지 않는다. `gameInstallPaths`의 이미 존재하는 nested 값만 immutable
+  update로 쓴다. `GameInstallStatusReconciler`의 소스도 수정하지 않는다.
+- `origin/master` 재배치는 완료되었다. old `a8fece1`은 new `975262b`로, old `990a668`은
+  new `e83258d`로 각각 patch-id가 동일하게 재배치되었고 remote는 아직 갱신하지 않았다.
+- 열린 owner 결정: 없음.
+
+### 대안 비교와 채택안
+
+| 접근                                   | 내용                                                                                             | 판정                                                                                                   |
+| -------------------------------------- | ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------ |
+| A. renderer chain                      | renderer가 picker 결과 뒤 registry/config IPC를 순서대로 호출                                    | renderer lifecycle·재로딩·중복 클릭이 mutation 순서와 retry 상태를 소유하므로 배제                     |
+| B. stateless batch                     | 매 batch IPC가 diagnostics를 다시 읽고 전달된 대상 목록을 즉시 처리                              | 이전 성공 대상과 확인 당시 snapshot을 안정적으로 묶지 못해 partial retry와 TOCTOU 설명이 약하므로 배제 |
+| C. main-owned opaque selection session | Main이 picker 이후 선택 세션·allowlist·snapshot·완료 대상을 소유하고 renderer는 opaque ID만 제출 | 채택. 권한, lifecycle, 순서, retry 경계를 Main 한 곳에 둔다                                            |
+
+### Main 소유권, opaque 선택 세션과 IPC 계약
+
+- 새 focused main runtime owner로 `GameInstallPathSelectionService`를 둔다. 세션은
+  `selectionId`, owner `webContents`, `serviceId`/`gameId`, 검증된 path, 예상 target
+  snapshot, completed target ID 집합, lazy TTL을 가진다. 새 selection 생성, renderer
+  destroy, TTL 만료 시 즉시 폐기한다. 세션은 persistent state가 아니며 AppConfig에
+  저장하지 않는다.
+- renderer가 Main에 보내는 mutation 식별자는 `selectionId`와 allowlisted target ID뿐이다.
+  raw registry path·value는 diagnostics 화면 표시용이며 mutation authority가 아니다.
+  Main은 세션의 owner `webContents` 및 `serviceId`/`gameId`를 검사한 뒤 target ID를
+  현재 세션 snapshot으로 다시 해석한다.
+- target ID는 `registry-primary`, 후보가 있을 때만 `registry-compatibility`, `config`다.
+  candidate diagnostics에는 readonly `targetId`를 추가한다. GGG는
+  `registry-primary`와 `config`만 노출하며 compatibility target을 만들지 않는다.
+- native folder picker의 `defaultPath`는 registry candidate 순서로 실존 directory를
+  먼저 찾고, 없으면 config path를 사용한다. 어느 후보도 실존 directory가 아니면
+  `defaultPath`를 생략한다. picker는 path 검증과 selection session 생성만 수행하며
+  picker 성공만으로 config를 즉시 저장하지 않는다.
+- selection batch 결과는 target별 `applied` / `unchanged` / `failed`와 fresh
+  diagnostics를 반환한다. completed target은 retry allowlist에서 제외하고, failed target만
+  fresh diagnostics를 보여준 뒤 다시 선택할 수 있다.
+
+### 다중 적용 UI와 접근성
+
+- picker 성공 뒤 nested selection dialog를 열고 primary registry와 config checkbox는
+  기본 checked, compatibility checkbox는 기본 unchecked로 둔다. CTA는 `선택 (n개)`이며
+  0개이면 disabled다. service, game, path는 readonly로 표시한다.
+- 각 registry candidate의 삭제 버튼은 해당 candidate `path`가 `null`이면 disabled다.
+  삭제 요청은 `targetId`와 `expectedPath`만 받아 allowlist에서 재해석하고,
+  `Remove-ItemProperty`만 실행해 값만 제거한다. key container는 유지한다.
+- outer 진단 dialog에는 최소 `role="dialog"`/`aria-modal="true"`/접근 가능한 이름을
+  보강한다. nested dialog는 native `fieldset`/`checkbox`/`button`, `role="dialog"`,
+  `aria-modal`, title 연결, initial focus, focus trap, Escape close, opener focus restore,
+  `aria-live` 결과 알림을 갖춘다.
+- 1024x683, 1440x960, 1920x1080과 Windows 100/125/150%에서 body scroll, header/footer,
+  긴 path wrapping, hit target, outer/nested overlay를 확인한다.
+
+### batch mutation, ordering과 실패 처리
+
+- batch 시작 시 선택 path를 fresh verify한 뒤, 모든 미완료 target의 현재 상태와
+  expected snapshot을 preflight한다. mutation 순서는 `registry-primary` →
+  `registry-compatibility` → `config`의 직렬 순서다.
+- 각 registry write는 expected state/path atomic recheck 후 조건부 write하고 read-back한다.
+  config는 immutable nested update와 expected snapshot compare를 통과했을 때만 쓴다.
+  preflight 또는 target mutation 실패는 다른 미완료 target의 결과를 숨기지 않고 target별로
+  기록한다.
+- rollback은 하지 않는다. 부분 성공은 보존하고 failed target만 재시도한다. 하나 이상의
+  target이 success이면 기존 `runManualGameInstallPathAction`의 `ok=true` 경로로
+  reconciliation을 정확히 1회 실행한다. `GameInstallStatusReconciler`는 호출 대상일
+  뿐 소스 변경 대상이 아니다.
+
+### MS6.1 — target identity + registry atomic mutation
+
+**TDD RED → GREEN 구현 파일**
+
+- RED: `src/main/tests/registry-install-status.test.ts`에 Kakao primary/compatibility 및
+  GGG allowlist, `targetId` readonly diagnostics, selected compatibility 생성·조건부
+  overwrite, stale expected state/path 거부, read-back, candidate별 값 삭제와 key container
+  유지, partial target 결과를 먼저 고정한다.
+- GREEN: `src/shared/types.ts`에 target ID·readonly diagnostic·batch target/result 계약을
+  추가하고, `src/main/utils/registry.ts`에 allowlist 해석, atomic recheck/write/read-back,
+  immutable config snapshot compare에 필요한 mutation primitive를 구현한다. AppConfig
+  type/metadata/default는 수정하지 않는다.
+
+**DoD**
+
+- [Windows-pwsh] `src/main/tests/registry-install-status.test.ts`의 RED case가 primary,
+  선택 compatibility, GGG 단일 primary, stale snapshot, read-back, `Remove-ItemProperty`
+  value-only 삭제를 fixture/격리된 registry profile에서 모두 GREEN으로 판정한다.
+- [Windows-pwsh] 테스트 fixture 외 실제 사용자 HKCU를 읽거나 쓰지 않았음을 실행
+  환경과 mock/isolated profile 경로로 확인한다.
+
+#### MS6.1 구현 및 분리 리뷰 기록
+
+- TDD/검증 경과: 최초 RED 18건을 추가한 뒤 targeted 77/77, candidate target-ID
+  delete correction RED 11건을 거쳐 88/88, quality correction에서 drive-root RED 2건과
+  partial config RED 4건을 거쳐 최종 targeted 92/92를 통과했다.
+- 최종 회귀 검증은 65 files / 435 tests가 모두 통과했고, `tsc`, `lint`, `prettier`,
+  `git diff --check`도 통과했다. PowerShell은 mock으로만 실행했으며 실제 사용자 HKCU
+  접근·변경은 0건이다.
+- 변경 API/파일 요약:
+  - `src/shared/types.ts`: `GameInstallPathTargetId`, registry target ID, target snapshot,
+    apply status/failure/result, registry delete request/failure/result 계약과 candidate
+    diagnostic의 readonly `targetId`를 추가했다.
+  - `src/main/utils/registry.ts`: `resolveGameInstallPathTarget`,
+    `collectGameInstallPathTargetSnapshots`, `applyGameInstallPathTarget`,
+    `deleteGameInstallPathRegistryTarget`를 추가하고 target allowlist, GGG compatibility
+    거부, atomic expected-state/path recheck와 read-back, value-only delete, immutable config
+    snapshot compare/write를 구현했다.
+  - `src/main/tests/registry-install-status.test.ts`: 위 target/API와 PowerShell
+    quoting·marker·exit/read-back, drive-root, partial config 회귀 계약을 고정했다.
+  - `src/renderer/components/modals/GamePathDiagnosticModal.test.tsx`: 기존 candidate
+    fixture에 readonly `targetId` 1줄을 보강해 shared contract 변경을 반영했다.
+- Review Round 1:
+  - 명세 리뷰는 candidate target-ID delete 누락으로 `반려`되었고, correction 후
+    재검토에서 `통과`했다.
+  - 품질·안전성 리뷰는 drive root 훼손과 partial persisted config shape 처리 문제로
+    `반려`되었고, 각각 root-aware normalization과 complete-shape immutable 처리로
+    correction한 뒤 재검토에서 `통과`했다.
+- 비차단 관찰: PowerShell command 중복과 사용자 경로가 로그에 포함될 수 있는 privacy
+  문제는 MS6.1 blocking이 아니며, 이번 범위 밖의 향후 개선 사항으로만 남긴다.
+
+### MS6.2 — picker + selection service + batch IPC
+
+**TDD RED → GREEN 구현 파일**
+
+- RED: 새 `src/main/tests/GameInstallPathSelectionService.test.ts`에 owner webContents
+  격리, 새 selection 교체 폐기, renderer destroy 폐기, lazy TTL 만료, target allowlist,
+  completed target retry 제외, registry 우선의 existing-directory `defaultPath`/생략을
+  고정한다. `src/main/tests/game-install-path-register-ipc-contract.test.ts`에는 opaque
+  selection batch IPC가 raw registry path/value를 받지 않고 한 success batch마다
+  reconciliation을 정확히 한 번 요청하는 계약을 고정한다.
+- GREEN: 새 `src/main/game/GameInstallPathSelectionService.ts`가 session lifecycle과 batch
+  orchestration을 소유한다. `src/main/main.ts`, `src/main/preload.ts`,
+  `src/shared/types.ts`에 picker/session/batch IPC를 연결하고, 기존 picker의 즉시
+  `setGameInstallPath` 경로를 selection 생성으로 교체한다. 기존
+  `runManualGameInstallPathAction`은 batch 결과 중 하나 이상 success일 때만 정확히 한 번
+  감싼다.
+
+**DoD**
+
+- [Windows-pwsh] 새 service test가 session owner mismatch, destroy, TTL, 새 selection,
+  completed target 재제출과 GGG compatibility 미생성을 모두 거부하고, valid path만
+  session으로 만들며 config를 picker 단계에서 쓰지 않음을 GREEN으로 판정한다.
+- [Windows-pwsh] IPC contract test가 `selectionId`와 target ID 이외의 registry mutation
+  authority를 허용하지 않고, successful target이 하나 이상인 batch의 reconciliation
+  호출 수를 1로 판정한다.
+
+#### MS6.2 구현 및 분리 리뷰 기록
+
+- TDD/검증 경과: initial RED를 확인한 뒤 service focused 21건, IPC focused 26건,
+  related 118건, full 460건과 build gate를 통과했다.
+- 명세 Review Round 1은 selection ID collision, async invalidation, coherent preflight,
+  TTL, source-string IPC contract 5건으로 `반려`되었다. correction 후 focused 136건과
+  full 478건을 통과했다.
+- 명세 재리뷰는 retired selection ID reuse 1건으로 다시 `반려`되었다. issued ID
+  tombstone correction 후 service 32건과 full 480건을 통과했고, 명세 재검토에서
+  `통과`했다.
+- 품질·안전성 리뷰는 same-selection concurrent apply와 retryable/disabled final snapshot
+  모순 2건으로 `반려`되었다. session in-flight lock과 단일 final eligibility correction 후
+  focused 44건, related 143건, full 485건과 최종 build gate를 통과했고, 분리 품질
+  재검토에서 `통과`했다.
+- 최종 runtime 계약:
+  - `GameInstallPathSelectionService`가 owner generation, owner별 issued selection ID,
+    lazy TTL, completed target과 coherent preflight/final snapshot을 소유한다.
+  - apply는 첫 await 전에 session 단위 in-flight lock을 획득하고 final diagnostics refresh까지
+    유지하며, identity-checked `finally`로 해제한다. 동시 replay는 typed
+    `selection-busy`로 거부한다.
+  - `GameInstallPathIpcHandlers`는 production DI와 동일한 service/context/manual-action
+    경계를 사용한다. renderer mutation request는 opaque `selectionId`와 allowlisted target
+    ID만 받으며 raw registry path/value/context를 authority로 사용하지 않는다.
+  - 새 `pickGameInstallPathTargets`/`applyGameInstallPathTargets` batch API를 연결하면서 기존
+    `pickGameInstallPath` legacy picker barrier API는 호환 경계로 유지한다.
+- 변경 파일:
+  - `src/main/game/GameInstallPathSelectionService.ts`,
+    `src/main/game/GameInstallPathIpcHandlers.ts`
+  - `src/main/tests/GameInstallPathSelectionService.test.ts`,
+    `src/main/tests/GameInstallPathIpcHandlers.test.ts`
+  - `src/shared/types.ts`, `src/main/main.ts`, `src/main/preload.ts`
+  - `src/main/utils/registry.ts`, `src/main/tests/registry-install-status.test.ts`,
+    `src/main/tests/game-install-path-register-ipc-contract.test.ts`
+- 검증 중 실제 사용자 HKCU 접근·변경과 Electron 실행은 각각 0건이다.
+- 비차단 관찰: live owner의 issued selection ID tombstone은 selection 생성 횟수에 따라
+  선형 증가한다. 또한 기존 Vite 500 kB chunk warning은 유지되며 둘 다 MS6.2
+  correctness blocking은 아니다.
+
+### MS6.3 — renderer modal + candidate delete + partial retry/accessibility
+
+**TDD RED → GREEN 구현 파일**
+
+- RED: `src/renderer/components/modals/GamePathDiagnosticModal.test.tsx`에 기본 checked
+  primary/config, 기본 unchecked compatibility, `선택 (n개)`와 0 disabled, GGG의
+  compatibility 부재, null path 삭제 disabled, failed-only retry, target별 결과와
+  fresh diagnostics, nested dialog focus/Escape/restore/aria-live를 고정한다.
+  `src/renderer/utils/game-path-modal-state.test.ts`에는 selection 결과가 기존 좌/우
+  diagnostic state를 유지하는 reducer/state 전이를 고정한다.
+- GREEN: `src/renderer/App.tsx`가 picker selection과 batch/partial retry 결과를 state로
+  연결하고, `src/renderer/components/modals/GamePathDiagnosticModal.tsx`와
+  `src/renderer/components/modals/GamePathDiagnosticModal.css`가 nested selection UI,
+  candidate별 delete, accessibility, 긴 path wrapping과 overlay layering을 구현한다.
+  `src/shared/types.ts`의 readonly result만 표시하고 raw registry identity를 다시 전송하지
+  않는다.
+
+**DoD**
+
+- [Windows-pwsh] renderer tests가 checkbox default/disabled CTA, GGG 제한, candidate null
+  delete guard, partial success 후 failed-only retry, aria role/name/live/focus 계약을
+  모두 GREEN으로 판정한다.
+- [Windows-pwsh] fixture/isolated profile에서 primary 성공·compatibility 실패처럼 부분
+  성공을 재현했을 때 성공 target이 retry UI에 다시 나타나지 않고 registry/config 두 열이
+  모두 fresh diagnostics를 표시함을 확인한다.
+
+#### MS6.3 구현 기록 (분리 리뷰 전)
+
+- TDD RED는 renderer modal/state와 IPC 계약 4개 파일에서 새 동작 부재 13건을 확인했다.
+  초기 GREEN 35/35 이후 failed-only retry가 이전 성공 결과를 보존하는 상태 전이와 후보
+  삭제 확인 dialog의 focus/Escape/restore를 별도 RED로 추가해 최종 GREEN으로 고정했다.
+- renderer는 legacy 즉시 저장 picker 대신 `pickGameInstallPathTargets`를 사용한다. Main이
+  반환한 기본값으로 primary/config를 checked, compatibility를 unchecked로 표시하고,
+  `선택 (n개)`의 0개 disabled, readonly service/game/path, target별 결과와 Main이 반환한
+  `retryableTargetIds`만 제출하는 재시도를 구현했다. 재시도 결과는 같은 selection의 이전
+  성공 결과와 target ID별로 병합해 부분 성공 표시를 보존한다.
+- registry 후보 행마다 target별 삭제 버튼과 exact candidate/path 확인 dialog를 추가했다.
+  renderer→preload 삭제 authority는 `targetId + expectedPath`로 제한했고, Main의
+  `deleteGameInstallPathRegistryTarget` primitive를 `runManualGameInstallPathAction`으로 한 번
+  감싸 fresh diagnostics를 반환한다. 기존 raw registry clear bridge는 제거했고 config clear는
+  전용 channel로 좁혔다.
+- outer 2열 진단 layout은 유지했다. outer/apply/delete 및 기존 nested confirm dialog에
+  dialog semantics를 보강하고, nested initial focus, focus trap, busy 중 Escape/backdrop 차단,
+  opener focus restore, native checkbox fieldset/legend/label, aria-live 결과를 연결했다. modal
+  body scroll, scale-aware max size, long path wrapping, reduced-motion CSS를 추가했다.
+- 최종 검증은 focused 4 files / 36 tests, full 67 files / 498 tests, `tsc`,
+  `npm run build:check`, `npm run lint`, touched-file Prettier check, `git diff --check`가 모두
+  통과했다. 기존 Vite 500 kB chunk warning 외 새 warning/error는 없다.
+- 검증 중 Electron 실행, 실제 사용자 HKCU 접근·변경, branch/commit/push/PR 변경은 각각
+  0건이다. Windows hidden visual QA와 실제 HKCU/native picker 확인은 MS6.4 및 `[사용자]`
+  DoD로 남긴다.
+
+#### MS6.3 분리 리뷰 Round 1 교정 기록
+
+- 명세·품질 리뷰는 같은 context close/reopen과 selection 교체를 구분하지 못하는 async
+  identity, Main candidate delete 중복 실행, session-level retry 실패 시 누적 성공 표시 소실,
+  result/delete 전환 focus, nested modality/오류 알림, raw conflict mutation bridge를 blocking으로
+  판정해 `반려`했다.
+- 교정 RED는 focused 5 files / 146 tests에서 18 failed, 128 passed로 고정했다. canary는 modal
+  generation과 selection ID, synchronous duplicate re-entry, 네 session failure variant의 누적
+  결과, delete coalescing invocation count, targetId 기반 conflict 대상 파생, nested inert/alert와
+  focus 전환·복원을 각각 재현했다.
+- renderer는 modal generation과 exclusive per-operation token을 사용한다. picker/apply/delete,
+  config clear, conflict, register 및 modal diagnostics 완료는 current generation과 request token을
+  통과해야 state를 갱신하고, apply는 요청 당시 selection ID까지 일치해야 결과를 병합한다.
+  transport에 diagnostics/selection이 없는 failure는 이전 target 결과만 표시 상태에 보존하며
+  fresh diagnostics나 retry ID를 만들지 않는다.
+- Main candidate delete는 owner webContents/context/target 단위 in-flight Promise를 공유하고
+  `finally`에서 제거한다. 동시 동일 요청은 mutation, manual-action reconciliation, final diagnostics를
+  각각 한 번만 실행하며 완료 뒤 새 요청은 정상 실행된다.
+- conflict mutation 요청은 `targetId + expectedPath + expectedConfigPath`로 축소했다. Main은
+  service/game allowlist에서 registry path/value name을 다시 파생하고 expected path를 조건부 mutation
+  안에서 재검증한다. renderer/preload conflict 요청에는 raw registry path/value name이 없다.
+- nested dialog가 열리면 outer background만 `inert`/`aria-hidden`으로 차단하고 outer의
+  `aria-modal`을 제거한다. apply/delete IPC 예외는 활성 nested dialog의 `role=alert`로 표시하고,
+  result 전환은 retry 또는 닫기로 focus를 옮긴다. 삭제로 opener가 disabled되면 candidate heading,
+  다음 action, outer dialog 순으로 복원한다. decorative glyph, overscroll containment, 40 px candidate
+  delete target도 함께 고정했다.
+- 최종 GREEN은 focused 5 files / 146 tests, full 67 files / 515 tests이며 `npx tsc --noEmit`,
+  `npm run build:check`, `npm run lint`, touched-source Prettier check, `git diff --check`가 모두 exit 0이다.
+  기존 Vite 500 kB chunk warning 외 새 warning/error는 없다.
+- 이 교정에서 Electron 실행, 실제 HKCU 접근·변경, command approval 요청, branch/commit/push/PR 및
+  기타 외부 상태 변경은 각각 0건이다. full-viewport outer overlay/titlebar 문제는 별도 fix로 유지했고
+  Windows DPI/scale 실동작 증거는 생성하거나 주장하지 않았다.
+
+#### MS6.3 독립 재검토 판정
+
+- 현 오케스트레이터의 mock 기반 표적 재검토는 6 files / 182 tests GREEN으로 `통과`했다.
+- 비차단 잔여 위험: 동일 owner/context/target에 서로 다른 `expectedPath` 요청을 동시에 보내면
+  delete coalescing이 첫 Promise 결과를 공유할 수 있다. 정상 renderer의 단일 작업 잠금 경로에서는
+  이 조합이 발생하지 않으며, Main의 atomic `expectedPath` 검증을 우회하지도 않는다.
+
+### MS6.4 — Windows regression / hidden Electron QA + 사용자 DoD
+
+**검증 파일과 변경 분리**
+
+- 제품 regression의 정확한 대상은 `src/main/tests/registry-install-status.test.ts`,
+  `src/main/tests/GameInstallPathSelectionService.test.ts`,
+  `src/main/tests/game-install-path-register-ipc-contract.test.ts`,
+  `src/renderer/components/modals/GamePathDiagnosticModal.test.tsx`,
+  `src/renderer/utils/game-path-modal-state.test.ts`다.
+- hidden Electron QA는 기존 `scripts/qa/hidden-electron-launch.cjs`와
+  `scripts/qa/cdp-capture.cjs`를 사용하고 isolated temporary profile만 사용한다. 이
+  harness를 고쳐야 하는 경우 그 변경은 제품 변경과 분리한 별도 `internal` 커밋으로
+  기록한다.
+
+#### MS6.4-A — HKCU 비접근 hidden fixture 진입점
+
+- activation owner는 Main bootstrap이다. `app.isPackaged=false`, Vite dev server,
+  `ELECTRON_START_HIDDEN=true`, safe run ID, run ID와 일치하는 `*-codex-qa/<runId>` 절대
+  `ELECTRON_QA_USER_DATA_DIR`, allowlisted `ELECTRON_QA_GAME_PATH_FIXTURE`가 모두 맞을 때만
+  전용 fixture window를 만든다. 하나라도 다르면 기존 normal startup을 그대로 수행한다.
+- active fixture branch는 `app.whenReady` 첫머리에서 1024x683 hidden frameless window를
+  만들고 즉시 return한다. 따라서 UAC registry check, `syncInstallLocation`,
+  `syncAutoLaunch`, normal `createWindow`, install-status reconciliation과 core service init에
+  진입하지 않는다. 창은 기존 preload/background/title-bar chrome과 run-owned
+  `codexQaRun` marker를 사용하고, same Vite origin의 allowlisted fixture URL 외 navigation과
+  새 창을 거부한다.
+- renderer query allowlist는 `diagnostic`, `selection`, `partial`, `delete` 네 mode와 valid
+  `codexQaRun`만 허용한다. fixture는 typed static diagnostics/selection/result를 실제
+  `GamePathDiagnosticModal`에 전달하며 Electron product API를 호출하지 않는다.
+- 기존 hidden launcher는 수정하지 않는다. 후속 실행은 renderer target에 allowlisted
+  `codexQaFixture`를 먼저 넣고 launcher가 동일 run의 `codexQaRun` ownership marker를 붙이는
+  기존 exact-target 계약을 유지한다.
+- 이번 A 단계는 source/jsdom targeted test만 수행하며 Electron, 실제 사용자 HKCU,
+  capture와 full suite는 실행하지 않는다.
+- TDD RED는 fixture 진입점/renderer module 부재로 2 suites가 실패했고, 기존 hidden
+  launcher exact-target 호환 URL 순서 canary는 13 tests 중 1건이 의도대로 실패했다. 최종
+  targeted GREEN은 2 files / 26 tests이며 `npx tsc --noEmit`, `npm run lint`, touched-file
+  Prettier check와 `git diff --check`가 모두 통과했다.
+- 검증 중 Electron, 실제 HKCU read/write, capture, full suite, branch/commit/stage/push/PR 및
+  외부 상태 변경은 각각 0건이다.
+
+#### MS6.4-B — internal CDP capture harness
+
+##### Review correction evidence (2026-08-27)
+
+- 고정 `--app-scale: 0.711` fixture 값은 제거했다. QA fixture는 mount 및 `resize`마다
+  App과 동일한 `min(innerWidth / 1440, innerHeight / 960)` 값을
+  `documentElement`에 설정하고, unmount 시 기존 값과 priority를 복구한다. renderer
+  canary는 수정 전 14건 중 1건 실패로 1024x683 scale 불일치를 확인했고, 수정 후
+  1024x683 약 `0.711111`, 1440x960 `1`, 1920x1080 `1.125`와 cleanup 복구를 포함해
+  14/14 통과했다.
+- capture state/manifest assertion은 fixture가 계산한 `appScale`을 scenario 기대값과
+  `0.0001` tolerance로 비교한다. document/body 및 modal body scroll containment,
+  대표 long Windows path wrap/containment, checkbox option/delete/active CTA hit target,
+  nested initial focus, nested overlay의 outer modal containment/coverage도 구조화된
+  boolean evidence로 기록한다. Node canary는 수정 전 18건 중 2건 실패했고, 잘못된
+  scale, overflow, nowrap, 작은 hit target, dialog 밖 focus, overlay overflow를 거부하는
+  adversarial 검증을 포함해 수정 후 18/18 통과했다.
+- `npm run lint`, capture CJS 두 파일의 직접 ESLint, touched Prettier 및
+  `git diff --check`를 통과했다. 이 matrix는 CDP viewport/deviceScaleFactor simulation
+  전용이며 실제 Windows OS DPI 통과 근거가 아니다. 이 correction에서 Electron,
+  실제 HKCU, branch/commit/stage/push/PR은 실행하거나 변경하지 않았다.
+
+##### Live QA layout-readiness correction (2026-08-27)
+
+- hidden Electron live capture에서 첫 scenario가 `Page.loadEventFired` 직후 두 차례
+  `Interactive hit target contract failed`로 종료됐지만, 같은
+  `LAYOUT_STATE_EXPRESSION`을 즉시 다시 평가하면 통과했다. 관찰된 scale과 unscaled
+  button/delete 크기는 각각 약 `0.711111`, `36px`, `40px`였으므로 assertion 기준이
+  아니라 React/layout/font 안정화 이전 state read race로 판정했다.
+- capture 순서는 `setViewport -> navigate -> waitForLayoutReady -> readState ->
+screenshot`으로 고정했다. CDP readiness는 5초 내부 deadline과 기존 10초 command
+  timeout 아래에서 `document.fonts.ready`, allowlisted fixture marker, App scale,
+  viewport/DPR을 확인하고 두 번의 `requestAnimationFrame` 뒤 같은 조건을 다시
+  확인한다. mismatch/timeout은 state read, screenshot, artifact write 전에 fail closed
+  한다.
+- TDD RED는 Node 22건 중 5건 실패(helper/validator 2, 순서 1, timeout/mismatch 2)였고,
+  구현 후 22/22 통과했다. writer는 실행 중인 Electron/CDP target에 접근하거나
+  종료하지 않았고 실제 HKCU 및 Git 외부 상태도 변경하지 않았다.
+
+##### Live QA entry-animation correction (2026-08-27)
+
+- readiness 적용 후 1920x1080/DPR 1.5 live capture에서 viewport/DPR과 App scale
+  `1.125`는 정확했지만 delete와 primary rect가 각각 `43.2px`, `38.88px`로 측정됐다.
+  unscaled 값 `38.4px`, `34.56px`는 목표 크기의 정확히 0.96배이며, modal의
+  0.16/0.18초 entry CSS animation initial transform과 일치하므로 2 RAF만으로 animation
+  완료를 보장하지 못한 race로 판정했다.
+- readiness는 game-path modal overlay/modal/confirm overlay 및 그 내부 dialog subtree의
+  실행 중인 Web Animation 중 `endTime <= 1000ms`이고 endTime/iterations가 유한한
+  항목만 기다린다. 문서 전체 animation, Toast lifecycle, 장기 및 무한 animation은
+  수집하지 않는다. allowlisted animation 완료 후 2 RAF와 marker/scale/viewport를 다시
+  확인하며, animation cancellation/rejection은 `owned animation rejected`로 fail closed
+  한다.
+- animation await 순서 canary와 전역 dialog selector 배제 canary는 각각 수정 전 Node
+  22건 중 1건 실패를 확인했고, 최종 22/22 통과했다. writer는 실행 중인
+  Electron/CDP target에 접근하거나 종료하지 않았다.
+
+##### Live QA scale-aware nested geometry correction (2026-08-27)
+
+- live capture에서 diagnostic 3개 scenario와 selection 1024x683/1440x960은 통과했고,
+  selection 1920x1080/DPR 1.5만 nested overlay edge의 고정 1px tolerance에서 실패했다.
+  해당 scenario의 App scale `1.125`가 정확하고 overlay inset이 modal의 1 CSS px border
+  안쪽이므로 물리 edge delta 약 `1.125px`는 제품 clipping이 아니라 scale된 border다.
+- nested overlay containment와 edge coverage에만 `1 CSS px border + 0.25 CSS px bounded
+subpixel tolerance`를 적용한다. 물리 containment allowance는 `appScale * 1.25`, edge
+  delta는 `appScale`로 나눈 CSS px 값으로 판정한다. outer modal의 viewport clipping
+  tolerance와 다른 geometry assertion은 변경하지 않았다.
+- TDD RED는 23건 중 1건 실패로 1920x1080의 정상 1 CSS px inset을 재현했다. 수정 후
+  정상 inset 통과, 1.35 CSS px gap 및 allowance 밖 clipping 거부를 포함해 Node 23/23
+  통과했다. writer는 실행 중인 Electron/CDP target에 접근하거나 종료하지 않았다.
+
+##### Live QA launcher-splash visual blocker correction (2026-08-27)
+
+- 이전 hidden run은 DOM/manifest assertion 12개 scenario를 통과했지만, PNG 직접 검토에서
+  모든 화면이 `#launcher-splash`의 `POE UNOFFICIAL LAUNCHER / PREPARING ASSETS`로
+  덮여 있었다. 따라서 해당 run의 visual artifact는 무효이며 이후 증거로 supersede한다.
+  오케스트레이터가 exact run-owned profile/tmp/visual copy를 Recycle Bin으로 정리하고
+  Electron을 종료했다. writer가 이 cleanup이나 Electron 종료를 수행한 것은 아니다.
+- allowlisted game-path fixture parse 결과가 있을 때 renderer는 `createRoot` 전에 정적
+  `#launcher-splash`를 one-shot 제거한다. fixture 요청이 없으면 helper가 DOM을 변경하지
+  않으므로 기존 normal `Root`/`App` splash lifecycle은 그대로 유지된다.
+- capture state/manifest에는 `splashPresent`와 `splashVisible`을 포함하며 둘 다 반드시
+  `false`여야 한다. renderer TDD RED는 15건 중 1건, Node TDD RED는 23건 중 3건
+  실패였고 수정 후 각각 15/15, 23/23 통과했다. 최종 hidden Electron visual PASS는 아직
+  실행하거나 주장하지 않는다.
+
+##### Live QA compositor-activation correction (2026-08-27)
+
+- hidden fixture BrowserWindow가 layout-ready에 도달한 뒤에도 scenario별 `Page.navigate`
+  직후 compositor activation을 잃어 모든 `Page.captureScreenshot`이 timeout됐다. 같은
+  CDP target에 수동 `Page.bringToFront`를 호출하면 screenshot capture가 즉시 복구됐다.
+  그러나 첫 correction의 `navigate -> bringToFront -> waitForLayoutReady` placement는 live
+  rerun에서도 screenshot timeout이 지속되어 충분하지 않았다. 앞선 수동 진단은
+  `Page.captureScreenshot` 직전에 activation했을 때만 성공한 것으로 재확인됐다.
+- 세 번째 live rerun은 같은 장기 CDP WebSocket에서 pre-screenshot
+  `Page.bringToFront`를 호출한 두 번째 correction도 항상 timeout됨을 확인했다. 같은
+  run에서 exact 동일 target에 새 WebSocket을 열고 `Page.bringToFront`와
+  `Page.captureScreenshot`만 전송하면 즉시 61,546-byte PNG가 반환됐다. 따라서 문제는
+  placement가 아니라 navigation을 수행한 장기 session의 capture 경로에 국한된다.
+- 네 번째 live rerun에서는 fresh one-shot capture도 장기 observer WebSocket이 연결된 동안은
+  timeout됐고, 실패한 harness가 종료되어 observer가 닫힌 뒤에만 수동 fresh capture가
+  성공했다. 따라서 session 역할 분리만으로는 부족하며, 동일 target에 observer와 capture
+  connection이 동시에 존재하는 것이 실제 차단 조건임을 관찰했다.
+- 다섯 번째 live 진단은 동일 Node 프로세스에서 observer open/enable/close event를 완료하고
+  추가 500ms를 기다린 뒤 새 WebSocket을 열어도 `Page.captureScreenshot`이 timeout됨을
+  확인했다. 반면 별도 Node 프로세스는 같은 exact target에 연결해 `Runtime.evaluate` 없이도
+  즉시 61,546-byte PNG를 반환했다. 따라서 connection 동시성뿐 아니라 observer를 소유했던
+  Node 프로세스 자체가 남기는 상태가 capture 차단 조건이라는 process-level 증거가 됐다.
+- 여섯 번째 live run은 capture child를 분리해도 CDP observer를 먼저 소유했던 부모 process가
+  살아 있는 동안에는 child의 `Page.captureScreenshot`이 계속 timeout됨을 확인했다. 같은
+  exact target의 수동 capture는 그 부모 process가 종료된 뒤에만 성공했다. 따라서 capture만
+  child로 옮기는 구조도 충분하지 않으며, top-level orchestrator가 전체 수명 동안 CDP-free여야
+  한다는 최종 process isolation 경계가 확정됐다.
+- 일곱 번째 live run은 분리된 capture/validation worker 자체가 Runtime/Page/Log/Inspector를
+  enable하고 readiness/state evaluate를 수행한 뒤 screenshot을 요청하면 timeout됨을 확인했다.
+  같은 live target에서 별도 pure process가 1024x683 DPR1 metrics 적용,
+  `Page.bringToFront`, `Page.captureScreenshot` 세 명령만 보내면 즉시 61,546-byte PNG가
+  반환됐다. 따라서 process 분리뿐 아니라 screenshot process의 CDP command surface도 순수
+  캡처 세 명령으로 제한해야 한다는 최종 causal proof가 됐다.
+- 여덟 번째 live run은 screenshot timeout에는 진입하지 않았지만 navigation worker가 성공적인
+  metrics/navigation/load 뒤 WebSocket close handshake의 `Observer WebSocket close failed`로
+  즉시 실패했다. dedicated child-process 경계에서는 성공 payload 뒤 process exit가 CDP session을
+  결정적으로 해제하므로 이 close 오류만 worker 실패로 승격하지 않는다. operation 실패는 그대로
+  실패하며, operation과 close가 모두 실패하면 두 원인을 `AggregateError`로 보존한다. 이 정책은
+  navigation/validation client helper에만 적용하며 pure screenshot의 세-command 및 close 계약은
+  변경하지 않았다.
+- 아홉 번째 live run에서 pure screenshot worker 단독 실행은 exit 0이었지만 validation worker 종료
+  후 250ms만 기다린 실행은 다시 screenshot timeout이 발생했고, 동일 조건에서 1000ms를 기다린
+  실행은 exit 0이었다. 부모는 validation payload와 assertion이 모두 성공한 뒤 scenario당 정확히
+  한 번의 bounded 1000ms CDP worker-detach settle을 기다린 다음 pure screenshot worker를 시작한다.
+  navigation 또는 validation 실패 시 settle과 screenshot은 모두 시작하지 않으며, pure worker의
+  metrics/bring-to-front/capture 세-command 계약은 변경하지 않았다.
+- 열 번째 live run에서는 1000ms detach settle 뒤에도 첫 pure screenshot worker가 간헐적으로
+  `Timed out waiting for pure CDP command Page.captureScreenshot`으로 실패했다. 첫 worker가 10초
+  command timeout 뒤 종료되면 그 시간이 추가 detach interval이 되고, harness 종료 뒤 수동 pure
+  worker는 일관되게 성공했다. 부모는 첫 child가 정확히 이 내부 timeout 서명으로 nonzero 종료한
+  경우에만 brand-new pure worker process를 한 번 재실행한다. 다른 nonzero, malformed PNG,
+  ownership 또는 protocol 오류는 재시도하지 않는다. 두 번째 실패는 두 attempt 오류와
+  scenario/target context를 `AggregateError`로 보존하며, retry가 성공하기 전에는 artifact를 쓰지
+  않는다. 첫 시도 전 1000ms settle과 pure worker의 세-command 계약은 그대로 유지한다.
+- 최종 harness의 부모는 WebSocket, `/json/list`, CDP command를 직접 사용하지 않는다. 각
+  scenario마다 첫 navigation worker가 직전 exact run-owned target에 연결해 device metrics를
+  적용하고 `Page.navigate`와 load 완료까지 기다린 뒤 완전히 종료한다. 두 번째 validation
+  worker는 결과 target에 metrics를 재적용하고 기존 font/finite-animation readiness,
+  state 및 Runtime/Page/Log error를 수집·검증한 bounded JSON payload만 반환한 뒤 종료한다.
+  부모가 이 payload를 재검증한 후에만 세 번째 pure screenshot worker를 실행한다. pure worker는
+  `/json/list` exact match와 WebSocket open 후 metrics, `Page.bringToFront`,
+  `Page.captureScreenshot`만 수행하며 Runtime/Page/Log/Inspector enable과 evaluate를 절대
+  호출하지 않는다. 부모는 bounded raw PNG를 검증한 뒤에만 screenshot과 manifest를 쓴다.
+- Node canary는 수정 전 27건 중 7건 실패로 세 worker parser/runner, pure command surface와
+  CDP-free matrix 경계를 확인했다. 최종 28/28은 12개 scenario의 worker 36회 생성과 무중첩
+  nav→validation→screenshot 순서, 세 worker metrics 전달, pure 세-command exact contract,
+  exact argv/env/ownership, nonzero/timeout/oversized/malformed/foreign cleanup 및
+  navigation/validation/screenshot 실패 artifact 0건을 포함한다.
+- 이 correction은 정적 harness 검증만 수행했다. 최종 hidden Electron capture와 visual
+  PASS는 아직 재실행하거나 주장하지 않는다.
+
+- 기존 `cdp-capture.cjs`와 `hidden-electron-launch.cjs`는 변경하지 않고,
+  `scripts/qa/game-path-diagnostic-capture.cjs`와 전용 Node test만 추가한다. 입력은
+  `CDP_PORT`, exact `CDP_TARGET_URL`, explicit absolute `GAME_PATH_QA_OUTPUT_DIR`만 읽는다.
+- target URL은 `http://localhost:54321/`의 valid `codexQaRun` + allowlisted
+  `codexQaFixture`만 허용한다. output은 `<runId>/game-path-diagnostic-capture` 소유 구조를
+  강제하고, repository 내부라면 `.tmp/electron/<runId>/game-path-diagnostic-capture`만
+  허용한다. 스크립트 안에는 cleanup/delete 동작을 두지 않는다.
+- `diagnostic`, `selection`, `partial`, `delete`를 각각 1024x683@DPR1,
+  1440x960@DPR1.25, 1920x1080@DPR1.5와 paired해 총 12 scenario를 exact owned URL로
+  순회한다. 이 값은 `Emulation.setDeviceMetricsOverride`의 simulated viewport/DPR이며
+  실제 Windows OS DPI 검증이 아니다.
+- scenario마다 Runtime/Page/Log error 부재, fixture marker/dialog count, modal containment,
+  header/footer visibility, 좌측 registry/우측 config 2열, selection CTA/defaults, partial
+  failed-only retry, exact delete confirmation, nested inert/ARIA modality를 구조화 assertion으로
+  판정한 뒤 PNG를 쓰고, 마지막에 simulation disclaimer와 scenario evidence를 포함한
+  `manifest.json`을 기록한다.
+- TDD RED는 capture module 부재로 Node suite가 실패했고, screenshot 단계 protocol error가
+  다음 scenario로 늦게 귀속되는 canary는 18 tests 중 1건이 의도대로 실패했다. 최종 Node
+  GREEN은 18/18이다. 실제 Electron/CDP capture는 이 writer 단계에서 실행하지 않았다.
+- 최종 정적 회귀는 MS6.4-A targeted Vitest 2 files / 26 tests, `npm run lint`, 새 CJS 두
+  파일의 direct ESLint, touched-file Prettier와 `git diff --check`가 모두 통과했다. actual
+  HKCU, Electron, branch/commit/stage/push/PR 및 외부 상태 변경은 각각 0건이다.
+
+##### Final hidden Electron run evidence (2026-08-27)
+
+- 최종 hidden Electron run ID는 `ms64-20260827-234500-a6c8e2d4`이고 isolated profile은
+  `C:\Users\nerdl\AppData\Local\Temp\poe2-unofficial-launcher-codex-qa\ms64-20260827-234500-a6c8e2d4`였다.
+  capture는 exit 0으로 완료됐으며 `diagnostic`, `selection`, `partial`, `delete` 네 mode의
+  12개 scenario에서 PNG 12개와 manifest 1개를 생성했다.
+- manifest의 protocol error는 0건이고 모든 scenario assertion이 `true`였다. 확인 범위는
+  splash absence, App scale, viewport/modal containment, wide viewport two-column layout,
+  document/body/modal scroll containment, long path wrapping, 주요 hit target, nested
+  modality/focus/overlay 및 mode-specific selection/partial/delete 계약을 포함한다.
+- 1024 viewport의 네 mode와 1920 viewport의 `selection`/`partial` PNG를 직접 시각 검토했다.
+  여섯 화면은 mode별 내용이 구분됐고 launcher splash, clipping 또는 잘린 주요 control이 없었다.
+- 이 결과의 100/125/150 값은 CDP viewport/deviceScaleFactor simulation이다. 실제 Windows OS
+  DPI 설정은 변경하거나 검증하지 않았으므로 actual OS DPI 통과 근거로 사용하지 않는다.
+- 검증 종료 후 Electron launcher, child process와 CDP endpoint가 모두 종료됐음을 확인했다.
+  exact run-owned profile, repository temp 및 ready marker만 Recycle Bin으로 이동했고, 기존의 더
+  오래된 QA folder는 건드리지 않았다.
+- 보존 증거는
+  `C:\Users\nerdl\.codex\visualizations\2026\08\22\01a02845-0014-7ac0-90d0-aee29881b09b\ms6.4-game-path-diagnostic-ms64-20260827-234500-a6c8e2d4`에 있다.
+  PNG 12개와 manifest 1개, 총 13개 파일의 이름과 크기가 원본 evidence와 일치했다.
+
+**DoD**
+
+- [Windows-pwsh] hidden Electron + isolated profile에서 1024x683, 1440x960, 1920x1080 및
+  CDP simulated DPR 1/1.25/1.5의 outer/nested dialog를 12개 screenshot과 manifest로 판정했다.
+  실제 사용자 HKCU 자동 QA는 수행하지 않았다.
+- [사용자] native folder dialog가 registry candidate 우선의 실존 directory를
+  `defaultPath`로 열고, 후보가 없으면 `defaultPath`를 생략하는지 확인한다.
+- [사용자] 실제 사용자 HKCU에서 선택한 primary/compatibility/config 적용, target별
+  read-back, 부분 실패 보존과 failed-only retry를 확인한다.
+- [사용자] 실제 Windows OS DPI 100/125/150%에서 clipping, scroll, path wrapping, hit target,
+  nested modality/focus/overlay를 확인한다.

--- a/package-lock.json
+++ b/package-lock.json
@@ -2067,9 +2067,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.142.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.142.0.tgz",
-      "integrity": "sha512-7W+2q5AKQVU36fkaryontrHn3YDt1RyUYXatw9i5H8ocYe2sPKSFB6eS8WNPeRKiN1qAWWZUPm7gwFzJGrccqQ==",
+      "version": "0.146.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.146.0.tgz",
+      "integrity": "sha512-XC0QsnnhVe7sLIWmYmdPw7x5P0h4W8vUU3Nv1ySgWXtvCz8NizoAEpGXA0sOYoJQV2Rl13LgURAHQ5cI5ILCSA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -2135,10 +2135,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@rolldown/binding-android-arm-eabi": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm-eabi/-/binding-android-arm-eabi-1.2.5.tgz",
+      "integrity": "sha512-DLe/i+l8ynIBY7XEQ191TeZvCoowIGa18R+dIV30GW7DiOtp74i/xX8hs8GUjW5ARV7VZuie3d6AumSmCwbeRA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.1.tgz",
-      "integrity": "sha512-02hOeOSryYxVrOIphmLAsqnCJWxwlzFk+pEt/N/i6OgT3lShHO7xGCU5cpgchRDHboAEbSjzgGh+O/u1GswQmA==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.5.tgz",
+      "integrity": "sha512-zXcwKlQApYAOELHd8PwKDFkagYF9Wy4e0RJ+0qnzl9Pjnpj75TEG8ufv40p2J7kCEfwZAsNiuzRIyNNMWT38ig==",
       "cpu": [
         "arm64"
       ],
@@ -2153,9 +2170,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.1.tgz",
-      "integrity": "sha512-fMsTOnN0OjFm3CyppWPitKnc8UlliVARUULW6cfU6AIqjdtgmSFWSk9vecHzZduv/yMWIHDlRhM1e8Iff9uAfA==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.5.tgz",
+      "integrity": "sha512-dK4QakI42nzWgJT5sm4y4y/O//D4OxM75/cH28RLV+nzIN9AY+YsbuUVrUTjlLjXR6vpyxFbSsbmNuJ6BP9sww==",
       "cpu": [
         "arm64"
       ],
@@ -2170,9 +2187,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.1.tgz",
-      "integrity": "sha512-1wjKdz/XLGKHaTNHjQveQ/B23TKx4ItAqm1JbyVuvNPc4Ze0Fb48s49TAd/2zcplPl8okE/UbTgmlVfwT7eFeQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.5.tgz",
+      "integrity": "sha512-fqSALaUu1Wjd1nK2uW2kJDWdLCc8lx1IcY+MTY26Aurfdx19anlzhqXOgCFbBFQnlFDTn4TC1/7Nz4Bl2mLP3A==",
       "cpu": [
         "x64"
       ],
@@ -2187,9 +2204,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.1.tgz",
-      "integrity": "sha512-Fa0jHR07E7YBN4vOEsbVf2briYNsuOowfLJaXULZM0ldMlaCaj2LJgLMbMe4iacRyZmvR8efFhgR9wKuGclQUg==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.5.tgz",
+      "integrity": "sha512-/vCnNxlkxs9tKxNDcyWUePpJ/PgTzxIaVhoM5SmG8UV+GR/IcPam4VYxi7GIMo7PSDuNqlJqvprqii9NqqVCMw==",
       "cpu": [
         "x64"
       ],
@@ -2204,9 +2221,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.1.tgz",
-      "integrity": "sha512-pzkgu1SSHGgRRyRZ4fbmSgmajbVt+epaLP99NDjFft69v/ypfTi6swBMiVdh2EkQ0OSnHE1lZDM7DRGkyAzUpA==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.5.tgz",
+      "integrity": "sha512-abk0NLA519LxRCszmbE0jYKuQ9YPocOXTiOXOo6Yr+YAT95VH+PtqYAjOJvGKt3viEd/x4qzabAlwd5bHOOARg==",
       "cpu": [
         "arm"
       ],
@@ -2221,9 +2238,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.1.tgz",
-      "integrity": "sha512-QI5SEDY8cbiYWHx0VO4vIc3UlS6a32vXHjU8Qy/17adEmZIPuByJg13UEvo9c/UCiUkdcVWY83C+b+JrwnNyUg==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.5.tgz",
+      "integrity": "sha512-Y7eALiJ8lr0M2HH103Js+g7V34wf6snlpZLAsHI90uLhr3PVlNsbFVAXJC9d/V6BnPyKtpSwI+NcB/RLxsQxuA==",
       "cpu": [
         "arm64"
       ],
@@ -2241,9 +2258,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.1.tgz",
-      "integrity": "sha512-Sm41FyCeXqmYcERoYOCbGIL5hNfd8w9LQ7Y61Bev48HkcjaJqV/iiVOaiDxjVTRMS+QKrZmD8cfPt4uMVnvM+A==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.5.tgz",
+      "integrity": "sha512-xMvZgnbZg4YVnR/AX2b3oOPDTFYJvUVaJg5FedA/LuvexAtXibZQej4cnTkw3rjsJ/ggUROB64TdtETiim+FYA==",
       "cpu": [
         "arm64"
       ],
@@ -2261,9 +2278,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.1.tgz",
-      "integrity": "sha512-2x+WhXTGl9yJYPbltW/BSEPTVz9OIWQyER4N+gJEDWkkn904eRcBzELqh/Hf7K0w/ubGbKNMv0ZC+94QK/IFEg==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.5.tgz",
+      "integrity": "sha512-GRjeqTUDHTo5GwntsLaAMcBahG3nlpjftXWZLN73HiYQlhwEowvarFgQnRnQZtIp4keXX7quXFbG38uPZBa2EA==",
       "cpu": [
         "ppc64"
       ],
@@ -2281,9 +2298,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.1.tgz",
-      "integrity": "sha512-eEjmQpuRQayHPWWnywaWHkFT3ToPbP3RYy42VVd/B9aBGDA+Ol25EIWHxKQST3IiWJjikCWUF7KtbfqwZrzVwQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.5.tgz",
+      "integrity": "sha512-vLNTR45F2Uwc8AufkNXPmB4VliaXs+FvcheEogIzOXzO4l+LzieXF5A/TWxLy5HtqpsRCHUfd0lPVrrdgXdLHQ==",
       "cpu": [
         "s390x"
       ],
@@ -2301,9 +2318,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.1.tgz",
-      "integrity": "sha512-/Orga1fZYkLc/56jBICcHrKchl8Z2UKdDSr3LG9ToWO1lQ6a4Livk9Xz+9WN91zsz5QR3XQz2NNoSDEvP6qadw==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.5.tgz",
+      "integrity": "sha512-Mgj59/HTuYeK9Gz2MA+mBWKnHsAgkBSec15ZMb1st3oIfFbX7gCjOae7GydHhzcyQi9Z/7M1QuN9bR3oFqF0jQ==",
       "cpu": [
         "x64"
       ],
@@ -2321,9 +2338,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.1.tgz",
-      "integrity": "sha512-xxBJRL+0q0Kce7orznGWLuylHDY65vuARXZRpX+hPdv+DqK2c3NlCsVA98tlWzWNEE7yPqA/1NQ5nnCrj49Y5A==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.5.tgz",
+      "integrity": "sha512-mY8AP0/ichsbhAxGnLa3d3+MwV0EfgrPND2bplI3Ym8T6R2pJ0N87bvrKVwNXmdy3jnr6eQBecdqx/HMknBmpA==",
       "cpu": [
         "x64"
       ],
@@ -2341,9 +2358,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.1.tgz",
-      "integrity": "sha512-M6AdXIXw3s+/8XpKMzdGDEXGS1S7kwUsy+rcTIUIOx5Ge4nXKCtAFHFV9YKkXvGcC5WMoTjAteLzlsQROVI0Yw==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.5.tgz",
+      "integrity": "sha512-8SLssA2oweAxyRgDp789ACfRb/3P+zNRJpzZxSizxF9m8NUDQ4+3xjo8ttjhVGGw6Qxb70oZiEtIjaKikCO7Yw==",
       "cpu": [
         "arm64"
       ],
@@ -2357,60 +2374,10 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.2.1.tgz",
-      "integrity": "sha512-/TX0SoRGojHzSAHpfVBbavRVSazg5U3h3Y3VXfcc0cdugq6kxdqw8LPGFiPr+/7gE/60zRcsOY2Vi9b9eT0jww==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/core": "2.0.0-alpha.3",
-        "@emnapi/runtime": "2.0.0-alpha.3",
-        "@napi-rs/wasm-runtime": "^1.2.0"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=23.5.0"
-      }
-    },
-    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "2.0.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-2.0.0-alpha.3.tgz",
-      "integrity": "sha512-AZypUeJ/yByuxyS7BlSNRDOMLMlROYtjYdIAuBmJssVz1UJDSeYxLrdizhXCFYhedC5bqd/ASy8EuNXbVVXp9g==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "2.0.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
-      "version": "2.0.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-2.0.0-alpha.3.tgz",
-      "integrity": "sha512-hFPAhMUjJD9BSyCANEISPOogeXC9Zo9ZQl7L6vKnaVsMkCtzznaW/naYypeyl0Gv5rYfWYsZbpixTMpjDJzQeA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-2.0.1.tgz",
-      "integrity": "sha512-9DsSk+o5NBX0CCJT8s0EROGSGxjR/tKu6aBTaVyq+SjAEQH4XcdcRxPBRzsBLizTTJ49MJjF+jgu3qnO9GLQcQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.1.tgz",
-      "integrity": "sha512-EvRrivJieyHG+AO9lleZWgq+g0+S7oV2C51yuqlcyU/R9net+sI4Pj0F+lUoP2bEr6TWX3SqFaaS0SzfLxSzkw==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.5.tgz",
+      "integrity": "sha512-vGbruD5zquhoc8D9SViXgN2FBJtNdTyQ4DtG+SWiEGlJiAzoKcZ2xp+xuXCffhubVdt0NJlTZqkeRuERy7g8Cw==",
       "cpu": [
         "arm64"
       ],
@@ -2425,9 +2392,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.1.tgz",
-      "integrity": "sha512-Z4eCmn5QJ/5+azF9knpLWKfVd9aidn0mAe9TpJgvBLId9Ax3t0+JVxBmT25Bv7NBbVW1TZyKjQjQReouMeH5UQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.5.tgz",
+      "integrity": "sha512-e/SXpgISz+IoqVcSSI0rx/d/he8zqLex+/rCWpnHpmVfmPIUjag9H6P7zotf0gJHwPUhQxZ/mF8tr6acebT9yw==",
       "cpu": [
         "x64"
       ],
@@ -3302,9 +3269,9 @@
       ]
     },
     "node_modules/@vitejs/plugin-react": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.5.tgz",
-      "integrity": "sha512-BOVzne/NL162sMdResB25mUv+vWMF5NoAjNf09TeGlE7ZpszZWSD3winycicLJw72yeVsoCn/2kOhEuCvEShMA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.1.0.tgz",
+      "integrity": "sha512-qd2BzUBehkov86WFhg0JkEFEYyCLG9uPCe6qWTY/kRlss9OvJrOF2UbIWT7p+8IzZHkEu0DNGHc4HSv+JdDLsw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3316,6 +3283,7 @@
       "peerDependencies": {
         "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0",
         "babel-plugin-react-compiler": "^1.0.0",
+        "oxc-transform-react": "^0.145.0",
         "vite": "^8.0.0"
       },
       "peerDependenciesMeta": {
@@ -3324,20 +3292,23 @@
         },
         "babel-plugin-react-compiler": {
           "optional": true
+        },
+        "oxc-transform-react": {
+          "optional": true
         }
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
-      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.11.tgz",
+      "integrity": "sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.10",
-        "@vitest/utils": "4.1.10",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -3346,13 +3317,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
-      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.11.tgz",
+      "integrity": "sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.10",
+        "@vitest/spy": "4.1.11",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -3373,9 +3344,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
-      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.11.tgz",
+      "integrity": "sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3386,13 +3357,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
-      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.11.tgz",
+      "integrity": "sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.10",
+        "@vitest/utils": "4.1.11",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -3400,14 +3371,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
-      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.11.tgz",
+      "integrity": "sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.10",
-        "@vitest/utils": "4.1.10",
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/utils": "4.1.11",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -3416,9 +3387,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
-      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.11.tgz",
+      "integrity": "sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -3426,13 +3397,13 @@
       }
     },
     "node_modules/@vitest/ui": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-4.1.10.tgz",
-      "integrity": "sha512-EOUqfXHTXtpSHsyLHH40ts3Ue+hRhSGwzwzMlK0dTEOLSDYyOXLyr5JDGmHQWhN2DYI30gw6dVx3cdgM9FZl+Q==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-4.1.11.tgz",
+      "integrity": "sha512-r/rwyKoev21mWdRGSEkZOqkQ2BYy68mwjihg9M90nNRbf4NGrgzZ4cj6JNCEwlOGJkbKeMgsjlykvwKUbRr7gw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.10",
+        "@vitest/utils": "4.1.11",
         "fflate": "^0.8.2",
         "flatted": "^3.4.2",
         "pathe": "^2.0.3",
@@ -3444,17 +3415,17 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "vitest": "4.1.10"
+        "vitest": "4.1.11"
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
-      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.11.tgz",
+      "integrity": "sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.10",
+        "@vitest/pretty-format": "4.1.11",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -4871,9 +4842,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.13",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
-      "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
+      "version": "3.4.14",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.14.tgz",
+      "integrity": "sha512-dVoH9z+MY+C9IilgGCk3YfFqjLi3fChm2OiKJMzh6axrJ5qwxqWaZamgmHrpv22CN/KdbZJuGEGgfQoL00LTdg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -5011,9 +4982,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "43.4.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-43.4.0.tgz",
-      "integrity": "sha512-3qxGF0CeQbiox5oWV1JlbWGQ1VerbmDhTFqW4sJ8h7uqTHniFYPObXJcDna0DMh32et0fFyKzz0YY8lJv3t5jg==",
+      "version": "43.4.1",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-43.4.1.tgz",
+      "integrity": "sha512-5b+EuiwkgG5iRcsEL34rimgRpkYp15SsfZOa0pC5kXs0Tb82TH4n95rpQzTZa7yRCbA7tm0WoEbuBL6NaAhAcA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7284,9 +7255,9 @@
       }
     },
     "node_modules/marked": {
-      "version": "18.0.9",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.9.tgz",
-      "integrity": "sha512-/Sa4qiiHZxf0/FQdBBowr9q4r10krCwMvpK48FUBdXdUXScDxiQGR9zCPrFgRVR5LU3iySOiIjy09ZQvADir1w==",
+      "version": "18.0.10",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.10.tgz",
+      "integrity": "sha512-FJeH4bRpYoXiggcgriCGItKCSv3xkngJc4QCZ/rkQCogU3VYaLxYJoZl8Nw/b4+x7iij/pd+09mZ6A1dXzpL0A==",
       "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"
@@ -7506,9 +7477,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -8004,9 +7975,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.25",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
-      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -8024,7 +7995,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.16",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -8383,13 +8354,13 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.1.tgz",
-      "integrity": "sha512-4FKJhg8d3OiyQOA6Q1Q0hoFFpW9/OoX+VsHzpECsdsIZoOArrAK90gl59YK/Z+gnDel45bgJZK03ozH/9bCqEw==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.5.tgz",
+      "integrity": "sha512-VD2IE5PUG4Oj8zz2VGykiYd5wbnjdIiSsNQb8Qu5B+noEp+A78mu2iVvpp27g8es14Tk9rofNs5Tku9iQCS4fA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.142.0",
+        "@oxc-project/types": "=0.146.0",
         "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
@@ -8399,21 +8370,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.2.1",
-        "@rolldown/binding-darwin-arm64": "1.2.1",
-        "@rolldown/binding-darwin-x64": "1.2.1",
-        "@rolldown/binding-freebsd-x64": "1.2.1",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.2.1",
-        "@rolldown/binding-linux-arm64-gnu": "1.2.1",
-        "@rolldown/binding-linux-arm64-musl": "1.2.1",
-        "@rolldown/binding-linux-ppc64-gnu": "1.2.1",
-        "@rolldown/binding-linux-s390x-gnu": "1.2.1",
-        "@rolldown/binding-linux-x64-gnu": "1.2.1",
-        "@rolldown/binding-linux-x64-musl": "1.2.1",
-        "@rolldown/binding-openharmony-arm64": "1.2.1",
-        "@rolldown/binding-wasm32-wasi": "1.2.1",
-        "@rolldown/binding-win32-arm64-msvc": "1.2.1",
-        "@rolldown/binding-win32-x64-msvc": "1.2.1"
+        "@rolldown/binding-android-arm-eabi": "1.2.5",
+        "@rolldown/binding-android-arm64": "1.2.5",
+        "@rolldown/binding-darwin-arm64": "1.2.5",
+        "@rolldown/binding-darwin-x64": "1.2.5",
+        "@rolldown/binding-freebsd-x64": "1.2.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.5",
+        "@rolldown/binding-linux-arm64-musl": "1.2.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.5",
+        "@rolldown/binding-linux-x64-gnu": "1.2.5",
+        "@rolldown/binding-linux-x64-musl": "1.2.5",
+        "@rolldown/binding-openharmony-arm64": "1.2.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.5",
+        "@rolldown/binding-win32-x64-msvc": "1.2.5"
       }
     },
     "node_modules/sanitize-filename": {
@@ -9202,16 +9173,16 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.1.tgz",
-      "integrity": "sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==",
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.2.tgz",
+      "integrity": "sha512-cFKLV/PRgAUlIRm5WjMjJ86jrftzpqcgH+Us+DS8mI3CDNiH30Whrz8uHL3+MOLPAgqbMBAqWdAHAphOAM+z/Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.33.0",
         "picomatch": "^4.0.5",
-        "postcss": "^8.5.25",
-        "rolldown": "~1.2.1",
+        "postcss": "^8.5.26",
+        "rolldown": "~1.2.4",
         "tinyglobby": "^0.2.17"
       },
       "bin": {
@@ -9228,7 +9199,7 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.4.0",
+        "@vitejs/devtools": "^0.4.0 || ^0.5.0",
         "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
@@ -9298,19 +9269,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
-      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.11.tgz",
+      "integrity": "sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.10",
-        "@vitest/mocker": "4.1.10",
-        "@vitest/pretty-format": "4.1.10",
-        "@vitest/runner": "4.1.10",
-        "@vitest/snapshot": "4.1.10",
-        "@vitest/spy": "4.1.10",
-        "@vitest/utils": "4.1.10",
+        "@vitest/expect": "4.1.11",
+        "@vitest/mocker": "4.1.11",
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/runner": "4.1.11",
+        "@vitest/snapshot": "4.1.11",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -9338,12 +9309,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.10",
-        "@vitest/browser-preview": "4.1.10",
-        "@vitest/browser-webdriverio": "4.1.10",
-        "@vitest/coverage-istanbul": "4.1.10",
-        "@vitest/coverage-v8": "4.1.10",
-        "@vitest/ui": "4.1.10",
+        "@vitest/browser-playwright": "4.1.11",
+        "@vitest/browser-preview": "4.1.11",
+        "@vitest/browser-webdriverio": "4.1.11",
+        "@vitest/coverage-istanbul": "4.1.11",
+        "@vitest/coverage-v8": "4.1.11",
+        "@vitest/ui": "4.1.11",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
     "format": "prettier --write .",
+    "audit:kakao-registry-source": "node scripts/check-kakao-registry-source.cjs",
     "roadmap:issue-body": "node scripts/build-roadmap-issue-body.cjs",
     "roadmap:notice": "node scripts/build-roadmap-notice.cjs",
     "test": "vitest",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "setup": "node -e \"if(!require('fs').existsSync('node_modules')) { require('child_process').execSync('npm install', {stdio: 'inherit'}) }\"",
     "dev": "chcp 65001 && vite",
-    "dev:wsl": "command -v pwsh.exe >/dev/null && PS=pwsh.exe || PS=powershell.exe; \"$PS\" -NoProfile -Command \"chcp 65001; npm run dev\"",
+    "dev:wsl": "node .agents/skills/windows-electron-debugging/scripts/run-hidden-windows.cjs detached --cwd . --stdout .tmp/electron/{runId}.stdout.log --stderr .tmp/electron/{runId}.stderr.log --metadata .tmp/electron/{runId}.metadata.json --ready-file .tmp/electron/{runId}.ready.json --ready-timeout-ms 35000 -- @node scripts/qa/hidden-electron-launch.cjs --ready-file .tmp/electron/{runId}.ready.json --renderer-target http://localhost:54321/ --timeout-ms 30000",
     "dev:crash:immediate": "chcp 65001 && cross-env VITE_TEST_CRASH_MODE=IMMEDIATE vite",
     "dev:crash:delayed": "chcp 65001 && cross-env VITE_TEST_CRASH_MODE=DELAYED vite",
     "dev:crash:null": "chcp 65001 && cross-env VITE_TEST_CRASH_MODE=NULL_REF vite",

--- a/scripts/check-kakao-registry-source.cjs
+++ b/scripts/check-kakao-registry-source.cjs
@@ -1,0 +1,228 @@
+#!/usr/bin/env node
+
+const REQUEST_TIMEOUT_MS = 15_000;
+
+const EXPECTED_SOURCES = [
+  {
+    gameId: "POE",
+    documentKey: "poe",
+    url: "https://common.gdn.gamecdn.net/live/config/kakaogames/poe.gamestarter.json",
+    expected: {
+      RegistryRoot: "HKCU",
+      RegistryPath: [
+        "SOFTWARE\\Kakaogames\\POE",
+        "SOFTWARE\\DaumGames\\POE",
+      ],
+    },
+  },
+  {
+    gameId: "POE2",
+    documentKey: "poe2",
+    url: "https://common.gdn.gamecdn.net/live/config/kakaogames/poe2.gamestarter.json",
+    expected: {
+      RegistryRoot: "HKCU",
+      RegistryPath: [
+        "SOFTWARE\\Kakaogames\\POE2",
+        "SOFTWARE\\DaumGames\\POE2",
+      ],
+    },
+  },
+];
+
+function isRecord(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function extractRegistryContract(document, documentKey) {
+  const issues = [];
+
+  if (!isRecord(document)) {
+    return {
+      contract: null,
+      issues: ["root must be a JSON object"],
+    };
+  }
+
+  if (!isRecord(document[documentKey])) {
+    return {
+      contract: null,
+      issues: [`${documentKey} must be a JSON object`],
+    };
+  }
+
+  const gameDocument = document[documentKey];
+  if (!isRecord(gameDocument.live)) {
+    return {
+      contract: null,
+      issues: [`${documentKey}.live must be a JSON object`],
+    };
+  }
+
+  const fieldPrefix = `${documentKey}.live`;
+  const registryRoot = gameDocument.live.RegistryRoot;
+  const registryPath = gameDocument.live.RegistryPath;
+
+  if (typeof registryRoot !== "string") {
+    issues.push(`${fieldPrefix}.RegistryRoot must be a string`);
+  }
+
+  if (
+    !Array.isArray(registryPath) ||
+    registryPath.some((item) => typeof item !== "string")
+  ) {
+    issues.push(`${fieldPrefix}.RegistryPath must be an array of strings`);
+  }
+
+  return {
+    contract:
+      issues.length === 0
+        ? {
+            RegistryRoot: registryRoot,
+            RegistryPath: [...registryPath],
+          }
+        : null,
+    issues,
+  };
+}
+
+function compareRegistryContract(actual, expected, documentKey) {
+  const issues = [];
+  const fieldPrefix = `${documentKey}.live`;
+
+  if (actual.RegistryRoot !== expected.RegistryRoot) {
+    issues.push(
+      `${fieldPrefix}.RegistryRoot: expected ${JSON.stringify(expected.RegistryRoot)}, received ${JSON.stringify(actual.RegistryRoot)}`,
+    );
+  }
+
+  if (actual.RegistryPath.length !== expected.RegistryPath.length) {
+    issues.push(
+      `${fieldPrefix}.RegistryPath length: expected ${expected.RegistryPath.length}, received ${actual.RegistryPath.length}`,
+    );
+  }
+
+  const pathCount = Math.max(
+    actual.RegistryPath.length,
+    expected.RegistryPath.length,
+  );
+  for (let index = 0; index < pathCount; index += 1) {
+    if (actual.RegistryPath[index] !== expected.RegistryPath[index]) {
+      issues.push(
+        `${fieldPrefix}.RegistryPath[${index}]: expected ${JSON.stringify(expected.RegistryPath[index])}, received ${JSON.stringify(actual.RegistryPath[index])}`,
+      );
+    }
+  }
+
+  return issues;
+}
+
+async function auditSource(source) {
+  let response;
+  try {
+    response = await fetch(source.url, {
+      headers: { accept: "application/json" },
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    });
+  } catch (error) {
+    return {
+      gameId: source.gameId,
+      kind: "NETWORK FAILURE",
+      url: source.url,
+      issues: [
+        `network request failed: ${error instanceof Error ? error.message : String(error)}`,
+      ],
+    };
+  }
+
+  if (!response.ok) {
+    return {
+      gameId: source.gameId,
+      kind: "NETWORK FAILURE",
+      url: source.url,
+      issues: [`network request failed: HTTP ${response.status}`],
+    };
+  }
+
+  let document;
+  try {
+    document = await response.json();
+  } catch (error) {
+    return {
+      gameId: source.gameId,
+      kind: "INVALID RESPONSE",
+      url: source.url,
+      issues: [
+        `response is not valid JSON: ${error instanceof Error ? error.message : String(error)}`,
+      ],
+    };
+  }
+
+  const extracted = extractRegistryContract(document, source.documentKey);
+  if (!extracted.contract) {
+    return {
+      gameId: source.gameId,
+      kind: "SHAPE DRIFT",
+      url: source.url,
+      issues: extracted.issues.map((issue) => `source shape drift: ${issue}`),
+    };
+  }
+
+  const issues = compareRegistryContract(
+    extracted.contract,
+    source.expected,
+    source.documentKey,
+  );
+  return {
+    gameId: source.gameId,
+    kind: issues.length === 0 ? null : "VALUE DRIFT",
+    url: source.url,
+    issues,
+  };
+}
+
+async function main() {
+  process.stdout.write(
+    "Auditing KakaoGames registry source contracts (opt-in network check).\n",
+  );
+
+  const results = await Promise.all(EXPECTED_SOURCES.map(auditSource));
+  let failed = false;
+
+  for (const result of results) {
+    if (result.issues.length === 0) {
+      process.stdout.write(`[OK] ${result.gameId}: ${result.url}\n`);
+      continue;
+    }
+
+    failed = true;
+    process.stderr.write(`[${result.kind}] ${result.gameId}: ${result.url}\n`);
+    for (const issue of result.issues) {
+      process.stderr.write(`  - ${issue}\n`);
+    }
+  }
+
+  if (failed) {
+    process.stderr.write(
+      "KakaoGames registry source audit failed. Review publisher changes before updating the versioned runtime mapping.\n",
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  process.stdout.write("KakaoGames registry source contracts match.\n");
+}
+
+if (require.main === module) {
+  void main().catch((error) => {
+    process.stderr.write(
+      `Unexpected KakaoGames registry source audit failure: ${error instanceof Error ? error.stack || error.message : String(error)}\n`,
+    );
+    process.exitCode = 1;
+  });
+}
+
+module.exports = {
+  EXPECTED_SOURCES,
+  compareRegistryContract,
+  extractRegistryContract,
+};

--- a/scripts/qa/cdp-capture.cjs
+++ b/scripts/qa/cdp-capture.cjs
@@ -1,3 +1,5 @@
+"use strict";
+
 const fs = require("node:fs");
 const path = require("node:path");
 

--- a/scripts/qa/game-path-diagnostic-capture.cjs
+++ b/scripts/qa/game-path-diagnostic-capture.cjs
@@ -1,0 +1,1792 @@
+#!/usr/bin/env node
+"use strict";
+
+/* eslint-disable @typescript-eslint/no-require-imports */
+/* global AbortSignal, Buffer, WebSocket, __filename, clearTimeout, fetch, module, process, require, setTimeout, URL */
+
+const fs = require("node:fs");
+const path = require("node:path");
+const { spawn } = require("node:child_process");
+
+const FIXTURE_MODES = ["diagnostic", "selection", "partial", "delete"];
+const VIEWPORTS = [
+  { viewportLabel: "1024x683", width: 1024, height: 683, deviceScaleFactor: 1 },
+  {
+    viewportLabel: "1440x960",
+    width: 1440,
+    height: 960,
+    deviceScaleFactor: 1.25,
+  },
+  {
+    viewportLabel: "1920x1080",
+    width: 1920,
+    height: 1080,
+    deviceScaleFactor: 1.5,
+  },
+];
+const CAPTURE_DIRECTORY_NAME = "game-path-diagnostic-capture";
+const MANIFEST_FILE_NAME = "manifest.json";
+const QA_RUN_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{7,127}$/;
+const TARGET_QUERY_KEYS = new Set(["codexQaRun", "codexQaFixture"]);
+const SELECTED_PATH = String.raw`C:\Games\Kakao Games\Path of Exile 2`;
+const CDP_COMMAND_TIMEOUT_MS = 10_000;
+const LAYOUT_READY_TIMEOUT_MS = 5_000;
+const NAVIGATION_WORKER_ARGUMENT = "--game-path-navigation-worker";
+const VALIDATION_WORKER_ARGUMENT = "--game-path-validation-worker";
+const PURE_SCREENSHOT_WORKER_ARGUMENT = "--game-path-pure-screenshot-worker";
+const CAPTURE_WORKER_TIMEOUT_MS = 35_000;
+const CAPTURE_WORKER_TERMINATION_GRACE_MS = 2_000;
+const CAPTURE_WORKER_MAX_OUTPUT_BYTES = 16 * 1024 * 1024;
+const CAPTURE_WORKER_MAX_ERROR_BYTES = 64 * 1024;
+const PNG_SIGNATURE = Buffer.from([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+]);
+const NESTED_OVERLAY_BORDER_CSS_PX = 1;
+const NESTED_OVERLAY_SUBPIXEL_TOLERANCE_CSS_PX = 0.25;
+
+const isFixtureMode = (value) => FIXTURE_MODES.includes(value);
+
+const parseOwnedTargetUrl = (value) => {
+  let url;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error("CDP_TARGET_URL must be a valid URL");
+  }
+
+  const keys = [...url.searchParams.keys()];
+  const runIds = url.searchParams.getAll("codexQaRun");
+  const fixtureModes = url.searchParams.getAll("codexQaFixture");
+  if (
+    url.protocol !== "http:" ||
+    url.hostname !== "localhost" ||
+    url.port !== "54321" ||
+    url.pathname !== "/" ||
+    url.hash !== "" ||
+    url.username !== "" ||
+    url.password !== "" ||
+    keys.some((key) => !TARGET_QUERY_KEYS.has(key)) ||
+    runIds.length !== 1 ||
+    fixtureModes.length !== 1 ||
+    !QA_RUN_ID_PATTERN.test(runIds[0]) ||
+    !isFixtureMode(fixtureModes[0])
+  ) {
+    throw new Error(
+      "CDP_TARGET_URL must be the exact owned localhost game-path fixture target",
+    );
+  }
+
+  return { runId: runIds[0], fixtureMode: fixtureModes[0] };
+};
+
+const isPathInside = (parentPath, candidatePath) => {
+  const relative = path.relative(parentPath, candidatePath);
+  return (
+    relative === "" ||
+    (relative !== ".." &&
+      !relative.startsWith(`..${path.sep}`) &&
+      !path.isAbsolute(relative))
+  );
+};
+
+const resolveOwnedOutputDirectory = (value, projectRoot, runId) => {
+  if (!value || !path.isAbsolute(value)) {
+    throw new Error(
+      "GAME_PATH_QA_OUTPUT_DIR must be an explicit absolute path",
+    );
+  }
+
+  const outputDir = path.resolve(value);
+  if (
+    path.basename(outputDir) !== CAPTURE_DIRECTORY_NAME ||
+    path.basename(path.dirname(outputDir)) !== runId
+  ) {
+    throw new Error(
+      "GAME_PATH_QA_OUTPUT_DIR must be the exact run-owned capture directory",
+    );
+  }
+
+  const root = path.resolve(projectRoot);
+  if (isPathInside(root, outputDir)) {
+    const allowedRepositoryOutput = path.join(
+      root,
+      ".tmp",
+      "electron",
+      runId,
+      CAPTURE_DIRECTORY_NAME,
+    );
+    if (outputDir !== allowedRepositoryOutput) {
+      throw new Error(
+        "GAME_PATH_QA_OUTPUT_DIR inside the repository must use .tmp/electron/<runId>",
+      );
+    }
+  }
+
+  return outputDir;
+};
+
+const parseCaptureEnvironment = (environment, projectRoot = process.cwd()) => {
+  const portText = environment.CDP_PORT;
+  if (!portText || !/^\d+$/.test(portText)) {
+    throw new Error("CDP_PORT must be an integer between 1 and 65535");
+  }
+  const port = Number(portText);
+  if (!Number.isSafeInteger(port) || port < 1 || port > 65535) {
+    throw new Error("CDP_PORT must be an integer between 1 and 65535");
+  }
+
+  if (!environment.CDP_TARGET_URL) {
+    throw new Error("CDP_TARGET_URL is required");
+  }
+  const target = parseOwnedTargetUrl(environment.CDP_TARGET_URL);
+  const outputDir = resolveOwnedOutputDirectory(
+    environment.GAME_PATH_QA_OUTPUT_DIR,
+    projectRoot,
+    target.runId,
+  );
+
+  return {
+    port,
+    targetUrl: environment.CDP_TARGET_URL,
+    runId: target.runId,
+    initialMode: target.fixtureMode,
+    outputDir,
+  };
+};
+
+const parseWorkerPort = (value) => {
+  if (!/^\d+$/.test(value)) {
+    throw new Error("Internal game-path worker port is invalid");
+  }
+  const port = Number(value);
+  if (!Number.isSafeInteger(port) || port < 1 || port > 65535) {
+    throw new Error("Internal game-path worker port is invalid");
+  }
+  return port;
+};
+
+const resolveWorkerScenario = (
+  targetUrl,
+  scenarioId,
+  widthText,
+  heightText,
+  deviceScaleFactorText,
+) => {
+  const target = parseOwnedTargetUrl(targetUrl);
+  const width = Number(widthText);
+  const height = Number(heightText);
+  const deviceScaleFactor = Number(deviceScaleFactorText);
+  const scenario = buildScenarioMatrix().find(
+    (candidate) =>
+      candidate.id === scenarioId &&
+      candidate.mode === target.fixtureMode &&
+      candidate.viewport.width === width &&
+      candidate.viewport.height === height &&
+      candidate.deviceScaleFactor === deviceScaleFactor,
+  );
+  if (!scenario) {
+    throw new Error("Internal game-path worker scenario is not allowlisted");
+  }
+  return { target, scenario };
+};
+
+const parseScenarioWorkerArguments = (args, workerArgument, label) => {
+  if (
+    !Array.isArray(args) ||
+    args.length !== 13 ||
+    args[0] !== workerArgument ||
+    args[1] !== "--cdp-port" ||
+    args[3] !== "--target-url" ||
+    args[5] !== "--scenario-id" ||
+    args[7] !== "--width" ||
+    args[9] !== "--height" ||
+    args[11] !== "--device-scale-factor"
+  ) {
+    throw new Error(`Invalid internal ${label} worker arguments`);
+  }
+  const port = parseWorkerPort(args[2]);
+  const { target, scenario } = resolveWorkerScenario(
+    args[4],
+    args[6],
+    args[8],
+    args[10],
+    args[12],
+  );
+  return {
+    port,
+    targetUrl: args[4],
+    runId: target.runId,
+    scenario,
+  };
+};
+
+const parseValidationWorkerArguments = (args) =>
+  parseScenarioWorkerArguments(args, VALIDATION_WORKER_ARGUMENT, "validation");
+
+const parsePureScreenshotWorkerArguments = (args) =>
+  parseScenarioWorkerArguments(
+    args,
+    PURE_SCREENSHOT_WORKER_ARGUMENT,
+    "pure screenshot",
+  );
+
+const parseNavigationWorkerArguments = (args) => {
+  if (
+    !Array.isArray(args) ||
+    args.length !== 15 ||
+    args[0] !== NAVIGATION_WORKER_ARGUMENT ||
+    args[1] !== "--current-target-url" ||
+    args[3] !== "--cdp-port" ||
+    args[5] !== "--target-url" ||
+    args[7] !== "--scenario-id" ||
+    args[9] !== "--width" ||
+    args[11] !== "--height" ||
+    args[13] !== "--device-scale-factor"
+  ) {
+    throw new Error("Invalid internal navigation worker arguments");
+  }
+  const currentTarget = parseOwnedTargetUrl(args[2]);
+  const port = parseWorkerPort(args[4]);
+  const { target, scenario } = resolveWorkerScenario(
+    args[6],
+    args[8],
+    args[10],
+    args[12],
+    args[14],
+  );
+  if (currentTarget.runId !== target.runId) {
+    throw new Error("Navigation worker targets must belong to the same run");
+  }
+  return {
+    port,
+    currentTargetUrl: args[2],
+    targetUrl: args[6],
+    runId: target.runId,
+    scenario,
+  };
+};
+
+const buildScenarioMatrix = () =>
+  FIXTURE_MODES.flatMap((mode) =>
+    VIEWPORTS.map((viewport) => ({
+      id: `${mode}--${viewport.viewportLabel}--dpr-${String(
+        viewport.deviceScaleFactor,
+      ).replace(".", "p")}`,
+      mode,
+      viewportLabel: viewport.viewportLabel,
+      viewport: { width: viewport.width, height: viewport.height },
+      deviceScaleFactor: viewport.deviceScaleFactor,
+    })),
+  );
+
+const buildScreenshotFileName = (scenario) => `${scenario.id}.png`;
+
+const buildOwnedFixtureUrl = (targetUrl, fixtureMode) => {
+  if (!isFixtureMode(fixtureMode)) {
+    throw new Error("fixture mode is not allowlisted");
+  }
+  const target = parseOwnedTargetUrl(targetUrl);
+  const url = new URL(targetUrl);
+  url.search = "";
+  url.searchParams.set("codexQaFixture", fixtureMode);
+  url.searchParams.set("codexQaRun", target.runId);
+  return url.toString();
+};
+
+const requireAssertion = (condition, message) => {
+  if (!condition) throw new Error(message);
+};
+
+const hasPositiveArea = (rect) =>
+  rect && rect.right > rect.left && rect.bottom > rect.top;
+
+const isRectContained = (rect, bounds, tolerance = 0.5) =>
+  hasPositiveArea(rect) &&
+  rect.left >= bounds.left - tolerance &&
+  rect.top >= bounds.top - tolerance &&
+  rect.right <= bounds.right + tolerance &&
+  rect.bottom <= bounds.bottom + tolerance;
+
+const rectWidth = (rect) =>
+  hasPositiveArea(rect) ? rect.right - rect.left : 0;
+const rectHeight = (rect) =>
+  hasPositiveArea(rect) ? rect.bottom - rect.top : 0;
+
+const meetsUnscaledHitTarget = (rect, appScale, minimumWidth, minimumHeight) =>
+  rectWidth(rect) / appScale >= minimumWidth - 0.5 &&
+  rectHeight(rect) / appScale >= minimumHeight - 0.5;
+
+const assertNoProtocolErrors = (scenario, protocolErrors) => {
+  requireAssertion(
+    Array.isArray(protocolErrors) && protocolErrors.length === 0,
+    `Protocol errors detected for ${scenario.id}: ${JSON.stringify(protocolErrors)}`,
+  );
+};
+
+const assertScenarioState = (scenario, state, protocolErrors) => {
+  assertNoProtocolErrors(scenario, protocolErrors);
+  requireAssertion(
+    state.modeMarker === scenario.mode,
+    `Fixture mode marker mismatch for ${scenario.id}`,
+  );
+  requireAssertion(
+    state.splashPresent === false && state.splashVisible === false,
+    `Launcher splash is present or visible for ${scenario.id}`,
+  );
+
+  const expectedAppScale = Math.min(
+    scenario.viewport.width / 1440,
+    scenario.viewport.height / 960,
+  );
+  requireAssertion(
+    Number.isFinite(state.appScale) &&
+      Math.abs(state.appScale - expectedAppScale) <= 0.0001,
+    `App scale mismatch for ${scenario.id}: expected=${expectedAppScale}, actual=${state.appScale}`,
+  );
+
+  const nested = scenario.mode !== "diagnostic";
+  requireAssertion(
+    state.dialogCount === (nested ? 2 : 1),
+    `Unexpected dialog count for ${scenario.id}`,
+  );
+  requireAssertion(
+    state.viewport?.width === scenario.viewport.width &&
+      state.viewport?.height === scenario.viewport.height &&
+      state.viewport?.devicePixelRatio === scenario.deviceScaleFactor,
+    `Simulated viewport/DPR mismatch for ${scenario.id}`,
+  );
+
+  const viewportRect = {
+    left: 0,
+    top: 0,
+    right: scenario.viewport.width,
+    bottom: scenario.viewport.height,
+  };
+  requireAssertion(
+    isRectContained(state.modalRect, viewportRect),
+    `Outer modal is clipped for ${scenario.id}`,
+  );
+  requireAssertion(
+    isRectContained(state.headerRect, state.modalRect) &&
+      isRectContained(state.headerRect, viewportRect),
+    `Modal header is not visible for ${scenario.id}`,
+  );
+  requireAssertion(
+    isRectContained(state.footerRect, state.modalRect) &&
+      isRectContained(state.footerRect, viewportRect),
+    `Modal footer is not visible for ${scenario.id}`,
+  );
+
+  const [registryRect, configRect] = state.optionRects || [];
+  requireAssertion(
+    hasPositiveArea(registryRect) &&
+      hasPositiveArea(configRect) &&
+      Math.abs(registryRect.top - configRect.top) <= 2 &&
+      registryRect.left < configRect.left,
+    `Registry/config columns are not side-by-side for ${scenario.id}`,
+  );
+
+  const documentScroll = state.scroll?.document;
+  const bodyScroll = state.scroll?.body;
+  const modalBodyScroll = state.scroll?.modalBody;
+  requireAssertion(
+    documentScroll?.scrollWidth <= documentScroll?.clientWidth + 1 &&
+      documentScroll?.scrollHeight <= documentScroll?.clientHeight + 1 &&
+      bodyScroll?.scrollWidth <= bodyScroll?.clientWidth + 1 &&
+      bodyScroll?.scrollHeight <= bodyScroll?.clientHeight + 1 &&
+      modalBodyScroll?.scrollWidth <= modalBodyScroll?.clientWidth + 1 &&
+      modalBodyScroll?.overflowY === "auto" &&
+      modalBodyScroll?.overscrollBehaviorY === "contain",
+    `Document/modal body scroll containment failed for ${scenario.id}`,
+  );
+
+  requireAssertion(
+    state.longPath?.text?.includes("Path of Exile 2") &&
+      state.longPath.scrollWidth <= state.longPath.clientWidth + 1 &&
+      ["anywhere", "break-word"].includes(state.longPath.overflowWrap) &&
+      isRectContained(state.longPath.rect, state.modalRect),
+    `Long path wrapping/containment failed for ${scenario.id}`,
+  );
+
+  const checkboxTargets = state.hitTargets?.checkboxOptions || [];
+  const deleteTargets = state.hitTargets?.deleteButtons || [];
+  requireAssertion(
+    (scenario.mode !== "selection" ||
+      (checkboxTargets.length === 3 &&
+        checkboxTargets.every((rect) =>
+          meetsUnscaledHitTarget(rect, state.appScale, 44, 52),
+        ))) &&
+      deleteTargets.length >= 1 &&
+      deleteTargets.every((rect) =>
+        meetsUnscaledHitTarget(rect, state.appScale, 40, 40),
+      ) &&
+      meetsUnscaledHitTarget(
+        state.hitTargets?.primaryAction,
+        state.appScale,
+        36,
+        36,
+      ),
+    `Interactive hit target contract failed for ${scenario.id}`,
+  );
+
+  if (nested) {
+    requireAssertion(
+      state.outerAriaModal === null &&
+        state.outerBackgroundInert === true &&
+        state.outerBackgroundAriaHidden === "true" &&
+        state.nestedAriaModal === "true",
+      `Nested modality contract failed for ${scenario.id}`,
+    );
+    requireAssertion(
+      state.nestedFocusInside === true,
+      `Initial focus is outside the active nested dialog for ${scenario.id}`,
+    );
+    const nestedOverlayCssTolerance =
+      NESTED_OVERLAY_BORDER_CSS_PX + NESTED_OVERLAY_SUBPIXEL_TOLERANCE_CSS_PX;
+    const nestedOverlayPhysicalTolerance =
+      nestedOverlayCssTolerance * state.appScale;
+    const nestedOverlayEdgeDeltasCss = [
+      Math.abs(state.nestedOverlayRect.left - state.modalRect.left) /
+        state.appScale,
+      Math.abs(state.nestedOverlayRect.top - state.modalRect.top) /
+        state.appScale,
+      Math.abs(state.nestedOverlayRect.right - state.modalRect.right) /
+        state.appScale,
+      Math.abs(state.nestedOverlayRect.bottom - state.modalRect.bottom) /
+        state.appScale,
+    ];
+    requireAssertion(
+      isRectContained(
+        state.nestedOverlayRect,
+        state.modalRect,
+        nestedOverlayPhysicalTolerance,
+      ) &&
+        nestedOverlayEdgeDeltasCss.every(
+          (delta) => delta <= nestedOverlayCssTolerance,
+        ),
+      `Nested overlay containment/coverage failed for ${scenario.id}`,
+    );
+  } else {
+    requireAssertion(
+      state.outerAriaModal === "true" &&
+        state.outerBackgroundInert === false &&
+        state.outerBackgroundAriaHidden === null &&
+        state.nestedAriaModal === null,
+      `Outer modality contract failed for ${scenario.id}`,
+    );
+  }
+
+  if (scenario.mode === "selection") {
+    requireAssertion(
+      state.selection?.ctaText === "선택 (2개)" &&
+        JSON.stringify(state.selection.checks) ===
+          JSON.stringify([
+            { targetId: "registry-primary", checked: true },
+            { targetId: "registry-compatibility", checked: false },
+            { targetId: "config", checked: true },
+          ]),
+      `Selection defaults/CTA mismatch for ${scenario.id}`,
+    );
+  }
+
+  if (scenario.mode === "partial") {
+    requireAssertion(
+      state.partial?.retryText === "실패 항목 다시 시도 (1개)" &&
+        JSON.stringify(state.partial.results) ===
+          JSON.stringify([
+            { targetId: "registry-primary", status: "applied" },
+            { targetId: "registry-compatibility", status: "failed" },
+            { targetId: "config", status: "unchanged" },
+          ]),
+      `Partial result/failed-only retry mismatch for ${scenario.id}`,
+    );
+  }
+
+  if (scenario.mode === "delete") {
+    requireAssertion(
+      state.deletion?.title === "레지스트리 경로값을 삭제할까요?" &&
+        state.deletion.candidate === "Kakaogames (기본)" &&
+        state.deletion.path === SELECTED_PATH,
+      `Delete confirmation mismatch for ${scenario.id}`,
+    );
+  }
+
+  return {
+    protocolErrors: true,
+    modeMarker: true,
+    splashAbsent: true,
+    appScale: true,
+    dialogCount: true,
+    modalContained: true,
+    headerVisible: true,
+    footerVisible: true,
+    twoColumn: true,
+    scrollContained: true,
+    longPathWrapped: true,
+    hitTargets: true,
+    nestedModal: true,
+    nestedFocus: true,
+    nestedOverlay: true,
+    modeSpecific: true,
+  };
+};
+
+const resolveArtifactPath = (outputDir, fileName) => {
+  if (path.basename(fileName) !== fileName) {
+    throw new Error("Artifact name must not contain a path");
+  }
+  const artifactPath = path.resolve(outputDir, fileName);
+  if (path.dirname(artifactPath) !== path.resolve(outputDir)) {
+    throw new Error("Artifact path escaped the run-owned output directory");
+  }
+  return artifactPath;
+};
+
+const buildLayoutReadyExpression = (scenario) => {
+  if (!isFixtureMode(scenario?.mode)) {
+    throw new Error("Layout readiness requires an allowlisted fixture mode");
+  }
+  const expectedAppScale = Math.min(
+    scenario.viewport.width / 1440,
+    scenario.viewport.height / 960,
+  );
+
+  return String.raw`(async () => {
+    const expectedMode = ${JSON.stringify(scenario.mode)};
+    const expectedWidth = ${scenario.viewport.width};
+    const expectedHeight = ${scenario.viewport.height};
+    const expectedDeviceScaleFactor = ${scenario.deviceScaleFactor};
+    const expectedAppScale = ${expectedAppScale};
+    const timeoutMs = ${LAYOUT_READY_TIMEOUT_MS};
+    const maxOwnedAnimationMs = 1_000;
+    const ownedAnimationRootSelector =
+      ".game-path-modal-overlay, .game-path-modal, .game-path-confirm-overlay, .game-path-modal [role='dialog']";
+    const startedAt = performance.now();
+    const nextFrame = () => new Promise((resolve) => requestAnimationFrame(resolve));
+    const readOwnedState = () => ({
+      marker: document.querySelector("[data-qa-fixture]")?.getAttribute("data-qa-fixture") ?? null,
+      appScale: Number.parseFloat(
+        getComputedStyle(document.documentElement).getPropertyValue("--app-scale")
+      ),
+      viewport: {
+        width: window.innerWidth,
+        height: window.innerHeight,
+        devicePixelRatio: window.devicePixelRatio
+      },
+      fontStatus: document.fonts?.status ?? "unavailable"
+    });
+    const matchesExpectedState = (state) =>
+      state.marker === expectedMode &&
+      Number.isFinite(state.appScale) &&
+      Math.abs(state.appScale - expectedAppScale) <= 0.0001 &&
+      state.viewport.width === expectedWidth &&
+      state.viewport.height === expectedHeight &&
+      Math.abs(state.viewport.devicePixelRatio - expectedDeviceScaleFactor) <= 0.0001 &&
+      state.fontStatus === "loaded";
+    const failureReason = (state) => {
+      if (state.marker !== expectedMode) return "fixture marker mismatch";
+      if (!Number.isFinite(state.appScale) || Math.abs(state.appScale - expectedAppScale) > 0.0001) {
+        return "app scale mismatch";
+      }
+      if (
+        state.viewport.width !== expectedWidth ||
+        state.viewport.height !== expectedHeight ||
+        Math.abs(state.viewport.devicePixelRatio - expectedDeviceScaleFactor) > 0.0001
+      ) {
+        return "viewport mismatch";
+      }
+      if (state.fontStatus !== "loaded") return "font readiness timeout";
+      return "qa-layout-ready-timeout";
+    };
+    const timedOutResult = () => {
+      const state = readOwnedState();
+      return { ready: false, reason: failureReason(state), ...state };
+    };
+    const getRelevantOwnedAnimations = () => {
+      const animations = new Set();
+      const roots = document.querySelectorAll(ownedAnimationRootSelector);
+      for (const root of roots) {
+        for (const animation of root.getAnimations({ subtree: true })) {
+          const target = animation.effect?.target;
+          const timing = animation.effect?.getComputedTiming();
+          const iterations = animation.effect?.getTiming().iterations;
+          const belongsToOwnedRoot =
+            target instanceof Element &&
+            target.closest(ownedAnimationRootSelector) !== null;
+          const isRunning =
+            animation.playState === "running" || animation.playState === "pending";
+          if (
+            belongsToOwnedRoot &&
+            isRunning &&
+            Number.isFinite(timing.endTime) &&
+            timing.endTime > 0 &&
+            timing.endTime <= maxOwnedAnimationMs &&
+            Number.isFinite(iterations)
+          ) {
+            animations.add(animation);
+          }
+        }
+      }
+      return [...animations];
+    };
+
+    let timeoutId;
+    const timeout = new Promise((resolve) => {
+      timeoutId = setTimeout(() => resolve(timedOutResult()), timeoutMs);
+    });
+    const readiness = (async () => {
+      if (!document.fonts?.ready) return timedOutResult();
+      await document.fonts.ready;
+      while (performance.now() - startedAt < timeoutMs) {
+        const state = readOwnedState();
+        if (matchesExpectedState(state)) {
+          const ownedAnimations = getRelevantOwnedAnimations();
+          const animationResults = await Promise.allSettled(
+            ownedAnimations.map((animation) => animation.finished)
+          );
+          if (animationResults.some((result) => result.status === "rejected")) {
+            return {
+              ready: false,
+              reason: "owned animation rejected",
+              ...readOwnedState()
+            };
+          }
+          await nextFrame();
+          await nextFrame();
+          const stableState = readOwnedState();
+          if (matchesExpectedState(stableState)) {
+            return { ready: true, ...stableState };
+          }
+        } else {
+          await nextFrame();
+        }
+      }
+      return timedOutResult();
+    })();
+
+    try {
+      return await Promise.race([readiness, timeout]);
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  })()`;
+};
+
+const assertLayoutReadyResult = (scenario, result) => {
+  requireAssertion(
+    result?.ready === true,
+    `Layout readiness failed for ${scenario.id}: ${result?.reason || "invalid result"}`,
+  );
+  requireAssertion(
+    result.marker === scenario.mode,
+    `Layout fixture marker mismatch for ${scenario.id}`,
+  );
+  const expectedAppScale = Math.min(
+    scenario.viewport.width / 1440,
+    scenario.viewport.height / 960,
+  );
+  requireAssertion(
+    Number.isFinite(result.appScale) &&
+      Math.abs(result.appScale - expectedAppScale) <= 0.0001,
+    `Layout scale mismatch for ${scenario.id}`,
+  );
+  requireAssertion(
+    result.viewport?.width === scenario.viewport.width &&
+      result.viewport?.height === scenario.viewport.height &&
+      Math.abs(
+        result.viewport?.devicePixelRatio - scenario.deviceScaleFactor,
+      ) <= 0.0001,
+    `Layout viewport mismatch for ${scenario.id}`,
+  );
+};
+
+const isPngBuffer = (value) =>
+  Buffer.isBuffer(value) &&
+  value.length >= PNG_SIGNATURE.length &&
+  value.subarray(0, PNG_SIGNATURE.length).equals(PNG_SIGNATURE);
+
+const runWorkerProcess = (workerArguments, dependencies = {}) => {
+  const spawnImpl = dependencies.spawn ?? spawn;
+  const timeoutMs = dependencies.timeoutMs ?? CAPTURE_WORKER_TIMEOUT_MS;
+  const terminationGraceMs =
+    dependencies.terminationGraceMs ?? CAPTURE_WORKER_TERMINATION_GRACE_MS;
+  const maxOutputBytes =
+    dependencies.maxOutputBytes ?? CAPTURE_WORKER_MAX_OUTPUT_BYTES;
+  const maxErrorBytes =
+    dependencies.maxErrorBytes ?? CAPTURE_WORKER_MAX_ERROR_BYTES;
+  const args = [__filename, ...workerArguments];
+
+  return new Promise((resolve, reject) => {
+    let child;
+    try {
+      child = spawnImpl(process.execPath, args, {
+        shell: false,
+        windowsHide: true,
+        env: {},
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+    } catch (error) {
+      reject(new Error("Failed to spawn game-path worker", { cause: error }));
+      return;
+    }
+
+    const stdoutChunks = [];
+    const stderrChunks = [];
+    let stdoutBytes = 0;
+    let stderrBytes = 0;
+    let failure = null;
+    let settled = false;
+    let terminationTimer = null;
+
+    const cleanup = () => {
+      clearTimeout(timeout);
+      if (terminationTimer) clearTimeout(terminationTimer);
+      child.removeListener("error", onError);
+      child.removeListener("close", onClose);
+      child.stdout.removeListener("data", onStdout);
+      child.stderr.removeListener("data", onStderr);
+    };
+    const settle = (callback, value) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      callback(value);
+    };
+    const terminate = (error) => {
+      if (failure || settled) return;
+      failure = error;
+      let killError = null;
+      try {
+        child.kill("SIGKILL");
+      } catch (caughtError) {
+        killError = caughtError;
+      }
+      if (killError) {
+        settle(
+          reject,
+          new AggregateError(
+            [failure, killError],
+            "Game-path worker failed and could not be terminated",
+            { cause: killError },
+          ),
+        );
+        return;
+      }
+      terminationTimer = setTimeout(() => {
+        settle(
+          reject,
+          new Error(`${failure.message}; game-path worker did not terminate`, {
+            cause: failure,
+          }),
+        );
+      }, terminationGraceMs);
+    };
+    const onStdout = (chunk) => {
+      if (failure) return;
+      const value = Buffer.from(chunk);
+      stdoutBytes += value.length;
+      if (stdoutBytes > maxOutputBytes) {
+        terminate(new Error("Game-path worker exceeded maximum output"));
+        return;
+      }
+      stdoutChunks.push(value);
+    };
+    const onStderr = (chunk) => {
+      if (failure) return;
+      const value = Buffer.from(chunk);
+      stderrBytes += value.length;
+      if (stderrBytes > maxErrorBytes) {
+        terminate(new Error("Game-path worker exceeded maximum error output"));
+        return;
+      }
+      stderrChunks.push(value);
+    };
+    const onError = (error) => {
+      terminate(
+        new Error(`Game-path worker process failed: ${error.message}`, {
+          cause: error,
+        }),
+      );
+    };
+    const onClose = (code, signal) => {
+      if (failure) {
+        settle(reject, failure);
+        return;
+      }
+      const stderrText = Buffer.concat(stderrChunks).toString("utf8").trim();
+      if (code !== 0) {
+        settle(
+          reject,
+          new Error(
+            `Game-path worker exited with code ${String(code)}${
+              signal ? ` (${signal})` : ""
+            }${stderrText ? `: ${stderrText}` : ""}`,
+          ),
+        );
+        return;
+      }
+      settle(resolve, Buffer.concat(stdoutChunks));
+    };
+
+    child.stdout.on("data", onStdout);
+    child.stderr.on("data", onStderr);
+    child.on("error", onError);
+    child.on("close", onClose);
+    const timeout = setTimeout(
+      () => terminate(new Error("Game-path worker timed out")),
+      timeoutMs,
+    );
+  });
+};
+
+const assertConfiguredOwnedTarget = (config, targetUrl, label) => {
+  const target = parseOwnedTargetUrl(targetUrl);
+  if (
+    target.runId !== config.runId ||
+    targetUrl !== buildOwnedFixtureUrl(config.targetUrl, target.fixtureMode)
+  ) {
+    throw new Error(`${label} must be the exact configured run-owned target`);
+  }
+  return target;
+};
+
+const scenarioWorkerArguments = (config, targetUrl, scenario) => [
+  "--cdp-port",
+  String(config.port),
+  "--target-url",
+  targetUrl,
+  "--scenario-id",
+  scenario.id,
+  "--width",
+  String(scenario.viewport.width),
+  "--height",
+  String(scenario.viewport.height),
+  "--device-scale-factor",
+  String(scenario.deviceScaleFactor),
+];
+
+const parseWorkerPayload = (output) => {
+  let payload;
+  try {
+    payload = JSON.parse(output.toString("utf8"));
+  } catch (error) {
+    throw new Error("Game-path worker returned no valid structured payload", {
+      cause: error,
+    });
+  }
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    throw new Error("Game-path worker returned no valid structured payload");
+  }
+  return payload;
+};
+
+const runNavigationWorkerProcess = async (
+  config,
+  currentTargetUrl,
+  targetUrl,
+  scenario,
+  dependencies = {},
+) => {
+  const currentTarget = assertConfiguredOwnedTarget(
+    config,
+    currentTargetUrl,
+    "Navigation current target",
+  );
+  const target = assertConfiguredOwnedTarget(
+    config,
+    targetUrl,
+    "Navigation destination target",
+  );
+  if (
+    currentTarget.runId !== target.runId ||
+    target.fixtureMode !== scenario.mode
+  ) {
+    throw new Error("Navigation worker target does not match the scenario");
+  }
+  const output = await runWorkerProcess(
+    [
+      NAVIGATION_WORKER_ARGUMENT,
+      "--current-target-url",
+      currentTargetUrl,
+      ...scenarioWorkerArguments(config, targetUrl, scenario),
+    ],
+    dependencies,
+  );
+  const payload = parseWorkerPayload(output);
+  if (
+    payload.schemaVersion !== 1 ||
+    payload.kind !== "navigation-complete" ||
+    payload.targetUrl !== targetUrl ||
+    payload.scenarioId !== scenario.id
+  ) {
+    throw new Error("Navigation worker returned no exact owned worker payload");
+  }
+};
+
+const runValidationWorkerProcess = async (
+  config,
+  targetUrl,
+  scenario,
+  dependencies = {},
+) => {
+  const target = assertConfiguredOwnedTarget(
+    config,
+    targetUrl,
+    "Validation target",
+  );
+  if (target.fixtureMode !== scenario.mode) {
+    throw new Error("Validation worker target does not match the scenario");
+  }
+  const output = await runWorkerProcess(
+    [
+      VALIDATION_WORKER_ARGUMENT,
+      ...scenarioWorkerArguments(config, targetUrl, scenario),
+    ],
+    dependencies,
+  );
+  const payload = parseWorkerPayload(output);
+  if (
+    payload.schemaVersion !== 1 ||
+    payload.kind !== "validation-result" ||
+    payload.targetUrl !== targetUrl ||
+    payload.scenarioId !== scenario.id ||
+    !payload.state ||
+    !Array.isArray(payload.protocolErrors)
+  ) {
+    throw new Error("Validation worker returned no exact owned worker payload");
+  }
+  return {
+    state: payload.state,
+    protocolErrors: payload.protocolErrors,
+  };
+};
+
+const runPureScreenshotWorkerProcess = async (
+  config,
+  targetUrl,
+  scenario,
+  dependencies = {},
+) => {
+  const target = assertConfiguredOwnedTarget(
+    config,
+    targetUrl,
+    "Pure screenshot target",
+  );
+  if (target.fixtureMode !== scenario.mode) {
+    throw new Error(
+      "Pure screenshot worker target does not match the scenario",
+    );
+  }
+  const workerArguments = [
+    PURE_SCREENSHOT_WORKER_ARGUMENT,
+    ...scenarioWorkerArguments(config, targetUrl, scenario),
+  ];
+  const runAttempt = async () => {
+    const screenshot = await runWorkerProcess(workerArguments, dependencies);
+    if (!isPngBuffer(screenshot)) {
+      throw new Error("Pure screenshot worker returned no valid PNG data");
+    }
+    return screenshot;
+  };
+  const retryableErrorMessage =
+    "Game-path worker exited with code 1: Timed out waiting for pure CDP command Page.captureScreenshot";
+
+  let firstError;
+  try {
+    return await runAttempt();
+  } catch (error) {
+    if (!(error instanceof Error) || error.message !== retryableErrorMessage) {
+      throw error;
+    }
+    firstError = error;
+  }
+
+  try {
+    return await runAttempt();
+  } catch (secondError) {
+    throw new AggregateError(
+      [firstError, secondError],
+      `Pure screenshot worker failed after one capture-timeout retry for ${scenario.id} at ${targetUrl}`,
+      { cause: secondError },
+    );
+  }
+};
+
+const CDP_WORKER_DETACH_SETTLE_MS = 1000;
+const settleAfterCdpWorkerDetach = (schedule = setTimeout) =>
+  new Promise((resolve) => schedule(resolve, CDP_WORKER_DETACH_SETTLE_MS));
+
+const captureFixtureMatrix = async (config, dependencies) => {
+  const matrix = buildScenarioMatrix();
+  const startedAt = dependencies.now();
+  const scenarios = [];
+  let currentTargetUrl = config.targetUrl;
+  const settleAfterValidation =
+    dependencies.settleAfterValidation ?? (() => settleAfterCdpWorkerDetach());
+
+  for (const scenario of matrix) {
+    const url = buildOwnedFixtureUrl(config.targetUrl, scenario.mode);
+    await dependencies.navigateInWorker(currentTargetUrl, url, scenario);
+    const validation = await dependencies.validateInWorker(url, scenario);
+    const assertions = assertScenarioState(
+      scenario,
+      validation.state,
+      validation.protocolErrors,
+    );
+    await settleAfterValidation(url, scenario);
+    const screenshot = await dependencies.screenshotInWorker(url, scenario);
+    const screenshotFile = buildScreenshotFileName(scenario);
+    dependencies.writeArtifact(
+      resolveArtifactPath(config.outputDir, screenshotFile),
+      screenshot,
+    );
+    scenarios.push({
+      id: scenario.id,
+      fixtureMode: scenario.mode,
+      url,
+      viewport: scenario.viewport,
+      deviceScaleFactor: scenario.deviceScaleFactor,
+      screenshot: screenshotFile,
+      assertions,
+      protocolErrors: validation.protocolErrors,
+    });
+    currentTargetUrl = url;
+  }
+
+  const manifest = {
+    schemaVersion: 1,
+    runId: config.runId,
+    targetUrl: config.targetUrl,
+    outputDir: config.outputDir,
+    startedAt,
+    completedAt: dependencies.now(),
+    simulation: {
+      viewport: "CDP Emulation.setDeviceMetricsOverride",
+      deviceScaleFactor: "CDP simulated",
+      windowsOsDpiChanged: false,
+    },
+    scenarios,
+  };
+  dependencies.writeArtifact(
+    resolveArtifactPath(config.outputDir, MANIFEST_FILE_NAME),
+    `${JSON.stringify(manifest, null, 2)}\n`,
+  );
+  return manifest;
+};
+
+const LAYOUT_STATE_EXPRESSION = String.raw`(() => {
+  const rect = (element) => {
+    if (!element) return null;
+    const value = element.getBoundingClientRect();
+    return {
+      left: value.left,
+      top: value.top,
+      right: value.right,
+      bottom: value.bottom
+    };
+  };
+  const text = (element) => element?.textContent?.replace(/\s+/g, " ").trim() ?? null;
+  const fixture = document.querySelector("[data-qa-fixture]");
+  const splash = document.getElementById("launcher-splash");
+  const splashStyle = splash ? getComputedStyle(splash) : null;
+  const splashRect = splash?.getBoundingClientRect() ?? null;
+  const splashVisible = Boolean(
+    splash &&
+    splashStyle?.display !== "none" &&
+    splashStyle?.visibility !== "hidden" &&
+    Number.parseFloat(splashStyle?.opacity ?? "1") > 0 &&
+    splashRect &&
+    splashRect.width > 0 &&
+    splashRect.height > 0
+  );
+  const outer = document.querySelector(".game-path-modal[role='dialog']");
+  const background = outer?.querySelector(".game-path-modal-background");
+  const modalBody = outer?.querySelector(".game-path-modal-body");
+  const dialogs = [...document.querySelectorAll("[role='dialog']")];
+  const nested = dialogs.find((dialog) => dialog !== outer) ?? null;
+  const nestedOverlay = nested?.closest(".game-path-confirm-overlay") ?? null;
+  const optionRects = [...document.querySelectorAll(".game-path-options > .game-path-option")].map(rect);
+  const selectionButton = [...document.querySelectorAll(".game-path-target-actions button")]
+    .find((button) => text(button)?.startsWith("선택 ("));
+  const checks = [...document.querySelectorAll(".game-path-target-list input[type='checkbox']")]
+    .map((input) => ({ targetId: input.value, checked: input.checked }));
+  const resultTargetIds = ["registry-primary", "registry-compatibility", "config"];
+  const resultItems = [...document.querySelectorAll(".game-path-target-results li")]
+    .map((item, index) => ({
+      targetId: resultTargetIds[index],
+      status: item.classList.contains("is-applied")
+        ? "applied"
+        : item.classList.contains("is-unchanged")
+          ? "unchanged"
+          : "failed"
+    }));
+  const retryButton = [...document.querySelectorAll(".game-path-target-actions button")]
+    .find((button) => text(button)?.startsWith("실패 항목 다시 시도"));
+  const deleteDialog = document.querySelector("[aria-labelledby='game-path-registry-delete-title']");
+  const deleteFields = [...(deleteDialog?.querySelectorAll(".game-path-confirm-paths > div") ?? [])];
+  const longPathElement = [
+    ...document.querySelectorAll(
+      ".game-path-option-path, .game-path-target-selected-path strong, .game-path-confirm-paths strong"
+    )
+  ].find((element) => text(element)?.includes("Path of Exile 2")) ?? null;
+  const activeDialog = nested ?? outer;
+  const activeActions = [
+    ...(activeDialog?.querySelectorAll(".game-path-action:not(:disabled)") ?? [])
+  ];
+  const primaryAction = activeActions.at(-1) ?? null;
+  const scrollState = (element) => element ? {
+    scrollWidth: element.scrollWidth,
+    clientWidth: element.clientWidth,
+    scrollHeight: element.scrollHeight,
+    clientHeight: element.clientHeight
+  } : null;
+  const fieldValue = (label) => {
+    const field = deleteFields.find((item) => text(item.querySelector("span")) === label);
+    return text(field?.querySelector("strong"));
+  };
+  return {
+    modeMarker: fixture?.getAttribute("data-qa-fixture") ?? null,
+    splashPresent: splash !== null,
+    splashVisible,
+    appScale: Number.parseFloat(
+      getComputedStyle(document.documentElement).getPropertyValue("--app-scale")
+    ),
+    dialogCount: dialogs.length,
+    viewport: {
+      width: window.innerWidth,
+      height: window.innerHeight,
+      devicePixelRatio: window.devicePixelRatio
+    },
+    modalRect: rect(outer),
+    headerRect: rect(outer?.querySelector(".game-path-modal-header")),
+    footerRect: rect(outer?.querySelector(".game-path-modal-footer")),
+    optionRects,
+    nestedOverlayRect: rect(nestedOverlay),
+    nestedFocusInside: nested ? nested.contains(document.activeElement) : null,
+    scroll: {
+      document: scrollState(document.documentElement),
+      body: scrollState(document.body),
+      modalBody: modalBody ? {
+        ...scrollState(modalBody),
+        overflowY: getComputedStyle(modalBody).overflowY,
+        overscrollBehaviorY: getComputedStyle(modalBody).overscrollBehaviorY
+      } : null
+    },
+    longPath: longPathElement ? {
+      text: text(longPathElement),
+      rect: rect(longPathElement),
+      scrollWidth: longPathElement.scrollWidth,
+      clientWidth: longPathElement.clientWidth,
+      overflowWrap: getComputedStyle(longPathElement).overflowWrap
+    } : null,
+    hitTargets: {
+      checkboxOptions: [
+        ...document.querySelectorAll(".game-path-target-option")
+      ].map(rect),
+      deleteButtons: [
+        ...document.querySelectorAll(".game-path-candidate-delete")
+      ].map(rect),
+      primaryAction: rect(primaryAction)
+    },
+    outerAriaModal: outer?.getAttribute("aria-modal") ?? null,
+    outerBackgroundInert: background?.hasAttribute("inert") ?? false,
+    outerBackgroundAriaHidden: background?.getAttribute("aria-hidden") ?? null,
+    nestedAriaModal: nested?.getAttribute("aria-modal") ?? null,
+    selection: selectionButton ? { ctaText: text(selectionButton), checks } : null,
+    partial: retryButton ? { retryText: text(retryButton), results: resultItems } : null,
+    deletion: deleteDialog ? {
+      title: text(deleteDialog.querySelector("#game-path-registry-delete-title")),
+      candidate: fieldValue("후보"),
+      path: fieldValue("삭제할 경로값")
+    } : null
+  };
+})()`;
+
+const capturePureScreenshot = async (worker, dependencies = {}) => {
+  const targetIdentity = parseOwnedTargetUrl(worker.targetUrl);
+  if (
+    targetIdentity.runId !== worker.runId ||
+    targetIdentity.fixtureMode !== worker.scenario.mode
+  ) {
+    throw new Error("Pure screenshot target identity is invalid");
+  }
+  const commandTimeoutMs =
+    dependencies.commandTimeoutMs ?? CDP_COMMAND_TIMEOUT_MS;
+  const fetchImpl = dependencies.fetch ?? fetch;
+  const WebSocketImpl =
+    dependencies.WebSocket ??
+    (typeof WebSocket === "function" ? WebSocket : null);
+  if (typeof WebSocketImpl !== "function") {
+    throw new Error("This capture script requires Node.js WebSocket support");
+  }
+
+  const response = await fetchImpl(
+    `http://127.0.0.1:${worker.port}/json/list`,
+    { signal: AbortSignal.timeout(commandTimeoutMs) },
+  );
+  if (!response.ok) {
+    throw new Error(
+      `Failed to list pure screenshot target: HTTP ${response.status}`,
+    );
+  }
+  const targets = await response.json();
+  const target = Array.isArray(targets)
+    ? targets.find((item) => item?.url === worker.targetUrl)
+    : null;
+  if (!target?.webSocketDebuggerUrl) {
+    throw new Error(
+      `Exact owned pure screenshot target not found: ${worker.targetUrl}`,
+    );
+  }
+
+  const socket = new WebSocketImpl(target.webSocketDebuggerUrl);
+  const pending = new Map();
+  let nextId = 0;
+  const failPending = (error) => {
+    for (const request of pending.values()) {
+      clearTimeout(request.timeout);
+      request.reject(error);
+    }
+    pending.clear();
+  };
+  const socketError = (event) =>
+    new Error(
+      event?.message ||
+        event?.error?.message ||
+        "Pure screenshot WebSocket error",
+    );
+  const waitForOpen = new Promise((resolve, reject) => {
+    let settled = false;
+    const finish = (callback, value) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      callback(value);
+    };
+    const timeout = setTimeout(
+      () =>
+        finish(
+          reject,
+          new Error("Timed out waiting for pure screenshot WebSocket open"),
+        ),
+      commandTimeoutMs,
+    );
+    socket.addEventListener("open", () => finish(resolve), { once: true });
+    socket.addEventListener(
+      "error",
+      (event) => finish(reject, socketError(event)),
+      { once: true },
+    );
+    socket.addEventListener(
+      "close",
+      () =>
+        finish(
+          reject,
+          new Error("Pure screenshot WebSocket closed before opening"),
+        ),
+      { once: true },
+    );
+  });
+
+  socket.addEventListener("message", (event) => {
+    let message;
+    try {
+      message = JSON.parse(event.data);
+    } catch {
+      failPending(new Error("Pure screenshot WebSocket returned invalid JSON"));
+      return;
+    }
+    if (!message.id || !pending.has(message.id)) return;
+    const request = pending.get(message.id);
+    pending.delete(message.id);
+    clearTimeout(request.timeout);
+    if (message.error) {
+      request.reject(
+        new Error(
+          `Pure screenshot CDP command ${request.method} failed: ${JSON.stringify(message.error)}`,
+        ),
+      );
+    } else {
+      request.resolve(message.result);
+    }
+  });
+  socket.addEventListener("error", (event) => failPending(socketError(event)));
+  socket.addEventListener("close", () =>
+    failPending(new Error("Pure screenshot WebSocket closed unexpectedly")),
+  );
+
+  const send = (method, params = {}) => {
+    const id = ++nextId;
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        pending.delete(id);
+        reject(new Error(`Timed out waiting for pure CDP command ${method}`));
+      }, commandTimeoutMs);
+      pending.set(id, { method, resolve, reject, timeout });
+      try {
+        socket.send(JSON.stringify({ id, method, params }));
+      } catch (error) {
+        clearTimeout(timeout);
+        pending.delete(id);
+        reject(error);
+      }
+    });
+  };
+  const closeSocket = () =>
+    new Promise((resolve, reject) => {
+      if (socket.readyState === 3) {
+        resolve();
+        return;
+      }
+      let settled = false;
+      const finish = (callback, value) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timeout);
+        callback(value);
+      };
+      const timeout = setTimeout(
+        () =>
+          finish(
+            reject,
+            new Error("Timed out waiting for pure screenshot WebSocket close"),
+          ),
+        commandTimeoutMs,
+      );
+      socket.addEventListener("close", () => finish(resolve), { once: true });
+      socket.addEventListener(
+        "error",
+        (event) => finish(reject, socketError(event)),
+        { once: true },
+      );
+      try {
+        socket.close();
+      } catch (error) {
+        finish(reject, error);
+      }
+    });
+
+  let screenshot;
+  let operationError;
+  try {
+    await waitForOpen;
+    const scenario = worker.scenario;
+    await send("Emulation.setDeviceMetricsOverride", {
+      width: scenario.viewport.width,
+      height: scenario.viewport.height,
+      deviceScaleFactor: scenario.deviceScaleFactor,
+      mobile: false,
+      screenWidth: scenario.viewport.width,
+      screenHeight: scenario.viewport.height,
+    });
+    await send("Page.bringToFront");
+    const result = await send("Page.captureScreenshot", {
+      format: "png",
+      fromSurface: true,
+    });
+    if (!result?.data) throw new Error("Pure screenshot returned no data");
+    screenshot = Buffer.from(result.data, "base64");
+  } catch (error) {
+    operationError = error;
+  }
+  try {
+    await closeSocket();
+  } catch (closeError) {
+    if (operationError) {
+      throw new AggregateError(
+        [operationError, closeError],
+        "Pure screenshot operation and close both failed",
+        { cause: closeError },
+      );
+    }
+    throw closeError;
+  } finally {
+    failPending(new Error("Pure screenshot session closed"));
+  }
+  if (operationError) throw operationError;
+  if (!isPngBuffer(screenshot)) {
+    throw new Error("Pure screenshot worker received no valid PNG data");
+  }
+  return screenshot;
+};
+
+const createCdpClient = async (config, targetUrl) => {
+  const ownedTarget = parseOwnedTargetUrl(targetUrl);
+  if (
+    ownedTarget.runId !== config.runId ||
+    targetUrl !==
+      buildOwnedFixtureUrl(config.targetUrl, ownedTarget.fixtureMode)
+  ) {
+    throw new Error(
+      "Observer target must be the exact configured run-owned fixture target",
+    );
+  }
+  const response = await fetch(`http://127.0.0.1:${config.port}/json/list`, {
+    signal: AbortSignal.timeout(CDP_COMMAND_TIMEOUT_MS),
+  });
+  if (!response.ok) {
+    throw new Error(`Failed to list CDP targets: HTTP ${response.status}`);
+  }
+  const targets = await response.json();
+  const target = Array.isArray(targets)
+    ? targets.find((item) => item?.url === targetUrl)
+    : null;
+  if (!target?.webSocketDebuggerUrl) {
+    throw new Error(`Exact owned CDP target not found: ${targetUrl}`);
+  }
+  if (typeof WebSocket !== "function") {
+    throw new Error("This capture script requires Node.js WebSocket support");
+  }
+
+  const socket = new WebSocket(target.webSocketDebuggerUrl);
+  let nextId = 0;
+  const pending = new Map();
+  const eventWaiters = new Map();
+  let protocolErrors = [];
+
+  const waitForOpen = new Promise((resolve, reject) => {
+    socket.addEventListener("open", resolve, { once: true });
+    socket.addEventListener("error", reject, { once: true });
+  });
+
+  const waitForEvent = (method) =>
+    new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        eventWaiters.delete(method);
+        reject(new Error(`Timed out waiting for CDP event ${method}`));
+      }, CDP_COMMAND_TIMEOUT_MS);
+      eventWaiters.set(method, (params) => {
+        clearTimeout(timeout);
+        eventWaiters.delete(method);
+        resolve(params);
+      });
+    });
+
+  socket.addEventListener("message", (event) => {
+    const message = JSON.parse(event.data);
+    if (message.id && pending.has(message.id)) {
+      const request = pending.get(message.id);
+      pending.delete(message.id);
+      clearTimeout(request.timeout);
+      if (message.error)
+        request.reject(
+          new Error(
+            `CDP command ${request.method} failed: ${JSON.stringify(message.error)}`,
+          ),
+        );
+      else request.resolve(message.result);
+      return;
+    }
+
+    const waiter = eventWaiters.get(message.method);
+    waiter?.(message.params);
+    if (message.method === "Runtime.exceptionThrown") {
+      protocolErrors.push({
+        domain: "Runtime",
+        message:
+          message.params?.exceptionDetails?.text || "Runtime.exceptionThrown",
+      });
+    } else if (
+      message.method === "Runtime.consoleAPICalled" &&
+      message.params?.type === "error"
+    ) {
+      protocolErrors.push({ domain: "Runtime", message: "console.error" });
+    } else if (
+      message.method === "Log.entryAdded" &&
+      message.params?.entry?.level === "error"
+    ) {
+      protocolErrors.push({
+        domain: "Log",
+        message: message.params.entry.text || "Log.entryAdded",
+      });
+    } else if (message.method === "Page.javascriptDialogOpening") {
+      protocolErrors.push({
+        domain: "Page",
+        message: message.params?.message || "javascriptDialogOpening",
+      });
+    } else if (message.method === "Inspector.targetCrashed") {
+      protocolErrors.push({ domain: "Page", message: "targetCrashed" });
+    }
+  });
+
+  await waitForOpen;
+
+  const send = (method, params = {}) => {
+    const id = ++nextId;
+    socket.send(JSON.stringify({ id, method, params }));
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        pending.delete(id);
+        reject(new Error(`Timed out waiting for CDP command ${method}`));
+      }, CDP_COMMAND_TIMEOUT_MS);
+      pending.set(id, { method, resolve, reject, timeout });
+    });
+  };
+
+  await send("Runtime.enable");
+  await send("Page.enable");
+  await send("Log.enable");
+  await send("Inspector.enable");
+
+  let closePromise;
+  return {
+    async setViewport(scenario) {
+      await send("Emulation.setDeviceMetricsOverride", {
+        width: scenario.viewport.width,
+        height: scenario.viewport.height,
+        deviceScaleFactor: scenario.deviceScaleFactor,
+        mobile: false,
+        screenWidth: scenario.viewport.width,
+        screenHeight: scenario.viewport.height,
+      });
+    },
+    async navigate(url) {
+      const loaded = waitForEvent("Page.loadEventFired");
+      const result = await send("Page.navigate", { url });
+      if (result?.errorText) {
+        throw new Error(`Page navigation failed: ${result.errorText}`);
+      }
+      await loaded;
+    },
+    async waitForLayoutReady(scenario) {
+      const result = await send("Runtime.evaluate", {
+        expression: buildLayoutReadyExpression(scenario),
+        awaitPromise: true,
+        returnByValue: true,
+      });
+      if (result?.exceptionDetails) {
+        throw new Error(
+          `Layout readiness evaluation failed: ${
+            result.exceptionDetails.text || "Runtime.evaluate failed"
+          }`,
+        );
+      }
+      assertLayoutReadyResult(scenario, result?.result?.value);
+    },
+    async readState() {
+      const result = await send("Runtime.evaluate", {
+        expression: LAYOUT_STATE_EXPRESSION,
+        returnByValue: true,
+      });
+      if (result?.exceptionDetails) {
+        protocolErrors.push({
+          domain: "Runtime",
+          message: result.exceptionDetails.text || "Runtime.evaluate failed",
+        });
+      }
+      return result?.result?.value;
+    },
+    takeErrors() {
+      const errors = protocolErrors;
+      protocolErrors = [];
+      return errors;
+    },
+    async close() {
+      if (closePromise) return closePromise;
+      closePromise = new Promise((resolve, reject) => {
+        if (socket.readyState === 3) {
+          resolve();
+          return;
+        }
+        let settled = false;
+        const finish = (callback, value) => {
+          if (settled) return;
+          settled = true;
+          clearTimeout(timeout);
+          callback(value);
+        };
+        const timeout = setTimeout(
+          () =>
+            finish(
+              reject,
+              new Error("Timed out waiting for observer WebSocket close"),
+            ),
+          CDP_COMMAND_TIMEOUT_MS,
+        );
+        socket.addEventListener("close", () => finish(resolve), { once: true });
+        socket.addEventListener(
+          "error",
+          (event) =>
+            finish(
+              reject,
+              new Error(
+                event?.message ||
+                  event?.error?.message ||
+                  "Observer WebSocket close failed",
+              ),
+            ),
+          { once: true },
+        );
+        try {
+          socket.close();
+        } catch (error) {
+          finish(reject, error);
+        }
+      });
+      return closePromise;
+    },
+  };
+};
+
+const writeArtifact = (filePath, contents) => {
+  fs.writeFileSync(filePath, contents);
+};
+
+const main = async () => {
+  const config = parseCaptureEnvironment(process.env, process.cwd());
+  fs.mkdirSync(config.outputDir, { recursive: true });
+  const manifest = await captureFixtureMatrix(config, {
+    navigateInWorker: (currentTargetUrl, targetUrl, scenario) =>
+      runNavigationWorkerProcess(config, currentTargetUrl, targetUrl, scenario),
+    validateInWorker: (targetUrl, scenario) =>
+      runValidationWorkerProcess(config, targetUrl, scenario),
+    screenshotInWorker: (targetUrl, scenario) =>
+      runPureScreenshotWorkerProcess(config, targetUrl, scenario),
+    now: () => new Date().toISOString(),
+    writeArtifact,
+  });
+  process.stdout.write(
+    `${JSON.stringify(
+      {
+        runId: manifest.runId,
+        outputDir: manifest.outputDir,
+        manifestPath: path.join(config.outputDir, MANIFEST_FILE_NAME),
+        scenarioCount: manifest.scenarios.length,
+        windowsOsDpiChanged: false,
+      },
+      null,
+      2,
+    )}\n`,
+  );
+};
+
+const useCdpClient = async (client, action) => {
+  let result;
+  let actionError;
+  try {
+    result = await action(client);
+  } catch (error) {
+    actionError = error;
+  }
+  try {
+    await client.close();
+  } catch (closeError) {
+    if (actionError) {
+      throw new AggregateError(
+        [actionError, closeError],
+        "Game-path worker operation and CDP close both failed",
+        { cause: closeError },
+      );
+    }
+    // This helper is used only at dedicated child-process boundaries. A
+    // successful worker payload is authoritative; process exit releases a CDP
+    // session whose WebSocket close handshake reports an error.
+  }
+  if (actionError) throw actionError;
+  return result;
+};
+
+const executeNavigationWorker = async (args) => {
+  const worker = parseNavigationWorkerArguments(args);
+  const client = await createCdpClient(
+    {
+      port: worker.port,
+      targetUrl: worker.currentTargetUrl,
+      runId: worker.runId,
+    },
+    worker.currentTargetUrl,
+  );
+  await useCdpClient(client, async (activeClient) => {
+    await activeClient.setViewport(worker.scenario);
+    await activeClient.navigate(worker.targetUrl);
+  });
+  return {
+    schemaVersion: 1,
+    kind: "navigation-complete",
+    targetUrl: worker.targetUrl,
+    scenarioId: worker.scenario.id,
+  };
+};
+
+const executeValidationWorker = async (args) => {
+  const worker = parseValidationWorkerArguments(args);
+  const client = await createCdpClient(
+    {
+      port: worker.port,
+      targetUrl: worker.targetUrl,
+      runId: worker.runId,
+    },
+    worker.targetUrl,
+  );
+  return useCdpClient(client, async (activeClient) => {
+    await activeClient.setViewport(worker.scenario);
+    await activeClient.waitForLayoutReady(worker.scenario);
+    const state = await activeClient.readState();
+    const protocolErrors = activeClient.takeErrors();
+    assertScenarioState(worker.scenario, state, protocolErrors);
+    return {
+      schemaVersion: 1,
+      kind: "validation-result",
+      targetUrl: worker.targetUrl,
+      scenarioId: worker.scenario.id,
+      state,
+      protocolErrors,
+    };
+  });
+};
+
+const executePureScreenshotWorker = async (args) => {
+  const worker = parsePureScreenshotWorkerArguments(args);
+  return capturePureScreenshot(worker);
+};
+
+if (require.main === module) {
+  const cliArguments = process.argv.slice(2);
+  if (cliArguments[0] === NAVIGATION_WORKER_ARGUMENT) {
+    executeNavigationWorker(cliArguments)
+      .then((payload) => process.stdout.write(`${JSON.stringify(payload)}\n`))
+      .catch((error) => {
+        process.stderr.write(`${error.message}\n`);
+        process.exitCode = 1;
+      });
+  } else if (cliArguments[0] === VALIDATION_WORKER_ARGUMENT) {
+    executeValidationWorker(cliArguments)
+      .then((payload) => process.stdout.write(`${JSON.stringify(payload)}\n`))
+      .catch((error) => {
+        process.stderr.write(`${error.message}\n`);
+        process.exitCode = 1;
+      });
+  } else if (cliArguments[0] === PURE_SCREENSHOT_WORKER_ARGUMENT) {
+    executePureScreenshotWorker(cliArguments)
+      .then((screenshot) => process.stdout.write(screenshot))
+      .catch((error) => {
+        process.stderr.write(`${error.message}\n`);
+        process.exitCode = 1;
+      });
+  } else {
+    main().catch((error) => {
+      process.stderr.write(`game-path-diagnostic-capture: ${error.message}\n`);
+      process.exitCode = 1;
+    });
+  }
+}
+
+module.exports = {
+  assertLayoutReadyResult,
+  assertScenarioState,
+  buildLayoutReadyExpression,
+  buildOwnedFixtureUrl,
+  buildScenarioMatrix,
+  buildScreenshotFileName,
+  capturePureScreenshot,
+  captureFixtureMatrix,
+  parseCaptureEnvironment,
+  parseNavigationWorkerArguments,
+  parsePureScreenshotWorkerArguments,
+  parseValidationWorkerArguments,
+  runNavigationWorkerProcess,
+  runPureScreenshotWorkerProcess,
+  runValidationWorkerProcess,
+  settleAfterCdpWorkerDetach,
+  useCdpClient,
+};

--- a/scripts/qa/game-path-diagnostic-capture.node-test.cjs
+++ b/scripts/qa/game-path-diagnostic-capture.node-test.cjs
@@ -1,0 +1,1635 @@
+"use strict";
+
+/* eslint-disable @typescript-eslint/no-require-imports */
+/* global Buffer, __dirname, process, queueMicrotask, require */
+
+const assert = require("node:assert/strict");
+const { EventEmitter } = require("node:events");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+
+const {
+  assertLayoutReadyResult,
+  assertScenarioState,
+  buildLayoutReadyExpression,
+  buildOwnedFixtureUrl,
+  buildScenarioMatrix,
+  buildScreenshotFileName,
+  capturePureScreenshot,
+  captureFixtureMatrix,
+  parseCaptureEnvironment,
+  parseNavigationWorkerArguments,
+  parsePureScreenshotWorkerArguments,
+  parseValidationWorkerArguments,
+  runNavigationWorkerProcess,
+  runPureScreenshotWorkerProcess,
+  runValidationWorkerProcess,
+  settleAfterCdpWorkerDetach,
+  useCdpClient,
+} = require("./game-path-diagnostic-capture.cjs");
+
+const RUN_ID = "qa-ms64b-12345678";
+const TARGET_URL = `http://localhost:54321/?codexQaFixture=diagnostic&codexQaRun=${RUN_ID}`;
+const SELECTED_PATH = String.raw`C:\Games\Kakao Games\Path of Exile 2`;
+const PNG_BYTES = Buffer.concat([
+  Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+  Buffer.from("worker-png"),
+]);
+
+const createProjectPaths = () => {
+  const projectRoot = path.join(os.tmpdir(), "poe2-launcher-source");
+  const outputDir = path.join(
+    projectRoot,
+    ".tmp",
+    "electron",
+    RUN_ID,
+    "game-path-diagnostic-capture",
+  );
+  return { projectRoot, outputDir };
+};
+
+const createState = (scenario) => {
+  const { width, height } = scenario.viewport;
+  const nested = scenario.mode !== "diagnostic";
+  const appScale = Math.min(width / 1440, height / 960);
+  const modalRect = {
+    left: 40,
+    top: 24,
+    right: width - 40,
+    bottom: height - 24,
+  };
+  return {
+    modeMarker: scenario.mode,
+    splashPresent: false,
+    splashVisible: false,
+    appScale,
+    dialogCount: nested ? 2 : 1,
+    viewport: { width, height, devicePixelRatio: scenario.deviceScaleFactor },
+    modalRect,
+    headerRect: { left: 40, top: 24, right: width - 40, bottom: 100 },
+    footerRect: {
+      left: 40,
+      top: height - 100,
+      right: width - 40,
+      bottom: height - 24,
+    },
+    optionRects: [
+      { left: 62, top: 122, right: width / 2 - 8, bottom: height - 160 },
+      {
+        left: width / 2 + 8,
+        top: 122,
+        right: width - 62,
+        bottom: height - 160,
+      },
+    ],
+    outerAriaModal: nested ? null : "true",
+    outerBackgroundInert: nested,
+    outerBackgroundAriaHidden: nested ? "true" : null,
+    nestedAriaModal: nested ? "true" : null,
+    nestedOverlayRect: nested ? modalRect : null,
+    nestedFocusInside: nested ? true : null,
+    scroll: {
+      document: {
+        scrollWidth: width,
+        clientWidth: width,
+        scrollHeight: height,
+        clientHeight: height,
+      },
+      body: {
+        scrollWidth: width,
+        clientWidth: width,
+        scrollHeight: height,
+        clientHeight: height,
+      },
+      modalBody: {
+        scrollWidth: 800,
+        clientWidth: 800,
+        scrollHeight: 900,
+        clientHeight: 420,
+        overflowY: "auto",
+        overscrollBehaviorY: "contain",
+      },
+    },
+    longPath: {
+      text: SELECTED_PATH,
+      rect: { left: 62, top: 170, right: width / 2 - 8, bottom: 220 },
+      scrollWidth: 360,
+      clientWidth: 360,
+      overflowWrap: "anywhere",
+    },
+    hitTargets: {
+      checkboxOptions:
+        scenario.mode === "selection"
+          ? [
+              {
+                left: 160,
+                top: 260,
+                right: 160 + 320 * appScale,
+                bottom: 260 + 52 * appScale,
+              },
+              {
+                left: 160,
+                top: 320,
+                right: 160 + 320 * appScale,
+                bottom: 320 + 52 * appScale,
+              },
+              {
+                left: 160,
+                top: 380,
+                right: 160 + 320 * appScale,
+                bottom: 380 + 52 * appScale,
+              },
+            ]
+          : [],
+      deleteButtons: [
+        {
+          left: 300,
+          top: 260,
+          right: 300 + 40 * appScale,
+          bottom: 260 + 40 * appScale,
+        },
+      ],
+      primaryAction: {
+        left: 500,
+        top: height - 80,
+        right: 500 + 120 * appScale,
+        bottom: height - 80 + 36 * appScale,
+      },
+    },
+    selection:
+      scenario.mode === "selection"
+        ? {
+            ctaText: "선택 (2개)",
+            checks: [
+              { targetId: "registry-primary", checked: true },
+              { targetId: "registry-compatibility", checked: false },
+              { targetId: "config", checked: true },
+            ],
+          }
+        : null,
+    partial:
+      scenario.mode === "partial"
+        ? {
+            retryText: "실패 항목 다시 시도 (1개)",
+            results: [
+              { targetId: "registry-primary", status: "applied" },
+              { targetId: "registry-compatibility", status: "failed" },
+              { targetId: "config", status: "unchanged" },
+            ],
+          }
+        : null,
+    deletion:
+      scenario.mode === "delete"
+        ? {
+            title: "레지스트리 경로값을 삭제할까요?",
+            candidate: "Kakaogames (기본)",
+            path: SELECTED_PATH,
+          }
+        : null,
+  };
+};
+
+const createLayoutReadyResult = (scenario) => ({
+  ready: true,
+  marker: scenario.mode,
+  appScale: Math.min(
+    scenario.viewport.width / 1440,
+    scenario.viewport.height / 960,
+  ),
+  viewport: {
+    width: scenario.viewport.width,
+    height: scenario.viewport.height,
+    devicePixelRatio: scenario.deviceScaleFactor,
+  },
+  fontStatus: "loaded",
+});
+
+const createWorkerProcessHarness = ({
+  stdout = PNG_BYTES,
+  stderr = Buffer.alloc(0),
+  exitCode = 0,
+  hang = false,
+  spawnError = null,
+} = {}) => {
+  const calls = [];
+  const children = [];
+  let activeChildren = 0;
+
+  const spawn = (command, args, options) => {
+    const callIndex = calls.length;
+    const child = new EventEmitter();
+    child.stdout = new EventEmitter();
+    child.stderr = new EventEmitter();
+    child.killCalls = [];
+    child.closed = false;
+    const closeChild = (code, signal) => {
+      if (child.closed) return;
+      child.closed = true;
+      activeChildren -= 1;
+      child.emit("close", code, signal);
+    };
+    child.kill = (signal) => {
+      child.killCalls.push(signal);
+      queueMicrotask(() => closeChild(null, signal));
+      return true;
+    };
+    const call = {
+      command,
+      args,
+      options,
+      callIndex,
+      activeAtSpawn: activeChildren,
+    };
+    calls.push(call);
+    children.push(child);
+    activeChildren += 1;
+
+    queueMicrotask(() => {
+      if (spawnError) {
+        child.emit("error", spawnError);
+        return;
+      }
+      if (hang) return;
+      const stdoutValue =
+        typeof stdout === "function" ? Buffer.from(stdout(call)) : stdout;
+      const stderrValue =
+        typeof stderr === "function" ? Buffer.from(stderr(call)) : stderr;
+      if (stdoutValue.length > 0) child.stdout.emit("data", stdoutValue);
+      if (stderrValue.length > 0) child.stderr.emit("data", stderrValue);
+      closeChild(
+        typeof exitCode === "function" ? exitCode(call) : exitCode,
+        null,
+      );
+    });
+    return child;
+  };
+
+  return {
+    calls,
+    children,
+    spawn,
+    get activeChildren() {
+      return activeChildren;
+    },
+  };
+};
+
+const createPureScreenshotHarness = (targetUrl) => {
+  const commands = [];
+  const sockets = [];
+  let fetchCount = 0;
+
+  class FakeWebSocket {
+    constructor(url) {
+      this.url = url;
+      this.listeners = new Map();
+      this.readyState = 0;
+      this.closeCount = 0;
+      sockets.push(this);
+      queueMicrotask(() => {
+        this.readyState = 1;
+        this.emit("open", {});
+      });
+    }
+
+    addEventListener(type, callback, options = {}) {
+      const listeners = this.listeners.get(type) || [];
+      listeners.push({ callback, once: options.once === true });
+      this.listeners.set(type, listeners);
+    }
+
+    emit(type, event) {
+      const listeners = [...(this.listeners.get(type) || [])];
+      for (const listener of listeners) {
+        listener.callback(event);
+        if (listener.once) {
+          this.listeners.set(
+            type,
+            (this.listeners.get(type) || []).filter(
+              (candidate) => candidate !== listener,
+            ),
+          );
+        }
+      }
+    }
+
+    send(payload) {
+      const command = JSON.parse(payload);
+      commands.push(command);
+      const result =
+        command.method === "Page.captureScreenshot"
+          ? { data: PNG_BYTES.toString("base64") }
+          : {};
+      queueMicrotask(() =>
+        this.emit("message", {
+          data: JSON.stringify({ id: command.id, result }),
+        }),
+      );
+    }
+
+    close() {
+      this.closeCount += 1;
+      this.readyState = 3;
+      this.emit("close", {});
+    }
+  }
+
+  return {
+    commands,
+    sockets,
+    get fetchCount() {
+      return fetchCount;
+    },
+    dependencies: {
+      commandTimeoutMs: 10,
+      async fetch() {
+        fetchCount += 1;
+        return {
+          ok: true,
+          async json() {
+            return [
+              {
+                url: targetUrl,
+                webSocketDebuggerUrl: "ws://owned-target/devtools/page/1",
+              },
+            ];
+          },
+        };
+      },
+      WebSocket: FakeWebSocket,
+    },
+  };
+};
+
+test("accepts only the exact localhost owned target and run-owned output", () => {
+  const { projectRoot, outputDir } = createProjectPaths();
+
+  assert.deepEqual(
+    parseCaptureEnvironment(
+      {
+        CDP_PORT: "43123",
+        CDP_TARGET_URL: TARGET_URL,
+        GAME_PATH_QA_OUTPUT_DIR: outputDir,
+      },
+      projectRoot,
+    ),
+    {
+      port: 43123,
+      targetUrl: TARGET_URL,
+      runId: RUN_ID,
+      initialMode: "diagnostic",
+      outputDir: path.resolve(outputDir),
+    },
+  );
+});
+
+const invalidEnvironmentCases = [
+  ["missing port", { CDP_PORT: undefined }],
+  ["invalid port", { CDP_PORT: "9222x" }],
+  [
+    "foreign host",
+    { CDP_TARGET_URL: TARGET_URL.replace("localhost", "127.0.0.1") },
+  ],
+  ["wrong port", { CDP_TARGET_URL: TARGET_URL.replace("54321", "54322") }],
+  [
+    "arbitrary path",
+    { CDP_TARGET_URL: TARGET_URL.replace("/?", "/fixture.html?") },
+  ],
+  ["unknown query", { CDP_TARGET_URL: `${TARGET_URL}&script=alert(1)` }],
+  [
+    "invalid mode",
+    { CDP_TARGET_URL: TARGET_URL.replace("diagnostic", "../../x") },
+  ],
+  ["duplicate run", { CDP_TARGET_URL: `${TARGET_URL}&codexQaRun=${RUN_ID}` }],
+  ["relative output", { GAME_PATH_QA_OUTPUT_DIR: ".tmp/output" }],
+  [
+    "production source output",
+    {
+      GAME_PATH_QA_OUTPUT_DIR: path.join(
+        createProjectPaths().projectRoot,
+        "src",
+        RUN_ID,
+        "game-path-diagnostic-capture",
+      ),
+    },
+  ],
+  [
+    "foreign run output",
+    {
+      GAME_PATH_QA_OUTPUT_DIR: path.join(
+        createProjectPaths().projectRoot,
+        ".tmp",
+        "electron",
+        "foreign-run",
+        "game-path-diagnostic-capture",
+      ),
+    },
+  ],
+];
+
+for (const [label, override] of invalidEnvironmentCases) {
+  test(`fails closed for ${label}`, () => {
+    const { projectRoot, outputDir } = createProjectPaths();
+    assert.throws(() =>
+      parseCaptureEnvironment(
+        {
+          CDP_PORT: "43123",
+          CDP_TARGET_URL: TARGET_URL,
+          GAME_PATH_QA_OUTPUT_DIR: outputDir,
+          ...override,
+        },
+        projectRoot,
+      ),
+    );
+  });
+}
+
+test("builds the four modes over the three paired simulated viewport/DPR cases", () => {
+  const matrix = buildScenarioMatrix();
+
+  assert.equal(matrix.length, 12);
+  assert.deepEqual(
+    [...new Set(matrix.map(({ mode }) => mode))],
+    ["diagnostic", "selection", "partial", "delete"],
+  );
+  assert.deepEqual(
+    [
+      ...new Set(
+        matrix.map(
+          ({ viewportLabel, deviceScaleFactor }) =>
+            `${viewportLabel}@${deviceScaleFactor}`,
+        ),
+      ),
+    ],
+    ["1024x683@1", "1440x960@1.25", "1920x1080@1.5"],
+  );
+  assert.equal(
+    new Set(matrix.map((scenario) => buildScreenshotFileName(scenario))).size,
+    12,
+  );
+  assert.equal(
+    buildScreenshotFileName(matrix[3]),
+    "selection--1024x683--dpr-1.png",
+  );
+  assert.equal(
+    buildScreenshotFileName(matrix[5]),
+    "selection--1920x1080--dpr-1p5.png",
+  );
+});
+
+test("cycles only exact owned fixture URLs", () => {
+  assert.equal(
+    buildOwnedFixtureUrl(TARGET_URL, "partial"),
+    `http://localhost:54321/?codexQaFixture=partial&codexQaRun=${RUN_ID}`,
+  );
+  assert.throws(() => buildOwnedFixtureUrl(TARGET_URL, "arbitrary"));
+});
+
+test("keeps the top-level orchestrator CDP-free", () => {
+  const source = fs.readFileSync(
+    path.join(__dirname, "game-path-diagnostic-capture.cjs"),
+    "utf8",
+  );
+  const mainBlock = source.slice(
+    source.indexOf("const main = async"),
+    source.indexOf("const useCdpClient = async"),
+  );
+  assert.match(mainBlock, /runNavigationWorkerProcess/);
+  assert.match(mainBlock, /runValidationWorkerProcess/);
+  assert.match(mainBlock, /runPureScreenshotWorkerProcess/);
+  assert.doesNotMatch(mainBlock, /createCdpClient|WebSocket|\/json\/list/);
+  const validationBlock = source.slice(
+    source.indexOf("const executeValidationWorker = async"),
+    source.indexOf("const executePureScreenshotWorker = async"),
+  );
+  assert.doesNotMatch(
+    validationBlock,
+    /Page\.bringToFront|Page\.captureScreenshot|captureScreenshot/,
+  );
+});
+
+test("parses only exact navigation validation and screenshot worker argv", () => {
+  const scenario = buildScenarioMatrix()[0];
+  const targetUrl = buildOwnedFixtureUrl(TARGET_URL, scenario.mode);
+  const shared = [
+    "--cdp-port",
+    "43123",
+    "--target-url",
+    targetUrl,
+    "--scenario-id",
+    scenario.id,
+    "--width",
+    String(scenario.viewport.width),
+    "--height",
+    String(scenario.viewport.height),
+    "--device-scale-factor",
+    String(scenario.deviceScaleFactor),
+  ];
+
+  assert.deepEqual(
+    parseNavigationWorkerArguments([
+      "--game-path-navigation-worker",
+      "--current-target-url",
+      TARGET_URL,
+      ...shared,
+    ]),
+    {
+      port: 43123,
+      currentTargetUrl: TARGET_URL,
+      targetUrl,
+      runId: RUN_ID,
+      scenario,
+    },
+  );
+  assert.deepEqual(
+    parseValidationWorkerArguments([
+      "--game-path-validation-worker",
+      ...shared,
+    ]),
+    { port: 43123, targetUrl, runId: RUN_ID, scenario },
+  );
+  assert.deepEqual(
+    parsePureScreenshotWorkerArguments([
+      "--game-path-pure-screenshot-worker",
+      ...shared,
+    ]),
+    { port: 43123, targetUrl, runId: RUN_ID, scenario },
+  );
+  assert.throws(() =>
+    parsePureScreenshotWorkerArguments([
+      "--game-path-pure-screenshot-worker",
+      ...shared.slice(0, -1),
+      "1.5",
+    ]),
+  );
+  assert.throws(() =>
+    parseNavigationWorkerArguments([
+      "--game-path-navigation-worker",
+      "--current-target-url",
+      TARGET_URL.replace("localhost", "127.0.0.1"),
+      ...shared,
+    ]),
+  );
+});
+
+test("runs navigation validation and pure screenshot in separate workers", async () => {
+  const scenario = buildScenarioMatrix()[0];
+  const targetUrl = buildOwnedFixtureUrl(TARGET_URL, scenario.mode);
+  const state = createState(scenario);
+  const harness = createWorkerProcessHarness({
+    stdout: ({ args }) => {
+      if (args.includes("--game-path-pure-screenshot-worker")) {
+        return PNG_BYTES;
+      }
+      return Buffer.from(
+        JSON.stringify(
+          args.includes("--game-path-navigation-worker")
+            ? {
+                schemaVersion: 1,
+                kind: "navigation-complete",
+                targetUrl,
+                scenarioId: scenario.id,
+              }
+            : {
+                schemaVersion: 1,
+                kind: "validation-result",
+                targetUrl,
+                scenarioId: scenario.id,
+                state,
+                protocolErrors: [],
+              },
+        ),
+      );
+    },
+  });
+  const { projectRoot, outputDir } = createProjectPaths();
+  const config = parseCaptureEnvironment(
+    {
+      CDP_PORT: "43123",
+      CDP_TARGET_URL: TARGET_URL,
+      GAME_PATH_QA_OUTPUT_DIR: outputDir,
+    },
+    projectRoot,
+  );
+
+  await runNavigationWorkerProcess(config, TARGET_URL, targetUrl, scenario, {
+    spawn: harness.spawn,
+  });
+  const validation = await runValidationWorkerProcess(
+    config,
+    targetUrl,
+    scenario,
+    { spawn: harness.spawn },
+  );
+  const screenshot = await runPureScreenshotWorkerProcess(
+    config,
+    targetUrl,
+    scenario,
+    { spawn: harness.spawn },
+  );
+
+  assert.deepEqual(validation, { state, protocolErrors: [] });
+  assert.deepEqual(screenshot, PNG_BYTES);
+  assert.equal(harness.calls.length, 3);
+  assert.ok(harness.calls.every(({ command }) => command === process.execPath));
+  assert.match(harness.calls[0].args.join(" "), /navigation-worker/);
+  assert.match(harness.calls[1].args.join(" "), /validation-worker/);
+  assert.match(harness.calls[2].args.join(" "), /pure-screenshot-worker/);
+  for (const { args, options } of harness.calls) {
+    assert.ok(args.includes(String(scenario.viewport.width)));
+    assert.ok(args.includes(String(scenario.viewport.height)));
+    assert.ok(args.includes(String(scenario.deviceScaleFactor)));
+    assert.deepEqual(options, {
+      shell: false,
+      windowsHide: true,
+      env: {},
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+  }
+});
+
+test("retries the exact pure capture timeout once in a new worker", async () => {
+  const scenario = buildScenarioMatrix()[0];
+  const timeoutSignature =
+    "Timed out waiting for pure CDP command Page.captureScreenshot";
+  const harness = createWorkerProcessHarness({
+    stdout: ({ callIndex }) => (callIndex === 0 ? Buffer.alloc(0) : PNG_BYTES),
+    stderr: ({ callIndex }) =>
+      callIndex === 0 ? Buffer.from(timeoutSignature) : Buffer.alloc(0),
+    exitCode: ({ callIndex }) => (callIndex === 0 ? 1 : 0),
+  });
+  const { projectRoot, outputDir } = createProjectPaths();
+  const config = parseCaptureEnvironment(
+    {
+      CDP_PORT: "43123",
+      CDP_TARGET_URL: TARGET_URL,
+      GAME_PATH_QA_OUTPUT_DIR: outputDir,
+    },
+    projectRoot,
+  );
+
+  const screenshot = await runPureScreenshotWorkerProcess(
+    config,
+    TARGET_URL,
+    scenario,
+    { spawn: harness.spawn },
+  );
+
+  assert.deepEqual(screenshot, PNG_BYTES);
+  assert.equal(harness.calls.length, 2);
+  assert.notEqual(harness.children[0], harness.children[1]);
+  assert.ok(
+    harness.calls.every(({ args }) =>
+      args.includes("--game-path-pure-screenshot-worker"),
+    ),
+  );
+  assert.equal(harness.activeChildren, 0);
+});
+
+test("does not retry non-exact pure screenshot worker failures", async () => {
+  const scenario = buildScenarioMatrix()[0];
+  const { projectRoot, outputDir } = createProjectPaths();
+  const config = parseCaptureEnvironment(
+    {
+      CDP_PORT: "43123",
+      CDP_TARGET_URL: TARGET_URL,
+      GAME_PATH_QA_OUTPUT_DIR: outputDir,
+    },
+    projectRoot,
+  );
+
+  for (const message of [
+    "Timed out waiting for pure CDP command Page.bringToFront",
+    "Timed out waiting for pure CDP command Page.captureScreenshot extra",
+    "Pure screenshot CDP command Page.captureScreenshot failed: blocked",
+  ]) {
+    const harness = createWorkerProcessHarness({
+      exitCode: 1,
+      stderr: Buffer.from(message),
+    });
+    await assert.rejects(
+      runPureScreenshotWorkerProcess(config, TARGET_URL, scenario, {
+        spawn: harness.spawn,
+      }),
+      new RegExp(message.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")),
+    );
+    assert.equal(harness.calls.length, 1);
+  }
+});
+
+test("preserves both pure screenshot failures after the one retry", async () => {
+  const scenario = buildScenarioMatrix()[0];
+  const firstMessage =
+    "Timed out waiting for pure CDP command Page.captureScreenshot";
+  const secondMessage =
+    "Pure screenshot CDP command Page.captureScreenshot failed: blocked";
+  const harness = createWorkerProcessHarness({
+    exitCode: 1,
+    stderr: ({ callIndex }) =>
+      Buffer.from(callIndex === 0 ? firstMessage : secondMessage),
+  });
+  const { projectRoot, outputDir } = createProjectPaths();
+  const config = parseCaptureEnvironment(
+    {
+      CDP_PORT: "43123",
+      CDP_TARGET_URL: TARGET_URL,
+      GAME_PATH_QA_OUTPUT_DIR: outputDir,
+    },
+    projectRoot,
+  );
+
+  await assert.rejects(
+    runPureScreenshotWorkerProcess(config, TARGET_URL, scenario, {
+      spawn: harness.spawn,
+    }),
+    (error) => {
+      assert.ok(error instanceof AggregateError);
+      assert.match(error.message, new RegExp(scenario.id));
+      assert.match(error.message, new RegExp(RUN_ID));
+      assert.equal(error.errors.length, 2);
+      assert.match(error.errors[0].message, new RegExp(firstMessage));
+      assert.match(error.errors[1].message, new RegExp(secondMessage));
+      return true;
+    },
+  );
+  assert.equal(harness.calls.length, 2);
+  assert.equal(harness.activeChildren, 0);
+});
+
+test("fails closed for worker nonzero timeout oversized malformed and foreign payloads", async () => {
+  const scenario = buildScenarioMatrix()[0];
+  const { projectRoot, outputDir } = createProjectPaths();
+  const config = parseCaptureEnvironment(
+    {
+      CDP_PORT: "43123",
+      CDP_TARGET_URL: TARGET_URL,
+      GAME_PATH_QA_OUTPUT_DIR: outputDir,
+    },
+    projectRoot,
+  );
+  const screenshotCases = [
+    {
+      harness: createWorkerProcessHarness({
+        exitCode: 1,
+        stderr: Buffer.from("Page.captureScreenshot failed: blocked"),
+      }),
+      dependencies: {},
+      expected: /Page\.captureScreenshot failed: blocked/,
+    },
+    {
+      harness: createWorkerProcessHarness({ hang: true }),
+      dependencies: { timeoutMs: 5 },
+      expected: /timed out/i,
+    },
+    {
+      harness: createWorkerProcessHarness({ stdout: Buffer.alloc(17, 1) }),
+      dependencies: { maxOutputBytes: 16 },
+      expected: /maximum output/i,
+    },
+    {
+      harness: createWorkerProcessHarness({ stdout: Buffer.from("not-png") }),
+      dependencies: {},
+      expected: /valid PNG/i,
+    },
+  ];
+
+  for (const testCase of screenshotCases) {
+    await assert.rejects(
+      runPureScreenshotWorkerProcess(config, TARGET_URL, scenario, {
+        spawn: testCase.harness.spawn,
+        ...testCase.dependencies,
+      }),
+      testCase.expected,
+    );
+    const [child] = testCase.harness.children;
+    assert.equal(child.listenerCount("error"), 0);
+    assert.equal(child.listenerCount("close"), 0);
+    assert.equal(child.stdout.listenerCount("data"), 0);
+    assert.equal(child.stderr.listenerCount("data"), 0);
+  }
+
+  for (const [stdout, expected] of [
+    [Buffer.from("not-json"), /structured payload/i],
+    [
+      Buffer.from(
+        JSON.stringify({
+          schemaVersion: 1,
+          kind: "validation-result",
+          targetUrl: TARGET_URL.replace(RUN_ID, "foreign-run-12345678"),
+          scenarioId: scenario.id,
+          state: createState(scenario),
+          protocolErrors: [],
+        }),
+      ),
+      /exact owned worker payload/i,
+    ],
+  ]) {
+    const harness = createWorkerProcessHarness({ stdout });
+    await assert.rejects(
+      runValidationWorkerProcess(config, TARGET_URL, scenario, {
+        spawn: harness.spawn,
+      }),
+      expected,
+    );
+  }
+});
+
+test("pure screenshot session sends only metrics bring-to-front and capture", async () => {
+  const scenario = buildScenarioMatrix()[0];
+  const harness = createPureScreenshotHarness(TARGET_URL);
+  const screenshot = await capturePureScreenshot(
+    {
+      port: 43123,
+      targetUrl: TARGET_URL,
+      runId: RUN_ID,
+      scenario,
+    },
+    harness.dependencies,
+  );
+
+  assert.deepEqual(screenshot, PNG_BYTES);
+  assert.equal(harness.fetchCount, 1);
+  assert.deepEqual(
+    harness.commands.map(({ method }) => method),
+    [
+      "Emulation.setDeviceMetricsOverride",
+      "Page.bringToFront",
+      "Page.captureScreenshot",
+    ],
+  );
+  assert.ok(
+    harness.commands.every(
+      ({ method }) =>
+        !/^(Runtime|Log|Inspector)\./.test(method) &&
+        method !== "Page.enable" &&
+        method !== "Runtime.evaluate",
+    ),
+  );
+  assert.deepEqual(harness.commands[0].params, {
+    width: 1024,
+    height: 683,
+    deviceScaleFactor: 1,
+    mobile: false,
+    screenWidth: 1024,
+    screenHeight: 683,
+  });
+  assert.equal(harness.sockets[0].closeCount, 1);
+});
+
+test("worker client keeps a successful action result when close fails", async () => {
+  const result = { kind: "navigation-complete" };
+
+  assert.equal(
+    await useCdpClient(
+      {
+        async close() {
+          throw new Error("Observer WebSocket close failed");
+        },
+      },
+      async () => result,
+    ),
+    result,
+  );
+});
+
+test("worker client preserves an action failure when close succeeds", async () => {
+  const actionError = new Error("navigation failed");
+
+  await assert.rejects(
+    useCdpClient({ async close() {} }, async () => {
+      throw actionError;
+    }),
+    (error) => error === actionError,
+  );
+});
+
+test("worker client aggregates action and close failures", async () => {
+  const actionError = new Error("validation failed");
+  const closeError = new Error("Observer WebSocket close failed");
+
+  await assert.rejects(
+    useCdpClient(
+      {
+        async close() {
+          throw closeError;
+        },
+      },
+      async () => {
+        throw actionError;
+      },
+    ),
+    (error) => {
+      assert.ok(error instanceof AggregateError);
+      assert.deepEqual(error.errors, [actionError, closeError]);
+      return true;
+    },
+  );
+});
+
+test("uses an exact bounded 1000ms CDP worker-detach settle", async () => {
+  let delayMs;
+
+  await settleAfterCdpWorkerDetach((resolve, milliseconds) => {
+    delayMs = milliseconds;
+    resolve();
+  });
+
+  assert.equal(delayMs, 1000);
+});
+
+test("awaits only short finite owned modal animations before two stable frames", () => {
+  const scenario = buildScenarioMatrix()[0];
+
+  assert.equal(typeof buildLayoutReadyExpression, "function");
+  const expression = buildLayoutReadyExpression(scenario);
+  assert.match(expression, /document\.fonts\.ready/);
+  assert.match(expression, /getAnimations\(\{ subtree: true \}\)/);
+  assert.match(expression, /animation\.finished/);
+  assert.match(expression, /Number\.isFinite\(timing\.endTime\)/);
+  assert.match(expression, /timing\.endTime <= maxOwnedAnimationMs/);
+  assert.match(expression, /owned animation rejected/);
+  assert.match(expression, /\.game-path-modal \[role='dialog'\]/);
+  assert.doesNotMatch(expression, /, \[role='dialog'\]"/);
+  assert.doesNotMatch(expression, /document\.getAnimations/);
+  assert.match(expression, /requestAnimationFrame/);
+  assert.match(expression, /await nextFrame\(\);\s*await nextFrame\(\);/);
+  assert.match(expression, /qa-layout-ready-timeout/);
+  assert.match(
+    expression,
+    new RegExp(`expectedMode = ${JSON.stringify(scenario.mode)}`),
+  );
+  assert.match(
+    expression,
+    new RegExp(`expectedWidth = ${scenario.viewport.width}`),
+  );
+  assert.match(
+    expression,
+    new RegExp(`expectedHeight = ${scenario.viewport.height}`),
+  );
+
+  const animationAwait = expression.indexOf("await Promise.allSettled");
+  const firstStableFrame = expression.indexOf(
+    "await nextFrame();",
+    animationAwait,
+  );
+  const secondStableFrame = expression.indexOf(
+    "await nextFrame();",
+    firstStableFrame + 1,
+  );
+  const finalRecheck = expression.indexOf(
+    "const stableState = readOwnedState();",
+    secondStableFrame,
+  );
+  assert.ok(animationAwait >= 0);
+  assert.ok(firstStableFrame > animationAwait);
+  assert.ok(secondStableFrame > firstStableFrame);
+  assert.ok(finalRecheck > secondStableFrame);
+});
+
+test("accepts only the exact ready marker, scale and simulated viewport", () => {
+  const scenario = buildScenarioMatrix()[0];
+  const ready = createLayoutReadyResult(scenario);
+
+  assert.equal(typeof assertLayoutReadyResult, "function");
+  assert.doesNotThrow(() => assertLayoutReadyResult(scenario, ready));
+  assert.throws(
+    () =>
+      assertLayoutReadyResult(scenario, {
+        ...ready,
+        marker: "selection",
+      }),
+    /marker mismatch/,
+  );
+  assert.throws(
+    () =>
+      assertLayoutReadyResult(scenario, {
+        ...ready,
+        appScale: 1,
+      }),
+    /scale mismatch/,
+  );
+  assert.throws(
+    () =>
+      assertLayoutReadyResult(scenario, {
+        ...ready,
+        viewport: { ...ready.viewport, width: 1440 },
+      }),
+    /viewport mismatch/,
+  );
+  assert.throws(
+    () =>
+      assertLayoutReadyResult(scenario, {
+        ...ready,
+        ready: false,
+        reason: "qa-layout-ready-timeout",
+      }),
+    /qa-layout-ready-timeout/,
+  );
+  assert.throws(
+    () =>
+      assertLayoutReadyResult(scenario, {
+        ...ready,
+        ready: false,
+        reason: "owned animation rejected",
+      }),
+    /owned animation rejected/,
+  );
+});
+
+test("asserts the shared modal geometry and each mode-specific contract", () => {
+  for (const scenario of buildScenarioMatrix()) {
+    const assertions = assertScenarioState(scenario, createState(scenario), []);
+    assert.equal(assertions.modeMarker, true);
+    assert.equal(assertions.splashAbsent, true);
+    assert.equal(assertions.dialogCount, true);
+    assert.equal(assertions.modalContained, true);
+    assert.equal(assertions.headerVisible, true);
+    assert.equal(assertions.footerVisible, true);
+    assert.equal(assertions.twoColumn, true);
+    assert.equal(assertions.appScale, true);
+    assert.equal(assertions.scrollContained, true);
+    assert.equal(assertions.longPathWrapped, true);
+    assert.equal(assertions.hitTargets, true);
+    if (scenario.mode !== "diagnostic") {
+      assert.equal(assertions.nestedModal, true);
+      assert.equal(assertions.nestedFocus, true);
+      assert.equal(assertions.nestedOverlay, true);
+    }
+  }
+});
+
+test("measures nested overlay border coverage in CSS pixels at scaled viewports", () => {
+  const scenario = buildScenarioMatrix().find(
+    ({ mode, viewport }) => mode === "selection" && viewport.width === 1920,
+  );
+  assert.ok(scenario);
+  const state = createState(scenario);
+  const borderInset = state.appScale;
+  const withinBorder = {
+    ...state,
+    nestedOverlayRect: {
+      left: state.modalRect.left + borderInset,
+      top: state.modalRect.top + borderInset,
+      right: state.modalRect.right - borderInset,
+      bottom: state.modalRect.bottom - borderInset,
+    },
+  };
+
+  assert.doesNotThrow(() => assertScenarioState(scenario, withinBorder, []));
+
+  const largerGap = 1.35 * state.appScale;
+  assert.throws(
+    () =>
+      assertScenarioState(
+        scenario,
+        {
+          ...state,
+          nestedOverlayRect: {
+            left: state.modalRect.left + largerGap,
+            top: state.modalRect.top + largerGap,
+            right: state.modalRect.right - largerGap,
+            bottom: state.modalRect.bottom - largerGap,
+          },
+        },
+        [],
+      ),
+    /Nested overlay containment\/coverage failed/,
+  );
+
+  const outsideAllowance = 1.35 * state.appScale;
+  assert.throws(
+    () =>
+      assertScenarioState(
+        scenario,
+        {
+          ...state,
+          nestedOverlayRect: {
+            ...state.modalRect,
+            left: state.modalRect.left - outsideAllowance,
+          },
+        },
+        [],
+      ),
+    /Nested overlay containment\/coverage failed/,
+  );
+});
+
+test("rejects protocol errors, clipped geometry and incorrect mode states", () => {
+  const scenarios = buildScenarioMatrix();
+  const diagnostic = scenarios.find(({ mode }) => mode === "diagnostic");
+  const selection = scenarios.find(({ mode }) => mode === "selection");
+  const partial = scenarios.find(({ mode }) => mode === "partial");
+  const deletion = scenarios.find(({ mode }) => mode === "delete");
+  assert.ok(diagnostic && selection && partial && deletion);
+
+  assert.throws(() =>
+    assertScenarioState(diagnostic, createState(diagnostic), [
+      { domain: "Runtime", message: "boom" },
+    ]),
+  );
+  assert.throws(
+    () =>
+      assertScenarioState(
+        diagnostic,
+        {
+          ...createState(diagnostic),
+          splashPresent: true,
+          splashVisible: true,
+        },
+        [],
+      ),
+    /Launcher splash is present or visible/,
+  );
+  assert.throws(() =>
+    assertScenarioState(
+      diagnostic,
+      {
+        ...createState(diagnostic),
+        modalRect: { left: -1, top: 0, right: 500, bottom: 500 },
+      },
+      [],
+    ),
+  );
+  assert.throws(() =>
+    assertScenarioState(
+      selection,
+      {
+        ...createState(selection),
+        selection: { ...createState(selection).selection, ctaText: "적용" },
+      },
+      [],
+    ),
+  );
+  assert.throws(() =>
+    assertScenarioState(
+      partial,
+      {
+        ...createState(partial),
+        partial: { retryText: "전체 재시도", results: [] },
+      },
+      [],
+    ),
+  );
+  assert.throws(() =>
+    assertScenarioState(
+      deletion,
+      {
+        ...createState(deletion),
+        deletion: { ...createState(deletion).deletion, path: "C:\\Other" },
+      },
+      [],
+    ),
+  );
+  assert.throws(() =>
+    assertScenarioState(
+      diagnostic,
+      { ...createState(diagnostic), appScale: 1 },
+      [],
+    ),
+  );
+  assert.throws(() =>
+    assertScenarioState(
+      diagnostic,
+      {
+        ...createState(diagnostic),
+        scroll: {
+          ...createState(diagnostic).scroll,
+          document: {
+            ...createState(diagnostic).scroll.document,
+            scrollWidth: diagnostic.viewport.width + 2,
+          },
+        },
+      },
+      [],
+    ),
+  );
+  assert.throws(() =>
+    assertScenarioState(
+      diagnostic,
+      {
+        ...createState(diagnostic),
+        longPath: {
+          ...createState(diagnostic).longPath,
+          scrollWidth: 400,
+          clientWidth: 360,
+        },
+      },
+      [],
+    ),
+  );
+  assert.throws(() =>
+    assertScenarioState(
+      selection,
+      {
+        ...createState(selection),
+        hitTargets: {
+          ...createState(selection).hitTargets,
+          primaryAction: { left: 0, top: 0, right: 10, bottom: 10 },
+        },
+      },
+      [],
+    ),
+  );
+  assert.throws(() =>
+    assertScenarioState(
+      selection,
+      { ...createState(selection), nestedFocusInside: false },
+      [],
+    ),
+  );
+  assert.throws(() =>
+    assertScenarioState(
+      selection,
+      {
+        ...createState(selection),
+        nestedOverlayRect: {
+          ...createState(selection).nestedOverlayRect,
+          right: selection.viewport.width + 1,
+        },
+      },
+      [],
+    ),
+  );
+});
+
+test("runs three non-overlapping worker processes for each of twelve scenarios", async () => {
+  const matrix = buildScenarioMatrix();
+  const writes = [];
+  const settledScenarios = new Set();
+  const settleCalls = [];
+  const workerHarness = createWorkerProcessHarness({
+    stdout: ({ args }) => {
+      const scenarioId = args[args.indexOf("--scenario-id") + 1];
+      const targetUrl = args[args.indexOf("--target-url") + 1];
+      const scenario = matrix.find(({ id }) => id === scenarioId);
+      assert.ok(scenario);
+      if (args.includes("--game-path-pure-screenshot-worker")) {
+        return PNG_BYTES;
+      }
+      return Buffer.from(
+        JSON.stringify(
+          args.includes("--game-path-navigation-worker")
+            ? {
+                schemaVersion: 1,
+                kind: "navigation-complete",
+                targetUrl,
+                scenarioId,
+              }
+            : {
+                schemaVersion: 1,
+                kind: "validation-result",
+                targetUrl,
+                scenarioId,
+                state: createState(scenario),
+                protocolErrors: [],
+              },
+        ),
+      );
+    },
+  });
+  const { projectRoot, outputDir } = createProjectPaths();
+  const config = parseCaptureEnvironment(
+    {
+      CDP_PORT: "43123",
+      CDP_TARGET_URL: TARGET_URL,
+      GAME_PATH_QA_OUTPUT_DIR: outputDir,
+    },
+    projectRoot,
+  );
+
+  const manifest = await captureFixtureMatrix(config, {
+    navigateInWorker: (currentTargetUrl, targetUrl, scenario) =>
+      runNavigationWorkerProcess(
+        config,
+        currentTargetUrl,
+        targetUrl,
+        scenario,
+        { spawn: workerHarness.spawn },
+      ),
+    validateInWorker: async (targetUrl, scenario) => {
+      const validation = await runValidationWorkerProcess(
+        config,
+        targetUrl,
+        scenario,
+        {
+          spawn: workerHarness.spawn,
+        },
+      );
+      settledScenarios.delete(scenario.id);
+      return validation;
+    },
+    async settleAfterValidation(targetUrl, scenario) {
+      settleCalls.push({ targetUrl, scenarioId: scenario.id });
+      await Promise.resolve();
+      settledScenarios.add(scenario.id);
+    },
+    screenshotInWorker: (targetUrl, scenario) => {
+      assert.ok(
+        settledScenarios.has(scenario.id),
+        "screenshot worker started before detach settle resolved",
+      );
+      return runPureScreenshotWorkerProcess(config, targetUrl, scenario, {
+        spawn: workerHarness.spawn,
+      });
+    },
+    now: () => "2026-08-27T00:00:00.000Z",
+    writeArtifact(filePath, contents) {
+      writes.push({ filePath, contents });
+    },
+  });
+
+  assert.equal(workerHarness.calls.length, 36);
+  assert.deepEqual(
+    settleCalls,
+    matrix.map((scenario) => ({
+      targetUrl: buildOwnedFixtureUrl(TARGET_URL, scenario.mode),
+      scenarioId: scenario.id,
+    })),
+  );
+  assert.equal(workerHarness.activeChildren, 0);
+  assert.ok(
+    workerHarness.calls.every(({ activeAtSpawn }) => activeAtSpawn === 0),
+  );
+  assert.deepEqual(
+    workerHarness.calls.map(({ args }) => args[1]),
+    matrix.flatMap(() => [
+      "--game-path-navigation-worker",
+      "--game-path-validation-worker",
+      "--game-path-pure-screenshot-worker",
+    ]),
+  );
+  for (let index = 0; index < matrix.length; index += 1) {
+    const scenario = matrix[index];
+    const navigationArgs = workerHarness.calls[index * 3].args;
+    const validationArgs = workerHarness.calls[index * 3 + 1].args;
+    const screenshotArgs = workerHarness.calls[index * 3 + 2].args;
+    assert.ok(navigationArgs.includes(String(scenario.viewport.width)));
+    assert.ok(validationArgs.includes(String(scenario.viewport.width)));
+    assert.ok(screenshotArgs.includes(String(scenario.viewport.width)));
+    assert.ok(navigationArgs.includes(String(scenario.deviceScaleFactor)));
+    assert.ok(validationArgs.includes(String(scenario.deviceScaleFactor)));
+    assert.ok(screenshotArgs.includes(String(scenario.deviceScaleFactor)));
+  }
+  assert.equal(
+    writes.filter(({ filePath }) => filePath.endsWith(".png")).length,
+    12,
+  );
+  assert.equal(
+    writes.filter(({ filePath }) => filePath.endsWith("manifest.json")).length,
+    1,
+  );
+  assert.equal(manifest.scenarios.length, 12);
+  assert.ok(
+    manifest.scenarios.every(
+      ({ assertions, protocolErrors }) =>
+        assertions.appScale === true && protocolErrors.length === 0,
+    ),
+  );
+});
+
+test("writes all twelve artifacts after exact-timeout pure worker retries", async () => {
+  const matrix = buildScenarioMatrix();
+  const writes = [];
+  const timeoutSignature =
+    "Timed out waiting for pure CDP command Page.captureScreenshot";
+  const workerHarness = createWorkerProcessHarness({
+    stdout: ({ args, callIndex }) => {
+      const scenarioId = args[args.indexOf("--scenario-id") + 1];
+      const targetUrl = args[args.indexOf("--target-url") + 1];
+      const scenario = matrix.find(({ id }) => id === scenarioId);
+      assert.ok(scenario);
+      if (args.includes("--game-path-pure-screenshot-worker")) {
+        return callIndex % 4 === 3 ? PNG_BYTES : Buffer.alloc(0);
+      }
+      return Buffer.from(
+        JSON.stringify(
+          args.includes("--game-path-navigation-worker")
+            ? {
+                schemaVersion: 1,
+                kind: "navigation-complete",
+                targetUrl,
+                scenarioId,
+              }
+            : {
+                schemaVersion: 1,
+                kind: "validation-result",
+                targetUrl,
+                scenarioId,
+                state: createState(scenario),
+                protocolErrors: [],
+              },
+        ),
+      );
+    },
+    stderr: ({ args, callIndex }) =>
+      args.includes("--game-path-pure-screenshot-worker") && callIndex % 4 === 2
+        ? Buffer.from(timeoutSignature)
+        : Buffer.alloc(0),
+    exitCode: ({ args, callIndex }) =>
+      args.includes("--game-path-pure-screenshot-worker") && callIndex % 4 === 2
+        ? 1
+        : 0,
+  });
+  const { projectRoot, outputDir } = createProjectPaths();
+  const config = parseCaptureEnvironment(
+    {
+      CDP_PORT: "43123",
+      CDP_TARGET_URL: TARGET_URL,
+      GAME_PATH_QA_OUTPUT_DIR: outputDir,
+    },
+    projectRoot,
+  );
+
+  const manifest = await captureFixtureMatrix(config, {
+    navigateInWorker: (currentTargetUrl, targetUrl, scenario) =>
+      runNavigationWorkerProcess(
+        config,
+        currentTargetUrl,
+        targetUrl,
+        scenario,
+        { spawn: workerHarness.spawn },
+      ),
+    validateInWorker: (targetUrl, scenario) =>
+      runValidationWorkerProcess(config, targetUrl, scenario, {
+        spawn: workerHarness.spawn,
+      }),
+    async settleAfterValidation() {},
+    screenshotInWorker: (targetUrl, scenario) =>
+      runPureScreenshotWorkerProcess(config, targetUrl, scenario, {
+        spawn: workerHarness.spawn,
+      }),
+    now: () => "2026-08-27T00:00:00.000Z",
+    writeArtifact(filePath, contents) {
+      writes.push({ filePath, contents });
+    },
+  });
+
+  assert.equal(workerHarness.calls.length, 48);
+  assert.equal(
+    workerHarness.calls.filter(({ args }) =>
+      args.includes("--game-path-pure-screenshot-worker"),
+    ).length,
+    24,
+  );
+  assert.equal(
+    writes.filter(({ filePath }) => filePath.endsWith(".png")).length,
+    12,
+  );
+  assert.equal(
+    writes.filter(({ filePath }) => filePath.endsWith("manifest.json")).length,
+    1,
+  );
+  assert.equal(manifest.scenarios.length, 12);
+  assert.equal(workerHarness.activeChildren, 0);
+});
+
+test("starts no validation or screenshot worker when navigation fails", async () => {
+  const writes = [];
+  let validationCount = 0;
+  let settleCount = 0;
+  let screenshotCount = 0;
+  const { projectRoot, outputDir } = createProjectPaths();
+  const config = parseCaptureEnvironment(
+    {
+      CDP_PORT: "43123",
+      CDP_TARGET_URL: TARGET_URL,
+      GAME_PATH_QA_OUTPUT_DIR: outputDir,
+    },
+    projectRoot,
+  );
+
+  await assert.rejects(
+    captureFixtureMatrix(config, {
+      async navigateInWorker() {
+        throw new Error("navigation worker failed");
+      },
+      async validateInWorker() {
+        validationCount += 1;
+      },
+      async settleAfterValidation() {
+        settleCount += 1;
+      },
+      async screenshotInWorker() {
+        screenshotCount += 1;
+      },
+      now: () => "2026-08-27T00:00:00.000Z",
+      writeArtifact(filePath, contents) {
+        writes.push({ filePath, contents });
+      },
+    }),
+    /navigation worker failed/,
+  );
+  assert.equal(validationCount, 0);
+  assert.equal(settleCount, 0);
+  assert.equal(screenshotCount, 0);
+  assert.equal(writes.length, 0);
+});
+
+test("parent starts no screenshot worker when validation fails", async () => {
+  const scenario = buildScenarioMatrix()[0];
+  const cases = [
+    {
+      error: new Error("validation worker failed"),
+      expected: /validation worker failed/,
+    },
+    {
+      result: {
+        state: { ...createState(scenario), splashPresent: true },
+        protocolErrors: [],
+      },
+      expected: /Launcher splash is present or visible/,
+    },
+    {
+      result: {
+        state: createState(scenario),
+        protocolErrors: [{ domain: "Runtime", message: "worker failure" }],
+      },
+      expected: /worker failure/,
+    },
+  ];
+
+  for (const testCase of cases) {
+    const writes = [];
+    let settleCount = 0;
+    let screenshotCount = 0;
+    const { projectRoot, outputDir } = createProjectPaths();
+    const config = parseCaptureEnvironment(
+      {
+        CDP_PORT: "43123",
+        CDP_TARGET_URL: TARGET_URL,
+        GAME_PATH_QA_OUTPUT_DIR: outputDir,
+      },
+      projectRoot,
+    );
+    await assert.rejects(
+      captureFixtureMatrix(config, {
+        async navigateInWorker() {},
+        async validateInWorker() {
+          if (testCase.error) throw testCase.error;
+          return testCase.result;
+        },
+        async settleAfterValidation() {
+          settleCount += 1;
+        },
+        async screenshotInWorker() {
+          screenshotCount += 1;
+          return PNG_BYTES;
+        },
+        now: () => "2026-08-27T00:00:00.000Z",
+        writeArtifact(filePath, contents) {
+          writes.push({ filePath, contents });
+        },
+      }),
+      testCase.expected,
+    );
+    assert.equal(settleCount, 0);
+    assert.equal(screenshotCount, 0);
+    assert.equal(writes.length, 0);
+  }
+});
+
+test("writes no artifact when the pure screenshot worker fails", async () => {
+  const writes = [];
+  const scenario = buildScenarioMatrix()[0];
+  const workerHarness = createWorkerProcessHarness({
+    exitCode: 1,
+    stderr: ({ callIndex }) =>
+      Buffer.from(
+        callIndex === 0
+          ? "Timed out waiting for pure CDP command Page.captureScreenshot"
+          : "Pure screenshot retry failed",
+      ),
+  });
+  const { projectRoot, outputDir } = createProjectPaths();
+  const config = parseCaptureEnvironment(
+    {
+      CDP_PORT: "43123",
+      CDP_TARGET_URL: TARGET_URL,
+      GAME_PATH_QA_OUTPUT_DIR: outputDir,
+    },
+    projectRoot,
+  );
+
+  await assert.rejects(
+    captureFixtureMatrix(config, {
+      async navigateInWorker() {},
+      async validateInWorker() {
+        return { state: createState(scenario), protocolErrors: [] };
+      },
+      async settleAfterValidation() {},
+      screenshotInWorker: (targetUrl, activeScenario) =>
+        runPureScreenshotWorkerProcess(config, targetUrl, activeScenario, {
+          spawn: workerHarness.spawn,
+        }),
+      now: () => "2026-08-27T00:00:00.000Z",
+      writeArtifact(filePath, contents) {
+        writes.push({ filePath, contents });
+      },
+    }),
+    /failed after one capture-timeout retry/,
+  );
+  assert.equal(workerHarness.calls.length, 2);
+  assert.equal(writes.length, 0);
+});

--- a/scripts/qa/hidden-electron-launch-fixture.cjs
+++ b/scripts/qa/hidden-electron-launch-fixture.cjs
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+"use strict";
+
+const http = require("node:http");
+
+const [mode, rendererTarget = "http://localhost:54321/"] =
+  process.argv.slice(2);
+
+if (mode === "exit") {
+  process.exitCode = 7;
+} else if (mode === "serve" || mode === "serve-own") {
+  const port = Number(process.env.ELECTRON_REMOTE_DEBUGGING_PORT);
+  const target =
+    process.argv[2] === "serve-own"
+      ? (() => {
+          const value = new URL(rendererTarget);
+          value.searchParams.set(
+            "codexQaRun",
+            process.env.ELECTRON_QA_RUN_ID || "missing-run-id",
+          );
+          return value.toString();
+        })()
+      : rendererTarget;
+  const server = http.createServer((request, response) => {
+    response.setHeader("content-type", "application/json");
+    response.end(
+      request.url === "/json/list"
+        ? JSON.stringify([{ url: target }])
+        : JSON.stringify({}),
+    );
+  });
+  server.listen(port, "127.0.0.1", () => {
+    setTimeout(() => server.close(), 750);
+  });
+} else {
+  throw new Error(`Unknown fixture mode: ${mode || "<missing>"}`);
+}

--- a/scripts/qa/hidden-electron-launch.cjs
+++ b/scripts/qa/hidden-electron-launch.cjs
@@ -1,0 +1,271 @@
+#!/usr/bin/env node
+"use strict";
+
+const fs = require("node:fs");
+const net = require("node:net");
+const os = require("node:os");
+const path = require("node:path");
+const { spawn } = require("node:child_process");
+
+const DEFAULT_RENDERER_TARGET = "http://localhost:54321/";
+const DEFAULT_TIMEOUT_MS = 30_000;
+const PROFILE_TEMP_ROOT_NAME = "poe2-unofficial-launcher-codex-qa";
+const POLL_MS = 100;
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+const withQaRunMarker = (rendererTarget, runId) => {
+  const markedTarget = new URL(rendererTarget);
+  markedTarget.searchParams.set("codexQaRun", runId);
+  return markedTarget.toString();
+};
+const resolveRunPath = (value) =>
+  path.resolve(
+    value.replaceAll(
+      "{runId}",
+      process.env.CODEX_HIDDEN_WINDOWS_RUN_ID || "missing-run-id",
+    ),
+  );
+
+const resolveQaProfilePath = (
+  profilePathTemplate,
+  runId,
+  cwd = process.cwd(),
+  temporaryRoot = os.tmpdir(),
+) => {
+  const expanded = profilePathTemplate
+    ? profilePathTemplate.replaceAll("{runId}", runId)
+    : path.join(temporaryRoot, PROFILE_TEMP_ROOT_NAME, runId);
+  if (!path.isAbsolute(expanded)) {
+    throw new Error("QA profile path must be absolute");
+  }
+  const profilePath = path.resolve(expanded);
+  const workingDirectory = path.resolve(cwd);
+  const relative = path.relative(workingDirectory, profilePath);
+  const isOutside =
+    relative !== "" &&
+    (relative === ".." ||
+      relative.startsWith(`..${path.sep}`) ||
+      path.isAbsolute(relative));
+  if (!isOutside) {
+    throw new Error(
+      "QA profile path must be outside the Vite working directory",
+    );
+  }
+  return profilePath;
+};
+
+const parseArgs = (argv) => {
+  const options = {
+    rendererTarget: DEFAULT_RENDERER_TARGET,
+    timeoutMs: DEFAULT_TIMEOUT_MS,
+    childScript: path.resolve("node_modules/vite/bin/vite.js"),
+    childArgs: [],
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    const value = () => {
+      index += 1;
+      if (index >= argv.length) throw new Error(`Missing value for ${token}`);
+      return argv[index];
+    };
+    if (token === "--ready-file") options.readyFile = resolveRunPath(value());
+    else if (token === "--renderer-target") options.rendererTarget = value();
+    else if (token === "--profile-path") options.profilePath = value();
+    else if (token === "--timeout-ms") options.timeoutMs = Number(value());
+    else if (token === "--candidate-port")
+      options.candidatePort = Number(value());
+    else if (token === "--child-script")
+      options.childScript = path.resolve(value());
+    else if (token === "--") {
+      options.childArgs = argv.slice(index + 1);
+      break;
+    } else throw new Error(`Unknown option: ${token}`);
+  }
+  if (!options.readyFile) throw new Error("--ready-file is required");
+  if (!Number.isSafeInteger(options.timeoutMs) || options.timeoutMs < 1) {
+    throw new Error("--timeout-ms must be a positive integer");
+  }
+  if (
+    options.candidatePort !== undefined &&
+    (!Number.isSafeInteger(options.candidatePort) ||
+      options.candidatePort < 1 ||
+      options.candidatePort > 65535)
+  ) {
+    throw new Error("--candidate-port must be between 1 and 65535");
+  }
+  return options;
+};
+
+const reserveUniquePort = (candidatePort = 0) =>
+  new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.unref();
+    server.once("error", (error) => {
+      reject(
+        new Error(
+          `CDP port ${candidatePort || "auto"} is not exclusively available: ${error.code || error.message}`,
+        ),
+      );
+    });
+    server.listen(
+      { host: "127.0.0.1", port: candidatePort, exclusive: true },
+      () => {
+        const address = server.address();
+        resolve({ server, port: address.port });
+      },
+    );
+  });
+
+const closeServer = (server) =>
+  new Promise((resolve, reject) =>
+    server.close((error) => (error ? reject(error) : resolve())),
+  );
+
+const writeReadyFile = (filePath, value) => {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  const temporaryPath = `${filePath}.${process.pid}.tmp`;
+  fs.writeFileSync(
+    temporaryPath,
+    `${JSON.stringify(value, null, 2)}\n`,
+    "utf8",
+  );
+  try {
+    fs.renameSync(temporaryPath, filePath);
+  } catch (error) {
+    if (!["EEXIST", "EPERM", "EACCES"].includes(error?.code)) throw error;
+    fs.rmSync(filePath, { force: true });
+    fs.renameSync(temporaryPath, filePath);
+  }
+};
+
+const hasExactRendererTarget = async (port, rendererTarget) => {
+  try {
+    const response = await fetch(`http://127.0.0.1:${port}/json/list`, {
+      signal: AbortSignal.timeout(500),
+    });
+    if (!response.ok) return false;
+    const targets = await response.json();
+    return (
+      Array.isArray(targets) &&
+      targets.some((target) => target?.url === rendererTarget)
+    );
+  } catch {
+    return false;
+  }
+};
+
+const waitForOwnedRenderer = async (
+  child,
+  port,
+  target,
+  timeoutMs,
+  getTerminalState = () => null,
+) => {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const terminal = getTerminalState();
+    if (terminal || child.exitCode !== null || child.signalCode !== null) {
+      throw new Error(
+        `Owned Vite child exited before renderer readiness (exitCode=${terminal?.exitCode ?? child.exitCode ?? "none"}, signal=${terminal?.signal ?? child.signalCode ?? "none"}, error=${terminal?.error?.message ?? "none"})`,
+      );
+    }
+    if (await hasExactRendererTarget(port, target)) return;
+    await sleep(POLL_MS);
+  }
+  throw new Error(
+    `Owned Vite child did not expose exact renderer ${target} on unique port ${port} within ${timeoutMs}ms`,
+  );
+};
+
+const waitForChildExit = (child) =>
+  new Promise((resolve, reject) => {
+    child.once("error", reject);
+    child.once("close", (exitCode, signal) => resolve({ exitCode, signal }));
+  });
+
+const main = async () => {
+  const options = parseArgs(process.argv.slice(2));
+  const runId = process.env.CODEX_HIDDEN_WINDOWS_RUN_ID;
+  if (!runId) throw new Error("CODEX_HIDDEN_WINDOWS_RUN_ID is required");
+  const ownedRendererTarget = withQaRunMarker(options.rendererTarget, runId);
+  const profilePath = resolveQaProfilePath(options.profilePath, runId);
+
+  const reservation = await reserveUniquePort(options.candidatePort);
+  fs.mkdirSync(profilePath, { recursive: true });
+  await closeServer(reservation.server);
+
+  const child = spawn(
+    process.execPath,
+    [options.childScript, ...options.childArgs],
+    {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        ELECTRON_START_HIDDEN: "true",
+        ELECTRON_QA_RUN_ID: runId,
+        ELECTRON_REMOTE_DEBUGGING_PORT: String(reservation.port),
+        ELECTRON_QA_USER_DATA_DIR: profilePath,
+      },
+      shell: false,
+      windowsHide: true,
+      stdio: "inherit",
+    },
+  );
+  const exitPromise = waitForChildExit(child);
+  let terminalState = null;
+  void exitPromise.then(
+    (terminal) => {
+      terminalState = terminal;
+    },
+    (error) => {
+      terminalState = { error };
+    },
+  );
+
+  await waitForOwnedRenderer(
+    child,
+    reservation.port,
+    ownedRendererTarget,
+    options.timeoutMs,
+    () => terminalState,
+  );
+  writeReadyFile(options.readyFile, {
+    schemaVersion: 1,
+    runId,
+    launcherPid: process.pid,
+    childPid: child.pid,
+    port: reservation.port,
+    rendererTarget: ownedRendererTarget,
+    profilePath,
+    ownershipMarker: {
+      name: "codexQaRun",
+      value: runId,
+    },
+    readyAt: new Date().toISOString(),
+  });
+
+  const terminal = await exitPromise;
+  if (typeof terminal.exitCode === "number")
+    process.exitCode = terminal.exitCode;
+  else {
+    process.stderr.write(
+      `Owned Vite child exited by signal ${terminal.signal || "unknown"}\n`,
+    );
+    process.exitCode = 1;
+  }
+};
+
+if (require.main === module) {
+  main().catch((error) => {
+    process.stderr.write(`hidden-electron-launch: ${error.message}\n`);
+    process.exitCode = 1;
+  });
+}
+
+module.exports = {
+  hasExactRendererTarget,
+  parseArgs,
+  reserveUniquePort,
+  resolveQaProfilePath,
+  withQaRunMarker,
+};

--- a/scripts/qa/hidden-electron-launch.node-test.cjs
+++ b/scripts/qa/hidden-electron-launch.node-test.cjs
@@ -1,0 +1,274 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const crypto = require("node:crypto");
+const fs = require("node:fs");
+const http = require("node:http");
+const os = require("node:os");
+const path = require("node:path");
+const { spawn } = require("node:child_process");
+const test = require("node:test");
+
+const LAUNCHER = path.join(__dirname, "hidden-electron-launch.cjs");
+const FIXTURE = path.join(__dirname, "hidden-electron-launch-fixture.cjs");
+const TARGET = "http://localhost:54321/";
+const tempRoots = [];
+
+const runLauncher = (
+  args,
+  runId = `qa-launcher-${crypto.randomBytes(8).toString("hex")}`,
+) =>
+  new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [LAUNCHER, ...args], {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        CODEX_HIDDEN_WINDOWS_RUN_ID: runId,
+      },
+      shell: false,
+      windowsHide: true,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => (stdout += chunk));
+    child.stderr.on("data", (chunk) => (stderr += chunk));
+    child.once("error", reject);
+    child.once("close", (code, signal) =>
+      resolve({ code, signal, stdout, stderr }),
+    );
+  });
+
+const listen = (server) =>
+  new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => resolve(server.address().port));
+  });
+
+test.after(() => {
+  for (const root of tempRoots)
+    fs.rmSync(root, { recursive: true, force: true });
+});
+
+test("project dev:wsl delegates unique-port readiness to the project launcher", () => {
+  const packageJson = JSON.parse(
+    fs.readFileSync(path.resolve("package.json"), "utf8"),
+  );
+  const command = packageJson.scripts["dev:wsl"];
+  assert.match(command, /scripts\/qa\/hidden-electron-launch\.cjs/);
+  assert.match(command, /--ready-file/);
+  assert.doesNotMatch(command, /--ready-url|\b9222\b/);
+  assert.doesNotMatch(command, /ELECTRON_QA_USER_DATA_DIR|profile-/);
+  const mainSource = fs.readFileSync(path.resolve("src/main/main.ts"), "utf8");
+  assert.match(mainSource, /process\.env\.ELECTRON_START_HIDDEN === "true"/);
+  assert.match(mainSource, /process\.env\.ELECTRON_QA_RUN_ID/);
+  assert.match(mainSource, /searchParams\.set\("codexQaRun", qaRunId\)/);
+});
+
+test("rejects a pre-existing CDP responder instead of accepting its target", async () => {
+  const server = http.createServer((_request, response) => {
+    response.setHeader("content-type", "application/json");
+    response.end(JSON.stringify([{ url: TARGET }]));
+  });
+  const port = await listen(server);
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "hidden-electron-port-"));
+  tempRoots.push(root);
+  const readyPath = path.join(root, "ready.json");
+  try {
+    const result = await runLauncher([
+      "--ready-file",
+      readyPath,
+      "--candidate-port",
+      String(port),
+      "--child-script",
+      FIXTURE,
+      "--",
+      "serve",
+      TARGET,
+    ]);
+    assert.equal(result.code, 1);
+    assert.match(result.stderr, /not exclusively available/);
+    assert.equal(fs.existsSync(readyPath), false);
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+});
+
+test("fails when its own child exits before exact renderer readiness", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "hidden-electron-exit-"));
+  tempRoots.push(root);
+  const readyPath = path.join(root, "ready.json");
+  const result = await runLauncher([
+    "--ready-file",
+    readyPath,
+    "--timeout-ms",
+    "3000",
+    "--child-script",
+    FIXTURE,
+    "--",
+    "exit",
+  ]);
+  assert.equal(result.code, 1);
+  assert.match(result.stderr, /exited before renderer readiness/);
+  assert.equal(fs.existsSync(readyPath), false);
+});
+
+test("rejects an alive responder exposing only the unmarked base target", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "hidden-electron-base-"));
+  tempRoots.push(root);
+  const readyPath = path.join(root, "ready.json");
+  const result = await runLauncher([
+    "--ready-file",
+    readyPath,
+    "--timeout-ms",
+    "3000",
+    "--child-script",
+    FIXTURE,
+    "--",
+    "serve",
+    TARGET,
+  ]);
+  assert.equal(result.code, 1);
+  assert.match(result.stderr, /exited before renderer readiness/);
+  assert.equal(fs.existsSync(readyPath), false);
+});
+
+test("rejects an alive responder marked for a different QA run", async () => {
+  const root = fs.mkdtempSync(
+    path.join(os.tmpdir(), "hidden-electron-foreign-"),
+  );
+  tempRoots.push(root);
+  const readyPath = path.join(root, "ready.json");
+  const foreignTarget = new URL(TARGET);
+  foreignTarget.searchParams.set("codexQaRun", "different-run");
+  const result = await runLauncher([
+    "--ready-file",
+    readyPath,
+    "--timeout-ms",
+    "3000",
+    "--child-script",
+    FIXTURE,
+    "--",
+    "serve",
+    foreignTarget.toString(),
+  ]);
+  assert.equal(result.code, 1);
+  assert.match(result.stderr, /exited before renderer readiness/);
+  assert.equal(fs.existsSync(readyPath), false);
+});
+
+test("writes readiness only for its alive child on its selected unique port", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "hidden-electron-ready-"));
+  tempRoots.push(root);
+  const readyPath = path.join(root, "ready.json");
+  const runId = `qa-own-${crypto.randomBytes(8).toString("hex")}`;
+  const result = await runLauncher(
+    [
+      "--ready-file",
+      readyPath,
+      "--timeout-ms",
+      "3000",
+      "--child-script",
+      FIXTURE,
+      "--",
+      "serve-own",
+      TARGET,
+    ],
+    runId,
+  );
+  assert.equal(result.code, 0, result.stderr);
+  const ready = JSON.parse(fs.readFileSync(readyPath, "utf8"));
+  const expectedTarget = new URL(TARGET);
+  expectedTarget.searchParams.set("codexQaRun", runId);
+  assert.equal(ready.rendererTarget, expectedTarget.toString());
+  assert.equal(ready.runId, runId);
+  assert.deepEqual(ready.ownershipMarker, {
+    name: "codexQaRun",
+    value: runId,
+  });
+  assert.equal(path.isAbsolute(ready.profilePath), true);
+  const profileFromCwd = path.relative(process.cwd(), ready.profilePath);
+  assert.ok(
+    profileFromCwd === ".." ||
+      profileFromCwd.startsWith(`..${path.sep}`) ||
+      path.isAbsolute(profileFromCwd),
+  );
+  const profileFromTemp = path.relative(os.tmpdir(), ready.profilePath);
+  assert.notEqual(profileFromTemp, "");
+  assert.equal(profileFromTemp.startsWith(`..${path.sep}`), false);
+  tempRoots.push(ready.profilePath);
+  assert.ok(Number.isInteger(ready.port));
+  assert.ok(Number.isInteger(ready.childPid));
+});
+
+test("accepts an explicit absolute outside-cwd profile and reports its ownership", async () => {
+  const root = fs.mkdtempSync(
+    path.join(os.tmpdir(), "hidden-electron-explicit-ready-"),
+  );
+  tempRoots.push(root);
+  const readyPath = path.join(root, "ready.json");
+  const runId = `qa-explicit-${crypto.randomBytes(8).toString("hex")}`;
+  const profileTemplate = path.join(
+    os.tmpdir(),
+    "poe2-explicit-codex-qa",
+    "{runId}",
+  );
+  const result = await runLauncher(
+    [
+      "--ready-file",
+      readyPath,
+      "--profile-path",
+      profileTemplate,
+      "--timeout-ms",
+      "3000",
+      "--child-script",
+      FIXTURE,
+      "--",
+      "serve-own",
+      TARGET,
+    ],
+    runId,
+  );
+  assert.equal(result.code, 0, result.stderr);
+  const ready = JSON.parse(fs.readFileSync(readyPath, "utf8"));
+  assert.equal(
+    path.normalize(ready.profilePath),
+    path.normalize(profileTemplate.replace("{runId}", runId)),
+  );
+  assert.equal(ready.runId, runId);
+  assert.equal(ready.ownershipMarker.value, runId);
+  tempRoots.push(ready.profilePath);
+});
+
+test("rejects relative and inside-cwd explicit profiles before child launch", async () => {
+  const root = fs.mkdtempSync(
+    path.join(os.tmpdir(), "hidden-electron-invalid-profile-"),
+  );
+  tempRoots.push(root);
+  for (const [label, profilePath, message] of [
+    ["relative", "relative-profile", /must be absolute/],
+    [
+      "inside-cwd",
+      path.join(process.cwd(), ".tmp", "invalid-qa-profile"),
+      /outside the Vite working directory/,
+    ],
+  ]) {
+    const readyPath = path.join(root, `${label}.ready.json`);
+    const result = await runLauncher([
+      "--ready-file",
+      readyPath,
+      "--profile-path",
+      profilePath,
+      "--child-script",
+      FIXTURE,
+      "--",
+      "serve-own",
+      TARGET,
+    ]);
+    assert.equal(result.code, 1, label);
+    assert.match(result.stderr, message, label);
+    assert.equal(fs.existsSync(readyPath), false, label);
+  }
+});

--- a/src/main/game/GameInstallPathIpcHandlers.ts
+++ b/src/main/game/GameInstallPathIpcHandlers.ts
@@ -1,0 +1,254 @@
+import type {
+  AppConfig,
+  GameInstallPathDiagnostics,
+  GameInstallPathRegistryTargetDeleteActionResult,
+  GameInstallPathRegistryTargetDeleteRequest,
+  GameInstallPathRegistryTargetDeleteResult,
+  GameInstallPathSelectionApplyRequest,
+  GameInstallPathSelectionBatchResult,
+  GameInstallPathSelectionResult,
+  GameInstallPathTargetId,
+} from "../../shared/types";
+
+type ServiceId = AppConfig["serviceChannel"];
+type GameId = AppConfig["activeGame"];
+
+export interface GameInstallPathIpcSender {
+  readonly id: number;
+  once(event: "destroyed", listener: () => void): unknown;
+  isDestroyed(): boolean;
+}
+
+export interface GameInstallPathIpcEvent {
+  readonly sender: GameInstallPathIpcSender;
+}
+
+export interface GameInstallPathOpenDialogOptions {
+  readonly title: string;
+  readonly buttonLabel: string;
+  readonly properties: "openDirectory"[];
+  readonly defaultPath?: string;
+}
+
+type SelectionService = {
+  getDefaultPath(
+    serviceId: ServiceId,
+    gameId: GameId,
+  ): Promise<string | undefined>;
+  createSelection(
+    ownerWebContentsId: number,
+    serviceId: ServiceId,
+    gameId: GameId,
+    rawPath: string,
+  ): Promise<GameInstallPathSelectionResult>;
+  disposeOwner(ownerWebContentsId: number): void;
+  resolveSelectionContext(
+    ownerWebContentsId: number,
+    selectionId: string,
+  ):
+    | { ok: true; context: { serviceId: ServiceId; gameId: GameId } }
+    | { ok: false; result: GameInstallPathSelectionBatchResult };
+  applySelection(
+    ownerWebContentsId: number,
+    request: GameInstallPathSelectionApplyRequest,
+  ): Promise<GameInstallPathSelectionBatchResult>;
+};
+
+export interface GameInstallPathIpcHandlerDependencies {
+  isSupportedContext(serviceId: unknown, gameId: unknown): boolean;
+  selectionService: SelectionService;
+  showOpenDialog(
+    sender: GameInstallPathIpcSender,
+    options: GameInstallPathOpenDialogOptions,
+  ): Promise<{ canceled: boolean; filePaths: string[] }>;
+  runManualAction(
+    context: { serviceId: ServiceId; gameId: GameId },
+    action: () => Promise<GameInstallPathSelectionBatchResult>,
+  ): Promise<GameInstallPathSelectionBatchResult>;
+}
+
+type RegistryDeleteOutcome = {
+  readonly ok: boolean;
+  readonly result: GameInstallPathRegistryTargetDeleteResult;
+};
+
+export interface GameInstallPathRegistryDeleteHandlerDependencies {
+  isSupportedContext(serviceId: unknown, gameId: unknown): boolean;
+  deleteRegistryTarget(
+    serviceId: ServiceId,
+    gameId: GameId,
+    request: GameInstallPathRegistryTargetDeleteRequest,
+  ): Promise<GameInstallPathRegistryTargetDeleteResult>;
+  getDiagnostics(
+    serviceId: ServiceId,
+    gameId: GameId,
+  ): Promise<GameInstallPathDiagnostics>;
+  runManualAction(
+    context: { serviceId: ServiceId; gameId: GameId },
+    action: () => Promise<RegistryDeleteOutcome>,
+  ): Promise<RegistryDeleteOutcome>;
+}
+
+const canceledSelection = (): GameInstallPathSelectionResult => ({
+  ok: false,
+  status: "canceled",
+});
+
+export const createGameInstallPathIpcHandlers = (
+  dependencies: GameInstallPathIpcHandlerDependencies,
+) => {
+  const cleanupOwners = new Set<number>();
+
+  const bindOwnerCleanup = (sender: GameInstallPathIpcSender): void => {
+    if (cleanupOwners.has(sender.id)) return;
+
+    cleanupOwners.add(sender.id);
+    sender.once("destroyed", () => {
+      cleanupOwners.delete(sender.id);
+      dependencies.selectionService.disposeOwner(sender.id);
+    });
+  };
+
+  const pickGameInstallPathTargets = async (
+    event: GameInstallPathIpcEvent,
+    serviceId: ServiceId,
+    gameId: GameId,
+  ): Promise<GameInstallPathSelectionResult> => {
+    if (!dependencies.isSupportedContext(serviceId, gameId)) {
+      throw new Error(
+        `Unsupported game install context: ${serviceId}/${gameId}`,
+      );
+    }
+
+    const { sender } = event;
+    bindOwnerCleanup(sender);
+    const defaultPath = await dependencies.selectionService.getDefaultPath(
+      serviceId,
+      gameId,
+    );
+    if (sender.isDestroyed()) return canceledSelection();
+
+    const result = await dependencies.showOpenDialog(sender, {
+      title: "게임 설치 폴더 선택",
+      buttonLabel: "이 폴더 사용",
+      properties: ["openDirectory"],
+      ...(defaultPath ? { defaultPath } : {}),
+    });
+    if (
+      result.canceled ||
+      result.filePaths.length === 0 ||
+      sender.isDestroyed()
+    ) {
+      return canceledSelection();
+    }
+
+    const selection = await dependencies.selectionService.createSelection(
+      sender.id,
+      serviceId,
+      gameId,
+      result.filePaths[0],
+    );
+    return sender.isDestroyed() ? canceledSelection() : selection;
+  };
+
+  const applyGameInstallPathTargets = async (
+    event: GameInstallPathIpcEvent,
+    request: GameInstallPathSelectionApplyRequest,
+  ): Promise<GameInstallPathSelectionBatchResult> => {
+    const ownerWebContentsId = event.sender.id;
+    const canonicalRequest: GameInstallPathSelectionApplyRequest = {
+      selectionId:
+        typeof request?.selectionId === "string" ? request.selectionId : "",
+      targetIds: Array.isArray(request?.targetIds)
+        ? ([...request.targetIds] as GameInstallPathTargetId[])
+        : [],
+    };
+    const resolved = dependencies.selectionService.resolveSelectionContext(
+      ownerWebContentsId,
+      canonicalRequest.selectionId,
+    );
+    if (!resolved.ok) return resolved.result;
+
+    return dependencies.runManualAction(resolved.context, () =>
+      dependencies.selectionService.applySelection(
+        ownerWebContentsId,
+        canonicalRequest,
+      ),
+    );
+  };
+
+  return { pickGameInstallPathTargets, applyGameInstallPathTargets };
+};
+
+export const createGameInstallPathRegistryDeleteHandler = (
+  dependencies: GameInstallPathRegistryDeleteHandlerDependencies,
+) => {
+  const inFlightByOwnerTarget = new Map<
+    string,
+    Promise<GameInstallPathRegistryTargetDeleteActionResult>
+  >();
+
+  return async (
+    event: GameInstallPathIpcEvent,
+    serviceId: ServiceId,
+    gameId: GameId,
+    request: GameInstallPathRegistryTargetDeleteRequest,
+  ): Promise<GameInstallPathRegistryTargetDeleteActionResult> => {
+    if (!dependencies.isSupportedContext(serviceId, gameId)) {
+      throw new Error(
+        `Unsupported game install context: ${serviceId}/${gameId}`,
+      );
+    }
+
+    if (
+      request?.targetId !== "registry-primary" &&
+      request?.targetId !== "registry-compatibility"
+    ) {
+      throw new Error(`Unsupported registry target ID: ${request?.targetId}`);
+    }
+    if (typeof request.expectedPath !== "string") {
+      throw new Error("Expected registry path must be a string.");
+    }
+
+    const canonicalRequest: GameInstallPathRegistryTargetDeleteRequest = {
+      targetId: request.targetId,
+      expectedPath: request.expectedPath,
+    };
+    const context = { serviceId, gameId };
+    const ownerTargetKey = JSON.stringify([
+      event.sender.id,
+      serviceId,
+      gameId,
+      canonicalRequest.targetId,
+    ]);
+    const existing = inFlightByOwnerTarget.get(ownerTargetKey);
+    if (existing) return existing;
+
+    const operation = (async () => {
+      const outcome = await dependencies.runManualAction(context, async () => {
+        const result = await dependencies.deleteRegistryTarget(
+          serviceId,
+          gameId,
+          canonicalRequest,
+        );
+        return { ok: result.status !== "failed", result };
+      });
+
+      return {
+        ok: outcome.ok,
+        source: "registry" as const,
+        result: outcome.result,
+        diagnostics: await dependencies.getDiagnostics(serviceId, gameId),
+      };
+    })();
+    inFlightByOwnerTarget.set(ownerTargetKey, operation);
+
+    try {
+      return await operation;
+    } finally {
+      if (inFlightByOwnerTarget.get(ownerTargetKey) === operation) {
+        inFlightByOwnerTarget.delete(ownerTargetKey);
+      }
+    }
+  };
+};

--- a/src/main/game/GameInstallPathSelectionService.ts
+++ b/src/main/game/GameInstallPathSelectionService.ts
@@ -1,0 +1,830 @@
+import path from "node:path";
+
+import type {
+  AppConfig,
+  GameInstallPathDiagnostics,
+  GameInstallPathRegistryCandidateDiagnostic,
+  GameInstallPathSelectionApplyRequest,
+  GameInstallPathSelectionBatchFailureCode,
+  GameInstallPathSelectionBatchResult,
+  GameInstallPathSelectionDescriptor,
+  GameInstallPathSelectionResult,
+  GameInstallPathSelectionTargetDisabledReason,
+  GameInstallPathSelectionTargetDescriptor,
+  GameInstallPathTargetApplyFailureCode,
+  GameInstallPathTargetApplyResult,
+  GameInstallPathTargetId,
+  GameInstallPathTargetSnapshot,
+} from "../../shared/types";
+
+type ServiceId = AppConfig["serviceChannel"];
+type GameId = AppConfig["activeGame"];
+
+type StatResult = {
+  isDirectory: () => boolean;
+  isFile: () => boolean;
+};
+
+export interface GameInstallPathSelectionServiceDependencies {
+  now: () => number;
+  randomUUID: () => string;
+  fsStat: (targetPath: string) => Promise<StatResult>;
+  getDiagnostics: (
+    serviceId: ServiceId,
+    gameId: GameId,
+  ) => Promise<GameInstallPathDiagnostics>;
+  collectSnapshots: (
+    diagnostics: GameInstallPathDiagnostics,
+  ) => readonly GameInstallPathTargetSnapshot[];
+  applyTarget: (
+    serviceId: ServiceId,
+    gameId: GameId,
+    snapshot: GameInstallPathTargetSnapshot,
+    installPath: string,
+  ) => Promise<GameInstallPathTargetApplyResult>;
+}
+
+type SelectionSession = {
+  selectionId: string;
+  ownerWebContentsId: number;
+  ownerGeneration: number;
+  serviceId: ServiceId;
+  gameId: GameId;
+  path: string;
+  expiresAt: number;
+  diagnostics: GameInstallPathDiagnostics;
+  expectedSnapshots: Map<
+    GameInstallPathTargetId,
+    GameInstallPathTargetSnapshot
+  >;
+  displaySnapshots: Map<GameInstallPathTargetId, GameInstallPathTargetSnapshot>;
+  completedTargetIds: Set<GameInstallPathTargetId>;
+  applyInFlight: boolean;
+};
+
+type ResolvedSelectionContext =
+  | {
+      ok: true;
+      context: {
+        serviceId: ServiceId;
+        gameId: GameId;
+      };
+    }
+  | {
+      ok: false;
+      result: GameInstallPathSelectionBatchResult;
+    };
+
+type VerificationResult =
+  { status: "valid" } | { status: "missing" | "unknown" };
+
+type ClassifiedTarget = {
+  targetId: GameInstallPathTargetId;
+  snapshot: GameInstallPathTargetSnapshot;
+  preflightFailure: GameInstallPathTargetApplyResult | null;
+};
+
+type TargetEligibility = {
+  disabled: boolean;
+  disabledReason?: GameInstallPathSelectionTargetDisabledReason;
+  retryable: boolean;
+};
+
+export const GAME_INSTALL_PATH_SELECTION_TTL_MS = 5 * 60 * 1000;
+
+const MAX_SELECTION_ID_ATTEMPTS = 8;
+const TARGET_ORDER: readonly GameInstallPathTargetId[] = [
+  "registry-primary",
+  "registry-compatibility",
+  "config",
+];
+
+const EXECUTABLE_NAMES = {
+  "Kakao Games": "PathOfExile_KG.exe",
+  GGG: "PathOfExile.exe",
+} as const satisfies Record<ServiceId, string>;
+
+const normalizeInstallPath = (rawPath: string): string => {
+  if (!rawPath.trim()) return "";
+
+  let normalized = path.win32.normalize(rawPath.trim());
+  const root = path.win32.parse(normalized).root;
+  while (
+    normalized.length > root.length &&
+    (normalized.endsWith("\\") || normalized.endsWith("/"))
+  ) {
+    normalized = normalized.slice(0, -1);
+  }
+  return normalized;
+};
+
+const isMissingPathError = (error: unknown): boolean =>
+  Boolean(
+    error &&
+    typeof error === "object" &&
+    "code" in error &&
+    (error.code === "ENOENT" || error.code === "ENOTDIR"),
+  );
+
+const createRejectedBatchResult = (
+  failureCode: GameInstallPathSelectionBatchFailureCode,
+): GameInstallPathSelectionBatchResult => ({
+  ok: false,
+  overall: "failed",
+  failureCode,
+  results: [],
+  retryableTargetIds: [],
+});
+
+const createTargetFailure = (
+  targetId: GameInstallPathTargetId,
+  code: GameInstallPathTargetApplyFailureCode,
+  retryable: boolean,
+): GameInstallPathTargetApplyResult => ({
+  targetId,
+  status: "failed",
+  code,
+  retryable,
+});
+
+const snapshotsMatch = (
+  expected: GameInstallPathTargetSnapshot,
+  fresh: GameInstallPathTargetSnapshot,
+): boolean => {
+  if (
+    expected.targetId !== fresh.targetId ||
+    expected.currentPath !== fresh.currentPath
+  ) {
+    return false;
+  }
+
+  if ("registryState" in expected || "registryState" in fresh) {
+    return (
+      "registryState" in expected &&
+      "registryState" in fresh &&
+      expected.registryState === fresh.registryState
+    );
+  }
+
+  return true;
+};
+
+export class GameInstallPathSelectionService {
+  private readonly sessions = new Map<string, SelectionSession>();
+  private readonly ownerSelections = new Map<number, string>();
+  private readonly ownerIssuedSelectionIds = new Map<number, Set<string>>();
+  private readonly ownerGenerations = new Map<number, number>();
+  private readonly disposedOwners = new Set<number>();
+
+  constructor(
+    private readonly dependencies: GameInstallPathSelectionServiceDependencies,
+  ) {}
+
+  async getDefaultPath(
+    serviceId: ServiceId,
+    gameId: GameId,
+  ): Promise<string | undefined> {
+    const diagnostics = await this.dependencies.getDiagnostics(
+      serviceId,
+      gameId,
+    );
+    const candidatePaths = [
+      ...diagnostics.registry.candidates.map((candidate) => candidate.path),
+      diagnostics.config.path,
+    ];
+
+    for (const candidatePath of candidatePaths) {
+      if (!candidatePath) continue;
+      try {
+        const stats = await this.dependencies.fsStat(candidatePath);
+        if (stats.isDirectory()) return candidatePath;
+      } catch {
+        // Missing or unreadable paths cannot be native dialog defaults.
+      }
+    }
+
+    return undefined;
+  }
+
+  async createSelection(
+    ownerWebContentsId: number,
+    serviceId: ServiceId,
+    gameId: GameId,
+    rawPath: string,
+  ): Promise<GameInstallPathSelectionResult> {
+    const ownerGeneration = this.beginSelectionCreation(ownerWebContentsId);
+    if (ownerGeneration === null) return { ok: false, status: "canceled" };
+
+    const selectedPath = normalizeInstallPath(rawPath);
+    if (!selectedPath) {
+      return {
+        ok: false,
+        status: "invalid",
+        code: "install-path-empty",
+        verification: "missing",
+      };
+    }
+
+    const verification = await this.verifySelectedPath(serviceId, selectedPath);
+    if (!this.isOwnerOperationCurrent(ownerWebContentsId, ownerGeneration)) {
+      return { ok: false, status: "canceled" };
+    }
+    if (verification.status !== "valid") {
+      return {
+        ok: false,
+        status: "invalid",
+        code:
+          verification.status === "missing"
+            ? "install-path-invalid"
+            : "install-path-check-failed",
+        verification: verification.status,
+      };
+    }
+
+    const diagnostics = await this.dependencies.getDiagnostics(
+      serviceId,
+      gameId,
+    );
+    if (!this.isOwnerOperationCurrent(ownerWebContentsId, ownerGeneration)) {
+      return { ok: false, status: "canceled" };
+    }
+
+    const snapshots = this.dependencies.collectSnapshots(diagnostics);
+    const snapshotMap = this.createSnapshotMap(
+      serviceId,
+      diagnostics,
+      snapshots,
+    );
+    const selectionId = this.allocateSelectionId(ownerWebContentsId);
+    if (!selectionId) {
+      return {
+        ok: false,
+        status: "unavailable",
+        code: "selection-id-unavailable",
+      };
+    }
+    if (!this.isOwnerOperationCurrent(ownerWebContentsId, ownerGeneration)) {
+      return { ok: false, status: "canceled" };
+    }
+
+    const session: SelectionSession = {
+      selectionId,
+      ownerWebContentsId,
+      ownerGeneration,
+      serviceId,
+      gameId,
+      path: selectedPath,
+      expiresAt: this.dependencies.now() + GAME_INSTALL_PATH_SELECTION_TTL_MS,
+      diagnostics,
+      expectedSnapshots: new Map(snapshotMap),
+      displaySnapshots: new Map(snapshotMap),
+      completedTargetIds: new Set(),
+      applyInFlight: false,
+    };
+
+    if (!this.isOwnerOperationCurrent(ownerWebContentsId, ownerGeneration)) {
+      return { ok: false, status: "canceled" };
+    }
+    this.sessions.set(selectionId, session);
+    this.ownerSelections.set(ownerWebContentsId, selectionId);
+
+    return {
+      ok: true,
+      status: "selected",
+      selection: this.createDescriptor(session),
+    };
+  }
+
+  resolveSelectionContext(
+    ownerWebContentsId: number,
+    selectionId: string,
+  ): ResolvedSelectionContext {
+    const resolved = this.resolveSession(ownerWebContentsId, selectionId);
+    if (!resolved.ok) {
+      return { ok: false, result: createRejectedBatchResult(resolved.code) };
+    }
+
+    return {
+      ok: true,
+      context: {
+        serviceId: resolved.session.serviceId,
+        gameId: resolved.session.gameId,
+      },
+    };
+  }
+
+  async applySelection(
+    ownerWebContentsId: number,
+    request: GameInstallPathSelectionApplyRequest,
+  ): Promise<GameInstallPathSelectionBatchResult> {
+    const resolved = this.resolveSession(
+      ownerWebContentsId,
+      request?.selectionId,
+    );
+    if (!resolved.ok) return createRejectedBatchResult(resolved.code);
+
+    const session = resolved.session;
+    if (session.applyInFlight) {
+      return createRejectedBatchResult("selection-busy");
+    }
+    session.applyInFlight = true;
+    try {
+      const targetIds = request?.targetIds;
+      if (
+        !Array.isArray(targetIds) ||
+        targetIds.length === 0 ||
+        targetIds.some((targetId) => typeof targetId !== "string" || !targetId)
+      ) {
+        return createRejectedBatchResult("invalid-target-ids");
+      }
+      if (new Set(targetIds).size !== targetIds.length) {
+        return createRejectedBatchResult("duplicate-target-ids");
+      }
+      if (
+        targetIds.some((targetId) => !session.expectedSnapshots.has(targetId))
+      ) {
+        return createRejectedBatchResult("target-not-allowed");
+      }
+      if (
+        targetIds.some((targetId) => session.completedTargetIds.has(targetId))
+      ) {
+        return createRejectedBatchResult("target-completed");
+      }
+
+      const orderedTargetIds = TARGET_ORDER.filter((targetId) =>
+        targetIds.includes(targetId),
+      );
+      const verification = await this.verifySelectedPath(
+        session.serviceId,
+        session.path,
+      );
+      if (!this.isSessionCurrent(session)) {
+        return this.createInvalidatedBatchResult([], orderedTargetIds);
+      }
+
+      if (verification.status !== "valid") {
+        const code =
+          verification.status === "missing"
+            ? "install-path-invalid"
+            : "install-path-check-failed";
+        const results = orderedTargetIds.map((targetId) =>
+          createTargetFailure(
+            targetId,
+            code,
+            verification.status === "unknown",
+          ),
+        );
+        return await this.refreshSessionAndCreateResult(session, results);
+      }
+
+      const preflightDiagnostics = await this.dependencies.getDiagnostics(
+        session.serviceId,
+        session.gameId,
+      );
+      if (!this.isSessionCurrent(session)) {
+        return this.createInvalidatedBatchResult([], orderedTargetIds);
+      }
+      const preflightSnapshotMap = this.createSnapshotMap(
+        session.serviceId,
+        preflightDiagnostics,
+        this.dependencies.collectSnapshots(preflightDiagnostics),
+      );
+      const classifiedTargets = orderedTargetIds.map((targetId) =>
+        this.classifyTarget(session, preflightSnapshotMap, targetId),
+      );
+
+      const results: GameInstallPathTargetApplyResult[] = [];
+      for (let index = 0; index < classifiedTargets.length; index += 1) {
+        const classified = classifiedTargets[index];
+        if (classified.preflightFailure) {
+          results.push(classified.preflightFailure);
+          continue;
+        }
+
+        if (!this.isSessionCurrent(session)) {
+          return this.createInvalidatedBatchResult(
+            results,
+            classifiedTargets.slice(index).map(({ targetId }) => targetId),
+          );
+        }
+        const result = await this.dependencies.applyTarget(
+          session.serviceId,
+          session.gameId,
+          classified.snapshot,
+          session.path,
+        );
+        results.push(result);
+        if (!this.isSessionCurrent(session)) {
+          return this.createInvalidatedBatchResult(
+            results,
+            classifiedTargets.slice(index + 1).map(({ targetId }) => targetId),
+          );
+        }
+        if (result.status === "applied" || result.status === "unchanged") {
+          session.completedTargetIds.add(result.targetId);
+        }
+      }
+
+      return await this.refreshSessionAndCreateResult(session, results);
+    } finally {
+      if (this.isSessionIdentityCurrent(session)) {
+        session.applyInFlight = false;
+      }
+    }
+  }
+
+  disposeOwner(ownerWebContentsId: number): void {
+    this.disposedOwners.add(ownerWebContentsId);
+    this.bumpOwnerGeneration(ownerWebContentsId);
+    this.ownerIssuedSelectionIds.delete(ownerWebContentsId);
+
+    const selectionId = this.ownerSelections.get(ownerWebContentsId);
+    this.ownerSelections.delete(ownerWebContentsId);
+    if (!selectionId) return;
+
+    const session = this.sessions.get(selectionId);
+    if (session?.ownerWebContentsId === ownerWebContentsId) {
+      this.sessions.delete(selectionId);
+    }
+  }
+
+  private beginSelectionCreation(ownerWebContentsId: number): number | null {
+    if (this.disposedOwners.has(ownerWebContentsId)) return null;
+
+    const ownerGeneration = this.bumpOwnerGeneration(ownerWebContentsId);
+    const previousSelectionId = this.ownerSelections.get(ownerWebContentsId);
+    this.ownerSelections.delete(ownerWebContentsId);
+    if (previousSelectionId) {
+      const previousSession = this.sessions.get(previousSelectionId);
+      if (previousSession?.ownerWebContentsId === ownerWebContentsId) {
+        this.sessions.delete(previousSelectionId);
+      }
+    }
+    return ownerGeneration;
+  }
+
+  private bumpOwnerGeneration(ownerWebContentsId: number): number {
+    const generation = (this.ownerGenerations.get(ownerWebContentsId) ?? 0) + 1;
+    this.ownerGenerations.set(ownerWebContentsId, generation);
+    return generation;
+  }
+
+  private isOwnerOperationCurrent(
+    ownerWebContentsId: number,
+    ownerGeneration: number,
+  ): boolean {
+    return (
+      !this.disposedOwners.has(ownerWebContentsId) &&
+      this.ownerGenerations.get(ownerWebContentsId) === ownerGeneration
+    );
+  }
+
+  private allocateSelectionId(ownerWebContentsId: number): string | null {
+    const issuedSelectionIds =
+      this.ownerIssuedSelectionIds.get(ownerWebContentsId) ?? new Set<string>();
+    for (let attempt = 0; attempt < MAX_SELECTION_ID_ATTEMPTS; attempt += 1) {
+      const selectionId = this.dependencies.randomUUID();
+      if (
+        selectionId &&
+        !this.sessions.has(selectionId) &&
+        !issuedSelectionIds.has(selectionId)
+      ) {
+        issuedSelectionIds.add(selectionId);
+        this.ownerIssuedSelectionIds.set(
+          ownerWebContentsId,
+          issuedSelectionIds,
+        );
+        return selectionId;
+      }
+    }
+    return null;
+  }
+
+  private resolveSession(
+    ownerWebContentsId: number,
+    selectionId: string,
+  ):
+    | { ok: true; session: SelectionSession }
+    | { ok: false; code: GameInstallPathSelectionBatchFailureCode } {
+    const session = this.sessions.get(selectionId);
+    if (!session) return { ok: false, code: "selection-not-found" };
+
+    if (this.dependencies.now() >= session.expiresAt) {
+      this.expireSession(session);
+      return { ok: false, code: "selection-expired" };
+    }
+    if (session.ownerWebContentsId !== ownerWebContentsId) {
+      return { ok: false, code: "selection-owner-mismatch" };
+    }
+    if (!this.isSessionIdentityCurrent(session)) {
+      return { ok: false, code: "selection-not-found" };
+    }
+
+    return { ok: true, session };
+  }
+
+  private isSessionCurrent(session: SelectionSession): boolean {
+    if (this.dependencies.now() >= session.expiresAt) {
+      this.expireSession(session);
+      return false;
+    }
+    return this.isSessionIdentityCurrent(session);
+  }
+
+  private isSessionIdentityCurrent(session: SelectionSession): boolean {
+    return (
+      !this.disposedOwners.has(session.ownerWebContentsId) &&
+      this.ownerGenerations.get(session.ownerWebContentsId) ===
+        session.ownerGeneration &&
+      this.sessions.get(session.selectionId) === session &&
+      this.ownerSelections.get(session.ownerWebContentsId) ===
+        session.selectionId
+    );
+  }
+
+  private expireSession(session: SelectionSession): void {
+    if (this.sessions.get(session.selectionId) === session) {
+      this.sessions.delete(session.selectionId);
+    }
+    if (
+      this.ownerSelections.get(session.ownerWebContentsId) ===
+      session.selectionId
+    ) {
+      this.ownerSelections.delete(session.ownerWebContentsId);
+    }
+    if (
+      this.ownerGenerations.get(session.ownerWebContentsId) ===
+      session.ownerGeneration
+    ) {
+      this.bumpOwnerGeneration(session.ownerWebContentsId);
+    }
+  }
+
+  private classifyTarget(
+    session: SelectionSession,
+    freshSnapshots: ReadonlyMap<
+      GameInstallPathTargetId,
+      GameInstallPathTargetSnapshot
+    >,
+    targetId: GameInstallPathTargetId,
+  ): ClassifiedTarget {
+    const expected = session.expectedSnapshots.get(targetId)!;
+    const fresh = freshSnapshots.get(targetId);
+    if (!fresh) {
+      return {
+        targetId,
+        snapshot: expected,
+        preflightFailure: createTargetFailure(
+          targetId,
+          "target-not-allowed",
+          false,
+        ),
+      };
+    }
+    if ("registryState" in fresh && fresh.registryState === "read-failed") {
+      return {
+        targetId,
+        snapshot: fresh,
+        preflightFailure: createTargetFailure(
+          targetId,
+          "target-read-failed",
+          false,
+        ),
+      };
+    }
+    if (!snapshotsMatch(expected, fresh)) {
+      return {
+        targetId,
+        snapshot: fresh,
+        preflightFailure: createTargetFailure(targetId, "target-changed", true),
+      };
+    }
+
+    return { targetId, snapshot: fresh, preflightFailure: null };
+  }
+
+  private async refreshSessionAndCreateResult(
+    session: SelectionSession,
+    results: readonly GameInstallPathTargetApplyResult[],
+  ): Promise<GameInstallPathSelectionBatchResult> {
+    const freshDiagnostics = await this.dependencies.getDiagnostics(
+      session.serviceId,
+      session.gameId,
+    );
+    if (!this.isSessionCurrent(session)) {
+      return this.createInvalidatedBatchResult([...results], []);
+    }
+    const freshSnapshotMap = this.createSnapshotMap(
+      session.serviceId,
+      freshDiagnostics,
+      this.dependencies.collectSnapshots(freshDiagnostics),
+    );
+
+    if (!this.isSessionCurrent(session)) {
+      return this.createInvalidatedBatchResult([...results], []);
+    }
+    session.diagnostics = freshDiagnostics;
+    session.displaySnapshots = freshSnapshotMap;
+    for (const result of results) {
+      if (result.status !== "failed") continue;
+      const freshSnapshot = freshSnapshotMap.get(result.targetId);
+      if (freshSnapshot) {
+        session.expectedSnapshots.set(result.targetId, freshSnapshot);
+      }
+    }
+
+    const normalizedResults = results.map((result) => {
+      if (result.status !== "failed") return result;
+
+      const eligibility = this.getTargetEligibility(
+        session,
+        result.targetId,
+        freshSnapshotMap.get(result.targetId),
+      );
+      return {
+        ...result,
+        retryable:
+          eligibility.retryable &&
+          (result.code === "target-read-failed" || result.retryable),
+      };
+    });
+
+    const succeededCount = normalizedResults.filter(
+      (result) => result.status === "applied" || result.status === "unchanged",
+    ).length;
+    const failedCount = normalizedResults.length - succeededCount;
+    const overall =
+      failedCount === 0 ? "success" : succeededCount > 0 ? "partial" : "failed";
+
+    return {
+      ok: succeededCount > 0,
+      overall,
+      results: normalizedResults,
+      retryableTargetIds: normalizedResults
+        .filter(
+          (
+            result,
+          ): result is Extract<
+            GameInstallPathTargetApplyResult,
+            { status: "failed" }
+          > => result.status === "failed" && result.retryable,
+        )
+        .map((result) => result.targetId),
+      diagnostics: freshDiagnostics,
+      selection: this.createDescriptor(session),
+    };
+  }
+
+  private createInvalidatedBatchResult(
+    completedResults: GameInstallPathTargetApplyResult[],
+    remainingTargetIds: readonly GameInstallPathTargetId[],
+  ): GameInstallPathSelectionBatchResult {
+    const results = [
+      ...completedResults,
+      ...remainingTargetIds.map((targetId) =>
+        createTargetFailure(targetId, "selection-invalidated", false),
+      ),
+    ];
+    const succeededCount = results.filter(
+      (result) => result.status === "applied" || result.status === "unchanged",
+    ).length;
+
+    return {
+      ok: succeededCount > 0,
+      overall: succeededCount > 0 ? "partial" : "failed",
+      failureCode: "selection-invalidated",
+      results,
+      retryableTargetIds: [],
+    };
+  }
+
+  private async verifySelectedPath(
+    serviceId: ServiceId,
+    installPath: string,
+  ): Promise<VerificationResult> {
+    try {
+      const stats = await this.dependencies.fsStat(
+        path.win32.join(installPath, EXECUTABLE_NAMES[serviceId]),
+      );
+      return stats.isFile() ? { status: "valid" } : { status: "missing" };
+    } catch (error) {
+      return isMissingPathError(error)
+        ? { status: "missing" }
+        : { status: "unknown" };
+    }
+  }
+
+  private createSnapshotMap(
+    serviceId: ServiceId,
+    diagnostics: GameInstallPathDiagnostics,
+    snapshots: readonly GameInstallPathTargetSnapshot[],
+  ): Map<GameInstallPathTargetId, GameInstallPathTargetSnapshot> {
+    const diagnosticTargetIds = new Set<GameInstallPathTargetId>([
+      ...diagnostics.registry.candidates.map((candidate) => candidate.targetId),
+      "config",
+    ]);
+    const allowedTargetIds = new Set<GameInstallPathTargetId>([
+      "registry-primary",
+      ...(serviceId === "Kakao Games"
+        ? (["registry-compatibility"] as const)
+        : []),
+      "config",
+    ]);
+    const result = new Map<
+      GameInstallPathTargetId,
+      GameInstallPathTargetSnapshot
+    >();
+
+    for (const snapshot of snapshots) {
+      if (
+        !allowedTargetIds.has(snapshot.targetId) ||
+        !diagnosticTargetIds.has(snapshot.targetId) ||
+        result.has(snapshot.targetId)
+      ) {
+        continue;
+      }
+      result.set(snapshot.targetId, snapshot);
+    }
+
+    return result;
+  }
+
+  private getTargetEligibility(
+    session: SelectionSession,
+    targetId: GameInstallPathTargetId,
+    snapshot: GameInstallPathTargetSnapshot | undefined,
+  ): TargetEligibility {
+    if (session.completedTargetIds.has(targetId)) {
+      return {
+        disabled: true,
+        disabledReason: "target-completed",
+        retryable: false,
+      };
+    }
+    if (
+      !snapshot ||
+      ("registryState" in snapshot && snapshot.registryState === "read-failed")
+    ) {
+      return {
+        disabled: true,
+        disabledReason: snapshot ? "target-read-failed" : undefined,
+        retryable: false,
+      };
+    }
+
+    return { disabled: false, retryable: true };
+  }
+
+  private createDescriptor(
+    session: SelectionSession,
+  ): GameInstallPathSelectionDescriptor {
+    const candidatesById = new Map<
+      GameInstallPathTargetId,
+      GameInstallPathRegistryCandidateDiagnostic
+    >(
+      session.diagnostics.registry.candidates.map((candidate) => [
+        candidate.targetId,
+        candidate,
+      ]),
+    );
+    const targets: GameInstallPathSelectionTargetDescriptor[] = [];
+
+    for (const targetId of TARGET_ORDER) {
+      const snapshot = session.displaySnapshots.get(targetId);
+      if (!snapshot) continue;
+
+      const completed = session.completedTargetIds.has(targetId);
+      const eligibility = this.getTargetEligibility(
+        session,
+        targetId,
+        snapshot,
+      );
+      const candidate = candidatesById.get(targetId);
+      targets.push({
+        targetId,
+        currentPath: snapshot.currentPath,
+        selectedByDefault:
+          targetId === "registry-primary" || targetId === "config",
+        completed,
+        disabled: eligibility.disabled,
+        ...(eligibility.disabledReason
+          ? { disabledReason: eligibility.disabledReason }
+          : {}),
+        ...(candidate
+          ? {
+              registryPath: candidate.registryPath,
+              registryValueName: candidate.registryValueName,
+            }
+          : {}),
+      });
+    }
+
+    return {
+      selectionId: session.selectionId,
+      serviceId: session.serviceId,
+      gameId: session.gameId,
+      path: session.path,
+      targets,
+    };
+  }
+}

--- a/src/main/game/GameInstallStatusReconciler.ts
+++ b/src/main/game/GameInstallStatusReconciler.ts
@@ -14,13 +14,13 @@ import {
 } from "../events/types";
 import {
   getGameStatus,
+  getGameStatusKey,
   shouldPreserveRuntimeGameStatus,
 } from "../state/GameStatusStore";
 import { logger } from "../utils/logger";
-import {
-  GameInstallationStatus,
-  getGameInstallationStatus,
-} from "../utils/registry";
+import { getGameInstallPathHealth } from "../utils/registry";
+
+import type { GameInstallationStatus } from "../../shared/types";
 
 export interface GameInstallStatusContext {
   gameId: AppConfig["activeGame"];
@@ -40,6 +40,39 @@ export const GAME_INSTALL_STATUS_CONTEXTS: readonly GameInstallStatusContext[] =
   SERVICE_CHANNELS.flatMap((serviceId) =>
     ACTIVE_GAMES.map((gameId) => ({ gameId, serviceId })),
   );
+
+const reconciliationGenerations = new Map<string, number>();
+const completedReconciliations = new Map<string, number>();
+const passiveReconciliations = new Map<string, Promise<boolean>>();
+const manualReconciliationCounts = new Map<string, number>();
+let now = () => Date.now();
+
+export const GAME_INSTALL_STATUS_REFRESH_TTL_MS = 30 * 60 * 1000;
+
+const beginReconciliation = (
+  serviceId: AppConfig["serviceChannel"],
+  gameId: AppConfig["activeGame"],
+) => {
+  const key = getGameStatusKey(gameId, serviceId);
+  const generation = (reconciliationGenerations.get(key) ?? 0) + 1;
+  reconciliationGenerations.set(key, generation);
+  return { generation, key };
+};
+
+const isCurrentReconciliation = (key: string, generation: number) =>
+  reconciliationGenerations.get(key) === generation;
+
+export const resetGameInstallStatusReconcilerForTests = () => {
+  reconciliationGenerations.clear();
+  completedReconciliations.clear();
+  passiveReconciliations.clear();
+  manualReconciliationCounts.clear();
+  now = () => Date.now();
+};
+
+export const setGameInstallStatusClockForTests = (clock: () => number) => {
+  now = clock;
+};
 
 export const shouldReconcileGameInstallStatusOnConfigChange = (
   event: ConfigChangeEvent,
@@ -165,42 +198,144 @@ export const reconcileGameInstallStatus = async (
   gameId: AppConfig["activeGame"],
   options: { reason?: string } = {},
 ) => {
+  const { generation, key } = beginReconciliation(serviceId, gameId);
   const label = `${gameId} (${serviceId})`;
   const reason = options.reason ? `; reason=${options.reason}` : "";
 
-  const currentStatus = getGameStatus(gameId, serviceId);
-  if (shouldPreserveRuntimeGameStatus(currentStatus)) {
-    logger.log(
-      `[GameInstallStatus] Preserving active runtime status for ${label}: ${currentStatus.status}${reason}`,
-    );
-    return;
-  }
-
-  if (isGameProcessRunning(context, serviceId, gameId)) {
-    logger.log(
-      `[GameInstallStatus] Game ${label} is currently running. Emitting running status${reason}.`,
-    );
-    await emitGameStatus(context, { gameId, serviceId, status: "running" });
-    return;
-  }
+  const processIsRunning =
+    isGameProcessRunning(context, serviceId, gameId) === true;
 
   logger.log(
     `[GameInstallStatus] Checking installation for ${label}${reason}.`,
   );
-  const installationStatus = await getGameInstallationStatus(serviceId, gameId);
+  const installPathHealth = await getGameInstallPathHealth(
+    serviceId,
+    gameId,
+    now(),
+  );
+  const installationStatus = installPathHealth.installationStatus;
+
+  if (!isCurrentReconciliation(key, generation)) {
+    logger.log(
+      `[GameInstallStatus] Discarding stale install check for ${label}${reason}.`,
+    );
+    return false;
+  }
 
   const latestStatus = getGameStatus(gameId, serviceId);
   if (shouldPreserveRuntimeGameStatus(latestStatus)) {
     logger.log(
       `[GameInstallStatus] Preserving active runtime status after install check for ${label}: ${latestStatus.status}${reason}`,
     );
-    return;
+    await emitGameStatus(context, {
+      gameId,
+      serviceId,
+      status: latestStatus.status,
+      ...(latestStatus.errorCode ? { errorCode: latestStatus.errorCode } : {}),
+      installPathHealth,
+    });
+  } else if (processIsRunning) {
+    logger.log(
+      `[GameInstallStatus] Game ${label} is currently running. Preserving process status with refreshed install-path health${reason}.`,
+    );
+    await emitGameStatus(context, {
+      gameId,
+      serviceId,
+      status: "running",
+      installPathHealth,
+    });
+  } else {
+    await emitGameStatus(context, {
+      gameId,
+      serviceId,
+      status: mapInstallationStatusToRunStatus(installationStatus),
+      ...getInstallCheckErrorPayload(installationStatus),
+      installPathHealth,
+    });
   }
 
-  await emitGameStatus(context, {
-    gameId,
-    serviceId,
-    status: mapInstallationStatusToRunStatus(installationStatus),
-    ...getInstallCheckErrorPayload(installationStatus),
-  });
+  if (!isCurrentReconciliation(key, generation)) return false;
+  completedReconciliations.set(key, installPathHealth.checkedAt);
+  return true;
+};
+
+export const reconcileAllGameInstallStatuses = async (
+  context: AppContext,
+  options: { reason?: string } = {},
+) => {
+  for (const { serviceId, gameId } of GAME_INSTALL_STATUS_CONTEXTS) {
+    await reconcileGameInstallStatus(context, serviceId, gameId, options);
+  }
+};
+
+export const reconcileCurrentGameInstallStatusIfStale = async (
+  context: AppContext,
+  options: { reason?: string } = {},
+) => {
+  const config = context.getConfig() as AppConfig;
+  const { activeGame: gameId, serviceChannel: serviceId } = config;
+  const key = getGameStatusKey(gameId, serviceId);
+  const lastCompletedAt = completedReconciliations.get(key);
+
+  if ((manualReconciliationCounts.get(key) ?? 0) > 0) return false;
+
+  if (
+    lastCompletedAt !== undefined &&
+    now() - lastCompletedAt < GAME_INSTALL_STATUS_REFRESH_TTL_MS
+  ) {
+    return false;
+  }
+
+  const existing = passiveReconciliations.get(key);
+  if (existing) {
+    await existing;
+    return false;
+  }
+
+  const task = reconcileGameInstallStatus(context, serviceId, gameId, options);
+  passiveReconciliations.set(key, task);
+  try {
+    return await task;
+  } finally {
+    if (passiveReconciliations.get(key) === task) {
+      passiveReconciliations.delete(key);
+    }
+  }
+};
+
+export const runManualGameInstallPathAction = async <
+  Result extends { ok: boolean },
+>(
+  context: AppContext,
+  serviceId: AppConfig["serviceChannel"],
+  gameId: AppConfig["activeGame"],
+  reason: string,
+  action: () => Promise<Result>,
+): Promise<Result> => {
+  const key = getGameStatusKey(gameId, serviceId);
+  manualReconciliationCounts.set(
+    key,
+    (manualReconciliationCounts.get(key) ?? 0) + 1,
+  );
+  try {
+    const result = await action();
+
+    if (result.ok) {
+      try {
+        await reconcileGameInstallStatus(context, serviceId, gameId, {
+          reason,
+        });
+      } catch (error) {
+        logger.warn(
+          `[GameInstallStatus] Manual path action succeeded but reconciliation failed for ${gameId} (${serviceId}); reason=${reason}; error=${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    }
+
+    return result;
+  } finally {
+    const remaining = (manualReconciliationCounts.get(key) ?? 1) - 1;
+    if (remaining > 0) manualReconciliationCounts.set(key, remaining);
+    else manualReconciliationCounts.delete(key);
+  }
 };

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -34,6 +34,9 @@ import {
   NewsCategory,
   DebugLogPayload,
   FatalErrorPayload,
+  GameInstallPathConflictTarget,
+  GameInstallPathRegisterRequest,
+  GameInstallPathRegistryTarget,
   GameLaunchContext,
   SERVICE_CHANNELS,
 } from "../shared/types";
@@ -62,8 +65,9 @@ import {
   UIEvent,
 } from "./events/types";
 import {
-  GAME_INSTALL_STATUS_CONTEXTS,
-  reconcileGameInstallStatus,
+  reconcileAllGameInstallStatuses,
+  reconcileCurrentGameInstallStatusIfStale,
+  runManualGameInstallPathAction,
 } from "./game/GameInstallStatusReconciler";
 import { GameSessionTracker, SessionContext } from "./game/GameSessionTracker";
 import { registerDiagnosticLogIpc } from "./ipc/diagnostic-log-ipc";
@@ -120,6 +124,7 @@ import {
   getGameInstallPath,
   getGameInstallPathDiagnostics,
   clearGameInstallPath,
+  registerGameInstallPath,
   resolveGameInstallPathConflict,
   setGameInstallPath,
   syncInstallLocation,
@@ -745,7 +750,13 @@ ipcMain.handle(
       );
     }
 
-    return setGameInstallPath(serviceId, gameId, installPath);
+    return runManualGameInstallPathAction(
+      appContext,
+      serviceId,
+      gameId,
+      "manual-config-path-set",
+      () => setGameInstallPath(serviceId, gameId, installPath),
+    );
   },
 );
 
@@ -780,7 +791,13 @@ ipcMain.handle(
       };
     }
 
-    return setGameInstallPath(serviceId, gameId, result.filePaths[0]);
+    return runManualGameInstallPathAction(
+      appContext,
+      serviceId,
+      gameId,
+      "manual-config-path-pick",
+      () => setGameInstallPath(serviceId, gameId, result.filePaths[0]),
+    );
   },
 );
 
@@ -791,6 +808,7 @@ ipcMain.handle(
     serviceId: AppConfig["serviceChannel"],
     gameId: AppConfig["activeGame"],
     action: "launcher-config-only" | "sync-registry",
+    registryTarget: GameInstallPathConflictTarget,
   ) => {
     if (!isSupportedGameInstallContext(serviceId, gameId)) {
       throw new Error(
@@ -802,7 +820,19 @@ ipcMain.handle(
       throw new Error(`Unsupported game install conflict action: ${action}`);
     }
 
-    return resolveGameInstallPathConflict(serviceId, gameId, action);
+    return runManualGameInstallPathAction(
+      appContext,
+      serviceId,
+      gameId,
+      `manual-path-conflict-${action}`,
+      () =>
+        resolveGameInstallPathConflict(
+          serviceId,
+          gameId,
+          action,
+          registryTarget,
+        ),
+    );
   },
 );
 
@@ -813,6 +843,7 @@ ipcMain.handle(
     serviceId: AppConfig["serviceChannel"],
     gameId: AppConfig["activeGame"],
     source: "config" | "registry",
+    registryTarget?: GameInstallPathRegistryTarget,
   ) => {
     if (!isSupportedGameInstallContext(serviceId, gameId)) {
       throw new Error(
@@ -824,15 +855,37 @@ ipcMain.handle(
       throw new Error(`Unsupported game install path clear source: ${source}`);
     }
 
-    const result = await clearGameInstallPath(serviceId, gameId, source);
+    return runManualGameInstallPathAction(
+      appContext,
+      serviceId,
+      gameId,
+      `manual-${source}-path-clear`,
+      () => clearGameInstallPath(serviceId, gameId, source, registryTarget),
+    );
+  },
+);
 
-    if (result.ok && source === "registry") {
-      await reconcileGameInstallStatus(appContext, serviceId, gameId, {
-        reason: "manual-registry-path-clear",
-      });
+ipcMain.handle(
+  "game-install-path:register",
+  async (
+    _event,
+    serviceId: AppConfig["serviceChannel"],
+    gameId: AppConfig["activeGame"],
+    request: GameInstallPathRegisterRequest,
+  ) => {
+    if (!isSupportedGameInstallContext(serviceId, gameId)) {
+      throw new Error(
+        `Unsupported game install context: ${serviceId}/${gameId}`,
+      );
     }
 
-    return result;
+    return runManualGameInstallPathAction(
+      appContext,
+      serviceId,
+      gameId,
+      "manual-registry-path-register",
+      () => registerGameInstallPath(serviceId, gameId, request),
+    );
   },
 );
 
@@ -2169,11 +2222,22 @@ async function createWindow() {
     };
   };
 
+  const refreshCurrentGameInstallStatusIfStale = (reason: string) => {
+    void reconcileCurrentGameInstallStatusIfStale(appContext, { reason }).catch(
+      (error) => {
+        logger.warn(
+          `[Main] Deferred game install status refresh failed; reason=${reason}; error=${error instanceof Error ? error.message : String(error)}`,
+        );
+      },
+    );
+  };
+
   mainWindow.on("show", () => {
     newsService.setActive(true, getNewsRefreshContext("show"));
     syncSubWindowsVisibility(true);
     mainWindow?.webContents.send("app:window-show");
     syncDebugWindow("MainShow");
+    refreshCurrentGameInstallStatusIfStale("window-show");
   });
   mainWindow.on("hide", () => {
     newsService.setActive(false);
@@ -2281,12 +2345,9 @@ async function createWindow() {
   // Perform initial installation check for ALL contexts
   const checkAllGameStatuses = async () => {
     logger.log("[Main] Checking initial status for all game contexts...");
-
-    for (const { serviceId, gameId } of GAME_INSTALL_STATUS_CONTEXTS) {
-      await reconcileGameInstallStatus(appContext, serviceId, gameId, {
-        reason: "initial-status-check",
-      });
-    }
+    await reconcileAllGameInstallStatuses(appContext, {
+      reason: "initial-status-check",
+    });
   };
 
   // Sync Auto Launch Status
@@ -2311,6 +2372,7 @@ async function createWindow() {
     logger.log("[Main] Window focused.");
     newsService.setActive(true, getNewsRefreshContext("focus"));
     getProcessWatcher()?.cancelSuspension();
+    refreshCurrentGameInstallStatusIfStale("window-focus");
   });
 
   // --- Main Window Loading ---

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -92,6 +92,12 @@ import { isExpectedNavigationAbort } from "./kakao/navigation-error";
 import { initKakaoSession, KAKAO_PARTITION } from "./kakao/session";
 import { shouldHideReleasedAutomationWindow } from "./kakao/visibility-policy";
 import { trayManager } from "./managers/TrayManager";
+import {
+  buildGamePathDiagnosticQaRendererUrl,
+  isAllowedGamePathDiagnosticQaRendererUrl,
+  resolveGamePathDiagnosticQaLaunch,
+  type GamePathDiagnosticQaLaunchRequest,
+} from "./qa/GamePathDiagnosticQa";
 import { setupSessionSecurity } from "./security/permissions";
 import { changelogService } from "./services/ChangelogService";
 import { diagnosticLogStore } from "./services/DiagnosticLogStore";
@@ -2114,6 +2120,46 @@ function broadcastTitleUpdate() {
   }
 }
 
+async function createGamePathDiagnosticQaWindow(
+  request: GamePathDiagnosticQaLaunchRequest,
+) {
+  mainWindow = new BrowserWindow({
+    width: 1024,
+    height: 683,
+    minWidth: 1024,
+    minHeight: 683,
+    resizable: false,
+    maximizable: false,
+    frame: false,
+    titleBarStyle: "hidden",
+    icon: path.join(process.env.VITE_PUBLIC as string, "icon.ico"),
+    show: false,
+    backgroundColor: "#000000",
+    webPreferences: {
+      preload: path.join(__dirname, "preload.js"),
+    },
+  });
+
+  mainWindow.webContents.setWindowOpenHandler(() => ({ action: "deny" }));
+  mainWindow.webContents.on("will-navigate", (event, url) => {
+    if (
+      !isAllowedGamePathDiagnosticQaRendererUrl(
+        url,
+        request.devServerUrl,
+        request.runId,
+      )
+    ) {
+      event.preventDefault();
+    }
+  });
+  mainWindow.on("closed", () => {
+    mainWindow = null;
+    app.quit();
+  });
+
+  await mainWindow.loadURL(buildGamePathDiagnosticQaRendererUrl(request));
+}
+
 async function createWindow() {
   // 1. Main Window (UI)
   mainWindow = new BrowserWindow({
@@ -3297,6 +3343,19 @@ ipcMain.handle("theme:sync-force", async () => {
 });
 
 app.whenReady().then(async () => {
+  const gamePathDiagnosticQaLaunch = resolveGamePathDiagnosticQaLaunch({
+    isPackaged: app.isPackaged,
+    devServerUrl: VITE_DEV_SERVER_URL,
+    startHidden: process.env.ELECTRON_START_HIDDEN,
+    runId: process.env.ELECTRON_QA_RUN_ID,
+    userDataPath: process.env.ELECTRON_QA_USER_DATA_DIR,
+    fixtureMode: process.env.ELECTRON_QA_GAME_PATH_FIXTURE,
+  });
+  if (gamePathDiagnosticQaLaunch.kind === "active") {
+    await createGamePathDiagnosticQaWindow(gamePathDiagnosticQaLaunch.request);
+    return;
+  }
+
   diagnosticLogStore.initialize(app.getPath("logs"), getLogHistory());
   setupDiagnosticLogSink((payload) => diagnosticLogStore.append(payload));
   registerDiagnosticLogIpc(diagnosticLogStore);

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -2377,7 +2377,14 @@ async function createWindow() {
 
   // --- Main Window Loading ---
   if (VITE_DEV_SERVER_URL) {
-    mainWindow.loadURL(VITE_DEV_SERVER_URL);
+    let rendererUrl = VITE_DEV_SERVER_URL;
+    const qaRunId = process.env.ELECTRON_QA_RUN_ID;
+    if (process.env.ELECTRON_START_HIDDEN === "true" && qaRunId) {
+      const qaRendererUrl = new URL(rendererUrl);
+      qaRendererUrl.searchParams.set("codexQaRun", qaRunId);
+      rendererUrl = qaRendererUrl.toString();
+    }
+    mainWindow.loadURL(rendererUrl);
   } else {
     mainWindow.loadFile(path.join(process.env.DIST as string, "index.html"));
   }

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -14,7 +14,6 @@ import {
   protocol,
   net,
   webContents,
-  type OpenDialogOptions,
 } from "electron";
 import JSZip from "jszip";
 
@@ -36,7 +35,6 @@ import {
   FatalErrorPayload,
   GameInstallPathConflictTarget,
   GameInstallPathRegisterRequest,
-  GameInstallPathRegistryTarget,
   GameLaunchContext,
   SERVICE_CHANNELS,
 } from "../shared/types";
@@ -64,6 +62,11 @@ import {
   IServiceManager,
   UIEvent,
 } from "./events/types";
+import {
+  createGameInstallPathIpcHandlers,
+  createGameInstallPathRegistryDeleteHandler,
+} from "./game/GameInstallPathIpcHandlers";
+import { GameInstallPathSelectionService } from "./game/GameInstallPathSelectionService";
 import {
   reconcileAllGameInstallStatuses,
   reconcileCurrentGameInstallStatusIfStale,
@@ -123,7 +126,10 @@ import { PowerShellManager } from "./utils/powershell";
 import {
   getGameInstallPath,
   getGameInstallPathDiagnostics,
+  applyGameInstallPathTarget,
   clearGameInstallPath,
+  deleteGameInstallPathRegistryTarget,
+  deriveGameInstallPathTargetSnapshots,
   registerGameInstallPath,
   resolveGameInstallPathConflict,
   setGameInstallPath,
@@ -223,6 +229,15 @@ let gameWindow: BrowserWindow | null;
 let debugWindow: BrowserWindow | null = null; // Debug Window Reference
 let debugDestructionTimeout: NodeJS.Timeout | null = null; // [New] Delayed destruction timer
 let debugRecoveryTimeout: NodeJS.Timeout | null = null;
+
+const gameInstallPathSelectionService = new GameInstallPathSelectionService({
+  now: () => Date.now(),
+  randomUUID: () => crypto.randomUUID(),
+  fsStat: (targetPath) => fs.stat(targetPath),
+  getDiagnostics: getGameInstallPathDiagnostics,
+  collectSnapshots: deriveGameInstallPathTargetSnapshots,
+  applyTarget: applyGameInstallPathTarget,
+});
 
 // --- Account Validation State ---
 let validationModeActive = false;
@@ -692,6 +707,43 @@ const isSupportedGameInstallContext = (
   );
 };
 
+const gameInstallPathIpcHandlers = createGameInstallPathIpcHandlers({
+  isSupportedContext: isSupportedGameInstallContext,
+  selectionService: gameInstallPathSelectionService,
+  showOpenDialog: async (sender, options) => {
+    const ownerWebContents = webContents.fromId(sender.id);
+    const targetWindow = ownerWebContents
+      ? BrowserWindow.fromWebContents(ownerWebContents)
+      : null;
+    return targetWindow
+      ? dialog.showOpenDialog(targetWindow, options)
+      : dialog.showOpenDialog(options);
+  },
+  runManualAction: (context, action) =>
+    runManualGameInstallPathAction(
+      appContext,
+      context.serviceId,
+      context.gameId,
+      "manual-path-targets-apply",
+      action,
+    ),
+});
+
+const gameInstallPathRegistryDeleteHandler =
+  createGameInstallPathRegistryDeleteHandler({
+    isSupportedContext: isSupportedGameInstallContext,
+    deleteRegistryTarget: deleteGameInstallPathRegistryTarget,
+    getDiagnostics: getGameInstallPathDiagnostics,
+    runManualAction: (context, action) =>
+      runManualGameInstallPathAction(
+        appContext,
+        context.serviceId,
+        context.gameId,
+        "manual-registry-target-delete",
+        action,
+      ),
+  });
+
 ipcMain.handle("config:set", (_event, key: string, value: unknown) => {
   // [Safety] Do not persist if the key is forced in dev:test mode
   if (FORCE_DEBUG && DEBUG_KEYS.includes(key)) {
@@ -761,44 +813,13 @@ ipcMain.handle(
 );
 
 ipcMain.handle(
-  "game-install-path:pick",
-  async (
-    event,
-    serviceId: AppConfig["serviceChannel"],
-    gameId: AppConfig["activeGame"],
-  ) => {
-    if (!isSupportedGameInstallContext(serviceId, gameId)) {
-      throw new Error(
-        `Unsupported game install context: ${serviceId}/${gameId}`,
-      );
-    }
+  "game-install-path:pick-targets",
+  gameInstallPathIpcHandlers.pickGameInstallPathTargets,
+);
 
-    const targetWindow = BrowserWindow.fromWebContents(event.sender);
-    const openDialogOptions: OpenDialogOptions = {
-      title: "게임 설치 폴더 선택",
-      buttonLabel: "이 폴더 사용",
-      properties: ["openDirectory"],
-    };
-    const result = targetWindow
-      ? await dialog.showOpenDialog(targetWindow, openDialogOptions)
-      : await dialog.showOpenDialog(openDialogOptions);
-
-    if (result.canceled || result.filePaths.length === 0) {
-      return {
-        ok: false,
-        canceled: true,
-        verification: "not-checked",
-      };
-    }
-
-    return runManualGameInstallPathAction(
-      appContext,
-      serviceId,
-      gameId,
-      "manual-config-path-pick",
-      () => setGameInstallPath(serviceId, gameId, result.filePaths[0]),
-    );
-  },
+ipcMain.handle(
+  "game-install-path:apply-targets",
+  gameInstallPathIpcHandlers.applyGameInstallPathTargets,
 );
 
 ipcMain.handle(
@@ -819,6 +840,11 @@ ipcMain.handle(
     if (action !== "launcher-config-only" && action !== "sync-registry") {
       throw new Error(`Unsupported game install conflict action: ${action}`);
     }
+    const canonicalRegistryTarget: GameInstallPathConflictTarget = {
+      targetId: registryTarget?.targetId,
+      expectedPath: registryTarget?.expectedPath,
+      expectedConfigPath: registryTarget?.expectedConfigPath,
+    };
 
     return runManualGameInstallPathAction(
       appContext,
@@ -830,20 +856,18 @@ ipcMain.handle(
           serviceId,
           gameId,
           action,
-          registryTarget,
+          canonicalRegistryTarget,
         ),
     );
   },
 );
 
 ipcMain.handle(
-  "game-install-path:clear",
+  "game-install-path:clear-config",
   async (
     _event,
     serviceId: AppConfig["serviceChannel"],
     gameId: AppConfig["activeGame"],
-    source: "config" | "registry",
-    registryTarget?: GameInstallPathRegistryTarget,
   ) => {
     if (!isSupportedGameInstallContext(serviceId, gameId)) {
       throw new Error(
@@ -851,18 +875,19 @@ ipcMain.handle(
       );
     }
 
-    if (source !== "config" && source !== "registry") {
-      throw new Error(`Unsupported game install path clear source: ${source}`);
-    }
-
     return runManualGameInstallPathAction(
       appContext,
       serviceId,
       gameId,
-      `manual-${source}-path-clear`,
-      () => clearGameInstallPath(serviceId, gameId, source, registryTarget),
+      "manual-config-path-clear",
+      () => clearGameInstallPath(serviceId, gameId, "config"),
     );
   },
+);
+
+ipcMain.handle(
+  "game-install-path:delete-registry-target",
+  gameInstallPathRegistryDeleteHandler,
 );
 
 ipcMain.handle(

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -22,12 +22,15 @@ import {
   GameInstallPathConflictTarget,
   GameInstallPathConflictResolveResult,
   GameInstallPathClearResult,
-  GameInstallPathClearSource,
   GameInstallPathDiagnostics,
-  GameInstallPathRegistryTarget,
+  GameInstallPathRegistryTargetDeleteActionResult,
+  GameInstallPathRegistryTargetDeleteRequest,
   GameInstallPathRegisterRequest,
   GameInstallPathRegisterResult,
   GameInstallPathSaveResult,
+  GameInstallPathSelectionBatchResult,
+  GameInstallPathSelectionResult,
+  GameInstallPathTargetId,
   FatalErrorPayload,
   LauncherLogAvailability,
   LauncherLogSaveResult,
@@ -54,11 +57,19 @@ contextBridge.exposeInMainWorld("electronAPI", {
     installPath: string,
   ): Promise<GameInstallPathSaveResult> =>
     ipcRenderer.invoke("game-install-path:set", serviceId, gameId, installPath),
-  pickGameInstallPath: (
+  pickGameInstallPathTargets: (
     serviceId: AppConfig["serviceChannel"],
     gameId: AppConfig["activeGame"],
-  ): Promise<GameInstallPathSaveResult> =>
-    ipcRenderer.invoke("game-install-path:pick", serviceId, gameId),
+  ): Promise<GameInstallPathSelectionResult> =>
+    ipcRenderer.invoke("game-install-path:pick-targets", serviceId, gameId),
+  applyGameInstallPathTargets: (
+    selectionId: string,
+    targetIds: readonly GameInstallPathTargetId[],
+  ): Promise<GameInstallPathSelectionBatchResult> =>
+    ipcRenderer.invoke("game-install-path:apply-targets", {
+      selectionId,
+      targetIds,
+    }),
   resolveGameInstallPathConflict: (
     serviceId: AppConfig["serviceChannel"],
     gameId: AppConfig["activeGame"],
@@ -75,15 +86,18 @@ contextBridge.exposeInMainWorld("electronAPI", {
   clearGameInstallPath: (
     serviceId: AppConfig["serviceChannel"],
     gameId: AppConfig["activeGame"],
-    source: GameInstallPathClearSource,
-    registryTarget?: GameInstallPathRegistryTarget,
   ): Promise<GameInstallPathClearResult> =>
+    ipcRenderer.invoke("game-install-path:clear-config", serviceId, gameId),
+  deleteGameInstallPathRegistryTarget: (
+    serviceId: AppConfig["serviceChannel"],
+    gameId: AppConfig["activeGame"],
+    request: GameInstallPathRegistryTargetDeleteRequest,
+  ): Promise<GameInstallPathRegistryTargetDeleteActionResult> =>
     ipcRenderer.invoke(
-      "game-install-path:clear",
+      "game-install-path:delete-registry-target",
       serviceId,
       gameId,
-      source,
-      registryTarget,
+      request,
     ),
   registerGameInstallPath: (
     serviceId: AppConfig["serviceChannel"],

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -19,10 +19,14 @@ import {
   KakaoMaintenanceInfo,
   KakaoGameStarterMigrationRequest,
   GameInstallPathConflictAction,
+  GameInstallPathConflictTarget,
   GameInstallPathConflictResolveResult,
   GameInstallPathClearResult,
   GameInstallPathClearSource,
   GameInstallPathDiagnostics,
+  GameInstallPathRegistryTarget,
+  GameInstallPathRegisterRequest,
+  GameInstallPathRegisterResult,
   GameInstallPathSaveResult,
   FatalErrorPayload,
   LauncherLogAvailability,
@@ -59,19 +63,39 @@ contextBridge.exposeInMainWorld("electronAPI", {
     serviceId: AppConfig["serviceChannel"],
     gameId: AppConfig["activeGame"],
     action: GameInstallPathConflictAction,
+    registryTarget: GameInstallPathConflictTarget,
   ): Promise<GameInstallPathConflictResolveResult> =>
     ipcRenderer.invoke(
       "game-install-path:resolve-conflict",
       serviceId,
       gameId,
       action,
+      registryTarget,
     ),
   clearGameInstallPath: (
     serviceId: AppConfig["serviceChannel"],
     gameId: AppConfig["activeGame"],
     source: GameInstallPathClearSource,
+    registryTarget?: GameInstallPathRegistryTarget,
   ): Promise<GameInstallPathClearResult> =>
-    ipcRenderer.invoke("game-install-path:clear", serviceId, gameId, source),
+    ipcRenderer.invoke(
+      "game-install-path:clear",
+      serviceId,
+      gameId,
+      source,
+      registryTarget,
+    ),
+  registerGameInstallPath: (
+    serviceId: AppConfig["serviceChannel"],
+    gameId: AppConfig["activeGame"],
+    request: GameInstallPathRegisterRequest,
+  ): Promise<GameInstallPathRegisterResult> =>
+    ipcRenderer.invoke(
+      "game-install-path:register",
+      serviceId,
+      gameId,
+      request,
+    ),
   minimizeWindow: () => ipcRenderer.send("window-minimize"),
   closeWindow: () => ipcRenderer.send("window-close"),
   getConfig: (
@@ -93,7 +117,10 @@ contextBridge.exposeInMainWorld("electronAPI", {
     ipcRenderer.on("message-progress", (_event, text) => callback(text));
   },
   onGameStatusUpdate: (callback: (status: GameStatusState) => void) => {
-    ipcRenderer.on("game-status-update", (_event, status) => callback(status));
+    const handler = (_event: IpcRendererEvent, status: GameStatusState) =>
+      callback(status);
+    ipcRenderer.on("game-status-update", handler);
+    return () => ipcRenderer.off("game-status-update", handler);
   },
   getGameStatus: (gameId: string, serviceId: string) =>
     ipcRenderer.invoke("game:get-status", gameId, serviceId),

--- a/src/main/qa/GamePathDiagnosticQa.ts
+++ b/src/main/qa/GamePathDiagnosticQa.ts
@@ -1,0 +1,118 @@
+import path from "node:path";
+
+import {
+  isGamePathDiagnosticQaFixtureMode,
+  isGamePathDiagnosticQaRunId,
+  parseGamePathDiagnosticQaSearch,
+  type GamePathDiagnosticQaFixtureMode,
+} from "../../shared/qa/game-path-diagnostic";
+
+export interface GamePathDiagnosticQaLaunchInput {
+  readonly isPackaged: boolean;
+  readonly devServerUrl?: string;
+  readonly startHidden?: string;
+  readonly runId?: string;
+  readonly userDataPath?: string;
+  readonly fixtureMode?: string;
+}
+
+export interface GamePathDiagnosticQaLaunchRequest {
+  readonly runId: string;
+  readonly userDataPath: string;
+  readonly fixtureMode: GamePathDiagnosticQaFixtureMode;
+  readonly devServerUrl: string;
+}
+
+export type GamePathDiagnosticQaLaunchDecision =
+  | { readonly kind: "inactive" }
+  | {
+      readonly kind: "active";
+      readonly request: GamePathDiagnosticQaLaunchRequest;
+    };
+
+const isOwnedQaUserDataPath = (
+  userDataPath: string,
+  runId: string,
+): boolean => {
+  if (!path.win32.isAbsolute(userDataPath)) return false;
+  const normalizedPath = path.win32.normalize(userDataPath);
+  const runDirectory = path.win32.basename(normalizedPath);
+  const qaRoot = path.win32.basename(path.win32.dirname(normalizedPath));
+  return runDirectory === runId && qaRoot.toLowerCase().endsWith("codex-qa");
+};
+
+const normalizeDevServerUrl = (value: string): string | null => {
+  try {
+    const url = new URL(value);
+    if (
+      url.protocol !== "http:" ||
+      url.hostname !== "localhost" ||
+      url.pathname !== "/" ||
+      url.search ||
+      url.hash
+    ) {
+      return null;
+    }
+    return url.toString();
+  } catch {
+    return null;
+  }
+};
+
+export const resolveGamePathDiagnosticQaLaunch = (
+  input: GamePathDiagnosticQaLaunchInput,
+): GamePathDiagnosticQaLaunchDecision => {
+  const devServerUrl = input.devServerUrl
+    ? normalizeDevServerUrl(input.devServerUrl)
+    : null;
+  if (
+    input.isPackaged ||
+    input.startHidden !== "true" ||
+    !devServerUrl ||
+    !isGamePathDiagnosticQaRunId(input.runId) ||
+    !input.userDataPath ||
+    !isOwnedQaUserDataPath(input.userDataPath, input.runId) ||
+    !isGamePathDiagnosticQaFixtureMode(input.fixtureMode)
+  ) {
+    return { kind: "inactive" };
+  }
+
+  return {
+    kind: "active",
+    request: {
+      runId: input.runId,
+      userDataPath: input.userDataPath,
+      fixtureMode: input.fixtureMode,
+      devServerUrl,
+    },
+  };
+};
+
+export const buildGamePathDiagnosticQaRendererUrl = (
+  request: GamePathDiagnosticQaLaunchRequest,
+): string => {
+  const url = new URL(request.devServerUrl);
+  url.searchParams.set("codexQaFixture", request.fixtureMode);
+  url.searchParams.set("codexQaRun", request.runId);
+  return url.toString();
+};
+
+export const isAllowedGamePathDiagnosticQaRendererUrl = (
+  candidate: string,
+  devServerUrl: string,
+  runId: string,
+): boolean => {
+  try {
+    const candidateUrl = new URL(candidate);
+    const baseUrl = new URL(devServerUrl);
+    const fixture = parseGamePathDiagnosticQaSearch(candidateUrl.search);
+    return (
+      candidateUrl.origin === baseUrl.origin &&
+      candidateUrl.pathname === baseUrl.pathname &&
+      candidateUrl.hash === "" &&
+      fixture?.runId === runId
+    );
+  } catch {
+    return false;
+  }
+};

--- a/src/main/state/GameStatusStore.ts
+++ b/src/main/state/GameStatusStore.ts
@@ -8,13 +8,22 @@ export const getGameStatusKey = (gameId: string, serviceId: string) =>
 export const updateGameStatusCache = (
   statusState: GameStatusState,
 ): GameStatusState => {
+  const key = getGameStatusKey(statusState.gameId, statusState.serviceId);
+  const previous = gameStatusCache[key];
+  const incomingHealth = statusState.installPathHealth;
+  const installPathHealth =
+    incomingHealth &&
+    (!previous?.installPathHealth ||
+      incomingHealth.checkedAt >= previous.installPathHealth.checkedAt)
+      ? incomingHealth
+      : previous?.installPathHealth;
   const payload: GameStatusState = {
     ...statusState,
+    ...(installPathHealth ? { installPathHealth } : {}),
     timestamp: statusState.timestamp ?? Date.now(),
   };
 
-  gameStatusCache[getGameStatusKey(payload.gameId, payload.serviceId)] =
-    payload;
+  gameStatusCache[key] = payload;
 
   return payload;
 };

--- a/src/main/tests/GameInstallPathIpcHandlers.test.ts
+++ b/src/main/tests/GameInstallPathIpcHandlers.test.ts
@@ -1,0 +1,554 @@
+import {
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type Mocked,
+  type MockedFunction,
+} from "vitest";
+
+import {
+  createGameInstallPathIpcHandlers,
+  createGameInstallPathRegistryDeleteHandler,
+  type GameInstallPathIpcHandlerDependencies,
+  type GameInstallPathRegistryDeleteHandlerDependencies,
+} from "../game/GameInstallPathIpcHandlers";
+import {
+  GameInstallPathSelectionService,
+  type GameInstallPathSelectionServiceDependencies,
+} from "../game/GameInstallPathSelectionService";
+
+import type {
+  GameInstallPathDiagnostics,
+  GameInstallPathRegistryTargetDeleteActionResult,
+  GameInstallPathSelectionBatchResult,
+  GameInstallPathSelectionResult,
+  GameInstallPathTargetApplyResult,
+} from "../../shared/types";
+
+const selectedResult: GameInstallPathSelectionResult = {
+  ok: true,
+  status: "selected",
+  selection: {
+    selectionId: "selection-1",
+    serviceId: "Kakao Games",
+    gameId: "POE2",
+    path: String.raw`F:\Games\Selected`,
+    targets: [],
+  },
+};
+
+const partialResult: GameInstallPathSelectionBatchResult = {
+  ok: true,
+  overall: "partial",
+  results: [
+    {
+      targetId: "registry-primary",
+      status: "applied",
+      path: String.raw`F:\Games\Selected`,
+    },
+    {
+      targetId: "config",
+      status: "failed",
+      code: "target-changed",
+      retryable: true,
+    },
+  ],
+  retryableTargetIds: ["config"],
+  diagnostics: {} as never,
+  selection: selectedResult.selection,
+};
+
+const failedResult: GameInstallPathSelectionBatchResult = {
+  ok: false,
+  overall: "failed",
+  results: [
+    {
+      targetId: "config",
+      status: "failed",
+      code: "target-changed",
+      retryable: true,
+    },
+  ],
+  retryableTargetIds: ["config"],
+  diagnostics: {} as never,
+  selection: selectedResult.selection,
+};
+
+const handlerDiagnostics: GameInstallPathDiagnostics = {
+  serviceId: "Kakao Games",
+  gameId: "POE2",
+  executableName: "PathOfExile_KG.exe",
+  config: {
+    source: "config",
+    path: String.raw`E:\Games\Config`,
+    state: "found",
+    verification: "valid",
+  },
+  registry: {
+    source: "registry",
+    path: String.raw`C:\Games\Primary`,
+    state: "found",
+    verification: "valid",
+    registryPath: String.raw`HKCU:\Software\Primary\POE2`,
+    registryValueName: "InstallPath",
+    aggregateState: "valid",
+    candidates: [
+      {
+        targetId: "registry-primary",
+        path: String.raw`C:\Games\Primary`,
+        state: "found",
+        verification: "valid",
+        registryPath: String.raw`HKCU:\Software\Primary\POE2`,
+        registryValueName: "InstallPath",
+        isActive: true,
+      },
+    ],
+  },
+  hasPathConflict: false,
+  isPathConflictAcknowledged: false,
+  recommendedSource: null,
+};
+
+const createSender = (id = 71) => {
+  let destroyed = false;
+  const destroyedListeners: Array<() => void> = [];
+  return {
+    id,
+    once: vi.fn((event: "destroyed", listener: () => void) => {
+      if (event === "destroyed") destroyedListeners.push(listener);
+    }),
+    isDestroyed: vi.fn(() => destroyed),
+    destroy: () => {
+      destroyed = true;
+      for (const listener of destroyedListeners.splice(0)) listener();
+    },
+  };
+};
+
+const createDeferred = <Value>() => {
+  let resolve!: (value: Value) => void;
+  const promise = new Promise<Value>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+};
+
+describe("GameInstallPathIpcHandlers", () => {
+  type SelectionService =
+    GameInstallPathIpcHandlerDependencies["selectionService"];
+  let reconcile: MockedFunction<() => void>;
+  let selectionService: Mocked<SelectionService>;
+  let showOpenDialog: MockedFunction<
+    GameInstallPathIpcHandlerDependencies["showOpenDialog"]
+  >;
+  let runManualAction: MockedFunction<
+    GameInstallPathIpcHandlerDependencies["runManualAction"]
+  >;
+  let handlers: ReturnType<typeof createGameInstallPathIpcHandlers>;
+
+  beforeEach(() => {
+    reconcile = vi.fn();
+    selectionService = {
+      getDefaultPath: vi.fn<SelectionService["getDefaultPath"]>(
+        async () => undefined,
+      ),
+      createSelection: vi.fn<SelectionService["createSelection"]>(
+        async () => selectedResult,
+      ),
+      disposeOwner: vi.fn<SelectionService["disposeOwner"]>(),
+      resolveSelectionContext: vi.fn<
+        SelectionService["resolveSelectionContext"]
+      >(() => ({
+        ok: true,
+        context: { serviceId: "Kakao Games", gameId: "POE2" },
+      })),
+      applySelection: vi.fn<SelectionService["applySelection"]>(
+        async () => partialResult,
+      ),
+    };
+    showOpenDialog = vi.fn<
+      GameInstallPathIpcHandlerDependencies["showOpenDialog"]
+    >(async () => ({
+      canceled: false,
+      filePaths: [String.raw`F:\Games\Selected`],
+    }));
+    runManualAction = vi.fn<
+      GameInstallPathIpcHandlerDependencies["runManualAction"]
+    >(async (_context, action) => {
+      const result = await action();
+      if (result.ok) reconcile();
+      return result;
+    });
+    handlers = createGameInstallPathIpcHandlers({
+      isSupportedContext: () => true,
+      selectionService,
+      showOpenDialog,
+      runManualAction,
+    });
+  });
+
+  it("picks a selection without applying a mutation and includes an existing defaultPath", async () => {
+    selectionService.getDefaultPath.mockResolvedValue(
+      String.raw`D:\Games\Default`,
+    );
+    const sender = createSender();
+
+    await expect(
+      handlers.pickGameInstallPathTargets({ sender }, "Kakao Games", "POE2"),
+    ).resolves.toEqual(selectedResult);
+
+    expect(showOpenDialog).toHaveBeenCalledWith(
+      sender,
+      expect.objectContaining({ defaultPath: String.raw`D:\Games\Default` }),
+    );
+    expect(selectionService.createSelection).toHaveBeenCalledWith(
+      sender.id,
+      "Kakao Games",
+      "POE2",
+      String.raw`F:\Games\Selected`,
+    );
+    expect(selectionService.applySelection).not.toHaveBeenCalled();
+    expect(runManualAction).not.toHaveBeenCalled();
+  });
+
+  it("omits defaultPath when no existing directory is available", async () => {
+    const sender = createSender();
+
+    await handlers.pickGameInstallPathTargets(
+      { sender },
+      "Kakao Games",
+      "POE2",
+    );
+
+    expect(showOpenDialog.mock.calls[0][1]).not.toHaveProperty("defaultPath");
+  });
+
+  it("registers owner destroyed cleanup exactly once", async () => {
+    const sender = createSender();
+
+    await handlers.pickGameInstallPathTargets(
+      { sender },
+      "Kakao Games",
+      "POE2",
+    );
+    await handlers.pickGameInstallPathTargets(
+      { sender },
+      "Kakao Games",
+      "POE2",
+    );
+
+    expect(sender.once).toHaveBeenCalledTimes(1);
+    sender.destroy();
+    expect(selectionService.disposeOwner).toHaveBeenCalledTimes(1);
+    expect(selectionService.disposeOwner).toHaveBeenCalledWith(sender.id);
+  });
+
+  it("cancels a delayed picker result after owner destruction", async () => {
+    let resolveDialog!: (value: {
+      canceled: false;
+      filePaths: string[];
+    }) => void;
+    showOpenDialog.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveDialog = resolve;
+      }),
+    );
+    const sender = createSender();
+    const picking = handlers.pickGameInstallPathTargets(
+      { sender },
+      "Kakao Games",
+      "POE2",
+    );
+    await vi.waitFor(() => expect(showOpenDialog).toHaveBeenCalledTimes(1));
+
+    sender.destroy();
+    resolveDialog({
+      canceled: false,
+      filePaths: [String.raw`F:\Games\Selected`],
+    });
+
+    await expect(picking).resolves.toEqual({ ok: false, status: "canceled" });
+    expect(selectionService.createSelection).not.toHaveBeenCalled();
+  });
+
+  it("cancels a delayed selection creation after owner destruction", async () => {
+    const deferredSelection = createDeferred<GameInstallPathSelectionResult>();
+    selectionService.createSelection.mockReturnValueOnce(
+      deferredSelection.promise,
+    );
+    const sender = createSender();
+    const picking = handlers.pickGameInstallPathTargets(
+      { sender },
+      "Kakao Games",
+      "POE2",
+    );
+    await vi.waitFor(() =>
+      expect(selectionService.createSelection).toHaveBeenCalledTimes(1),
+    );
+
+    sender.destroy();
+    deferredSelection.resolve(selectedResult);
+
+    await expect(picking).resolves.toEqual({ ok: false, status: "canceled" });
+    expect(selectionService.disposeOwner).toHaveBeenCalledWith(sender.id);
+  });
+
+  it("canonicalizes apply authority and reconciles one partial ok batch once", async () => {
+    const sender = createSender();
+    const request = {
+      selectionId: "selection-1",
+      targetIds: ["config"],
+      serviceId: "GGG",
+      gameId: "POE1",
+      path: String.raw`Z:\Untrusted`,
+      registryPath: "untrusted",
+    } as const;
+
+    await expect(
+      handlers.applyGameInstallPathTargets({ sender }, request),
+    ).resolves.toEqual(partialResult);
+
+    expect(selectionService.resolveSelectionContext).toHaveBeenCalledWith(
+      sender.id,
+      "selection-1",
+    );
+    expect(selectionService.applySelection).toHaveBeenCalledWith(sender.id, {
+      selectionId: "selection-1",
+      targetIds: ["config"],
+    });
+    expect(runManualAction).toHaveBeenCalledTimes(1);
+    expect(reconcile).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not reconcile an all-failed batch", async () => {
+    selectionService.applySelection.mockResolvedValueOnce(failedResult);
+    const sender = createSender();
+
+    await expect(
+      handlers.applyGameInstallPathTargets(
+        { sender },
+        { selectionId: "selection-1", targetIds: ["config"] },
+      ),
+    ).resolves.toEqual(failedResult);
+
+    expect(runManualAction).toHaveBeenCalledTimes(1);
+    expect(reconcile).not.toHaveBeenCalled();
+  });
+
+  it("reconciles only the first of two concurrent same-selection applies", async () => {
+    const deferredApply = createDeferred<GameInstallPathTargetApplyResult>();
+    const applyTarget =
+      vi.fn<GameInstallPathSelectionServiceDependencies["applyTarget"]>();
+    applyTarget.mockReturnValueOnce(deferredApply.promise).mockResolvedValue({
+      targetId: "config",
+      status: "applied",
+      path: String.raw`F:\Games\Selected`,
+    });
+    const actualService = new GameInstallPathSelectionService({
+      now: () => 1_000,
+      randomUUID: () => "selection-1",
+      fsStat: async () => ({
+        isDirectory: () => false,
+        isFile: () => true,
+      }),
+      getDiagnostics: async () => handlerDiagnostics,
+      collectSnapshots: (diagnostics) => [
+        ...diagnostics.registry.candidates.map((candidate) => ({
+          targetId: candidate.targetId,
+          currentPath: candidate.path,
+          registryState: candidate.state,
+        })),
+        { targetId: "config", currentPath: diagnostics.config.path },
+      ],
+      applyTarget,
+    });
+    const selection = await actualService.createSelection(
+      71,
+      "Kakao Games",
+      "POE2",
+      String.raw`F:\Games\Selected`,
+    );
+    expect(selection.ok).toBe(true);
+    if (!selection.ok) throw new Error("Expected handler selection fixture");
+    const actualHandlers = createGameInstallPathIpcHandlers({
+      isSupportedContext: () => true,
+      selectionService: actualService,
+      showOpenDialog,
+      runManualAction,
+    });
+    const sender = createSender();
+    const request = {
+      selectionId: selection.selection.selectionId,
+      targetIds: ["config" as const],
+    };
+
+    const firstApply = actualHandlers.applyGameInstallPathTargets(
+      { sender },
+      request,
+    );
+    await vi.waitFor(() => expect(applyTarget).toHaveBeenCalledTimes(1));
+    const replayResult = await actualHandlers.applyGameInstallPathTargets(
+      { sender },
+      request,
+    );
+    deferredApply.resolve({
+      targetId: "config",
+      status: "applied",
+      path: String.raw`F:\Games\Selected`,
+    });
+    const firstResult = await firstApply;
+
+    expect(firstResult).toMatchObject({ ok: true, overall: "success" });
+    expect(replayResult).toMatchObject({
+      ok: false,
+      overall: "failed",
+      failureCode: "selection-busy",
+    });
+    expect(applyTarget).toHaveBeenCalledTimes(1);
+    expect(reconcile).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("GameInstallPathRegistryDeleteHandler", () => {
+  const deletedResult: GameInstallPathRegistryTargetDeleteActionResult = {
+    ok: true,
+    source: "registry",
+    result: { targetId: "registry-primary", status: "deleted" },
+    diagnostics: handlerDiagnostics,
+  };
+
+  const createDependencies = () => {
+    const deleteRegistryTarget = vi.fn(async () => deletedResult.result);
+    const getDiagnostics = vi.fn(async () => handlerDiagnostics);
+    const runManualAction = vi.fn(async (_context, action) => action());
+    const dependencies: GameInstallPathRegistryDeleteHandlerDependencies = {
+      isSupportedContext: () => true,
+      deleteRegistryTarget,
+      getDiagnostics,
+      runManualAction,
+    };
+    return {
+      dependencies,
+      deleteRegistryTarget,
+      getDiagnostics,
+      runManualAction,
+    };
+  };
+
+  it("canonicalizes deletion to targetId and expectedPath and wraps it once", async () => {
+    const { dependencies, deleteRegistryTarget, runManualAction } =
+      createDependencies();
+    const handler = createGameInstallPathRegistryDeleteHandler(dependencies);
+    const request = {
+      targetId: "registry-primary",
+      expectedPath: String.raw`F:\\Games\\Selected`,
+      registryPath: "untrusted",
+      registryValueName: "untrusted",
+    } as const;
+
+    await expect(
+      handler({ sender: createSender() }, "Kakao Games", "POE2", request),
+    ).resolves.toEqual(deletedResult);
+    expect(deleteRegistryTarget).toHaveBeenCalledWith("Kakao Games", "POE2", {
+      targetId: "registry-primary",
+      expectedPath: String.raw`F:\\Games\\Selected`,
+    });
+    expect(runManualAction).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns fresh diagnostics for a failed candidate deletion", async () => {
+    const { dependencies, getDiagnostics, runManualAction } =
+      createDependencies();
+    dependencies.deleteRegistryTarget = vi.fn<
+      GameInstallPathRegistryDeleteHandlerDependencies["deleteRegistryTarget"]
+    >(async () => ({
+      targetId: "registry-compatibility",
+      status: "failed",
+      code: "target-changed",
+      retryable: true,
+    }));
+    const handler = createGameInstallPathRegistryDeleteHandler(dependencies);
+
+    const result = await handler(
+      { sender: createSender() },
+      "Kakao Games",
+      "POE2",
+      {
+        targetId: "registry-compatibility",
+        expectedPath: String.raw`D:\\Games\\Old`,
+      },
+    );
+
+    expect(result).toMatchObject({
+      ok: false,
+      source: "registry",
+      result: { status: "failed", code: "target-changed" },
+      diagnostics: handlerDiagnostics,
+    });
+    expect(runManualAction).toHaveBeenCalledTimes(1);
+    expect(getDiagnostics).toHaveBeenCalledTimes(1);
+  });
+
+  it("coalesces concurrent same-owner context and target deletion through one reconciliation and refresh", async () => {
+    const {
+      dependencies,
+      deleteRegistryTarget,
+      getDiagnostics,
+      runManualAction,
+    } = createDependencies();
+    const deferredDelete =
+      createDeferred<
+        GameInstallPathRegistryTargetDeleteActionResult["result"]
+      >();
+    deleteRegistryTarget.mockReturnValueOnce(deferredDelete.promise);
+    const handler = createGameInstallPathRegistryDeleteHandler(dependencies);
+    const sender = createSender();
+    const request = {
+      targetId: "registry-primary" as const,
+      expectedPath: String.raw`F:\\Games\\Selected`,
+    };
+
+    const first = handler({ sender }, "Kakao Games", "POE2", request);
+    await vi.waitFor(() =>
+      expect(deleteRegistryTarget).toHaveBeenCalledTimes(1),
+    );
+    const duplicate = handler({ sender }, "Kakao Games", "POE2", request);
+
+    expect(runManualAction).toHaveBeenCalledTimes(1);
+    expect(deleteRegistryTarget).toHaveBeenCalledTimes(1);
+    expect(getDiagnostics).not.toHaveBeenCalled();
+
+    deferredDelete.resolve(deletedResult.result);
+    await expect(Promise.all([first, duplicate])).resolves.toEqual([
+      deletedResult,
+      deletedResult,
+    ]);
+    expect(runManualAction).toHaveBeenCalledTimes(1);
+    expect(deleteRegistryTarget).toHaveBeenCalledTimes(1);
+    expect(getDiagnostics).toHaveBeenCalledTimes(1);
+
+    await expect(
+      handler({ sender }, "Kakao Games", "POE2", request),
+    ).resolves.toEqual(deletedResult);
+    expect(runManualAction).toHaveBeenCalledTimes(2);
+    expect(deleteRegistryTarget).toHaveBeenCalledTimes(2);
+    expect(getDiagnostics).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects a non-allowlisted runtime target before mutation", async () => {
+    const { dependencies, deleteRegistryTarget, runManualAction } =
+      createDependencies();
+    const handler = createGameInstallPathRegistryDeleteHandler(dependencies);
+
+    await expect(
+      handler({ sender: createSender() }, "Kakao Games", "POE2", {
+        targetId: "config",
+        expectedPath: String.raw`F:\\Games\\Selected`,
+      } as never),
+    ).rejects.toThrow("Unsupported registry target ID");
+    expect(deleteRegistryTarget).not.toHaveBeenCalled();
+    expect(runManualAction).not.toHaveBeenCalled();
+  });
+});

--- a/src/main/tests/GameInstallPathSelectionService.test.ts
+++ b/src/main/tests/GameInstallPathSelectionService.test.ts
@@ -1,0 +1,1092 @@
+import path from "node:path";
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  GAME_INSTALL_PATH_SELECTION_TTL_MS,
+  GameInstallPathSelectionService,
+  type GameInstallPathSelectionServiceDependencies,
+} from "../game/GameInstallPathSelectionService";
+
+import type {
+  AppConfig,
+  GameInstallPathDiagnostics,
+  GameInstallPathTargetApplyResult,
+  GameInstallPathTargetId,
+  GameInstallPathTargetSnapshot,
+} from "../../shared/types";
+
+type ServiceId = AppConfig["serviceChannel"];
+type GameId = AppConfig["activeGame"];
+
+const primaryPath = String.raw`C:\Games\Primary`;
+const compatibilityPath = String.raw`D:\Games\Compatibility`;
+const configPath = String.raw`E:\Games\Config`;
+const selectedPath = String.raw`F:\Games\Selected POE2`;
+
+const createDiagnostics = (
+  serviceId: ServiceId = "Kakao Games",
+  gameId: GameId = "POE2",
+  options: {
+    primaryPath?: string | null;
+    primaryState?: "found" | "key-missing" | "read-failed";
+    compatibilityPath?: string | null;
+    compatibilityState?: "found" | "key-missing" | "read-failed";
+    configPath?: string | null;
+    includeCompatibility?: boolean;
+  } = {},
+): GameInstallPathDiagnostics => {
+  const resolvedPrimaryPath = options.primaryPath ?? primaryPath;
+  const primaryState = options.primaryState ?? "found";
+  const resolvedCompatibilityPath =
+    options.compatibilityPath ?? compatibilityPath;
+  const compatibilityState = options.compatibilityState ?? "found";
+  const resolvedConfigPath = options.configPath ?? configPath;
+  const primaryCandidate = {
+    targetId: "registry-primary" as const,
+    path: primaryState === "found" ? resolvedPrimaryPath : null,
+    state: primaryState,
+    verification:
+      primaryState === "found" ? ("valid" as const) : ("not-checked" as const),
+    registryPath: ["HKCU:", "Software", "Primary", gameId].join("\\"),
+    registryValueName: "InstallPath",
+    isActive: primaryState === "found",
+  };
+  const compatibilityCandidate = {
+    targetId: "registry-compatibility" as const,
+    path: compatibilityState === "found" ? resolvedCompatibilityPath : null,
+    state: compatibilityState,
+    verification:
+      compatibilityState === "found"
+        ? ("valid" as const)
+        : ("not-checked" as const),
+    registryPath: ["HKCU:", "Software", "Compatibility", gameId].join("\\"),
+    registryValueName: "InstallPath",
+    isActive: false,
+  };
+  const candidates = [
+    primaryCandidate,
+    ...((options.includeCompatibility ?? serviceId === "Kakao Games")
+      ? [compatibilityCandidate]
+      : []),
+  ];
+
+  return {
+    serviceId,
+    gameId,
+    executableName:
+      serviceId === "Kakao Games" ? "PathOfExile_KG.exe" : "PathOfExile.exe",
+    config: {
+      source: "config",
+      path: resolvedConfigPath,
+      state: resolvedConfigPath ? "found" : "empty",
+      verification: resolvedConfigPath ? "valid" : "not-checked",
+    },
+    registry: {
+      source: "registry",
+      path: primaryCandidate.path,
+      state: primaryCandidate.state,
+      verification: primaryCandidate.verification,
+      registryPath: primaryCandidate.registryPath,
+      registryValueName: primaryCandidate.registryValueName,
+      aggregateState: primaryCandidate.path ? "valid" : "absent",
+      candidates,
+    },
+    hasPathConflict: false,
+    isPathConflictAcknowledged: false,
+    recommendedSource: null,
+  };
+};
+
+const snapshotsFromDiagnostics = (
+  diagnostics: GameInstallPathDiagnostics,
+): readonly GameInstallPathTargetSnapshot[] => [
+  ...diagnostics.registry.candidates.map((candidate) => ({
+    targetId: candidate.targetId,
+    currentPath: candidate.path,
+    registryState: candidate.state,
+  })),
+  { targetId: "config", currentPath: diagnostics.config.path },
+];
+
+const createDeferred = <Value>() => {
+  let resolve!: (value: Value) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<Value>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+};
+
+const fileStats = { isDirectory: () => false, isFile: () => true };
+
+describe("GameInstallPathSelectionService", () => {
+  let now: number;
+  let uuidSequence: number;
+  let diagnostics: GameInstallPathDiagnostics;
+  let directories: Set<string>;
+  let files: Set<string>;
+  let dependencies: GameInstallPathSelectionServiceDependencies;
+  let service: GameInstallPathSelectionService;
+
+  const normalize = (value: string) =>
+    path.win32.normalize(value).toLowerCase();
+  const executablePath = (serviceId: ServiceId, installPath: string) =>
+    path.win32.join(
+      installPath,
+      serviceId === "Kakao Games" ? "PathOfExile_KG.exe" : "PathOfExile.exe",
+    );
+  const markDirectory = (...paths: string[]) => {
+    for (const candidatePath of paths)
+      directories.add(normalize(candidatePath));
+  };
+  const markValidInstall = (
+    installPath: string,
+    serviceId: ServiceId = "Kakao Games",
+  ) => {
+    files.add(normalize(executablePath(serviceId, installPath)));
+  };
+  const createValidSelection = async (
+    ownerWebContentsId = 1,
+    serviceId: ServiceId = "Kakao Games",
+    gameId: GameId = "POE2",
+    installPath = selectedPath,
+  ) => {
+    markValidInstall(installPath, serviceId);
+    const result = await service.createSelection(
+      ownerWebContentsId,
+      serviceId,
+      gameId,
+      `${installPath}\\`,
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("Expected a valid selection fixture");
+    return result.selection;
+  };
+
+  beforeEach(() => {
+    now = 1_000;
+    uuidSequence = 0;
+    diagnostics = createDiagnostics();
+    directories = new Set();
+    files = new Set();
+
+    dependencies = {
+      now: () => now,
+      randomUUID: () => `selection-${++uuidSequence}`,
+      fsStat: vi.fn(async (targetPath: string) => {
+        const normalized = normalize(targetPath);
+        if (directories.has(normalized)) {
+          return { isDirectory: () => true, isFile: () => false };
+        }
+        if (files.has(normalized)) {
+          return { isDirectory: () => false, isFile: () => true };
+        }
+        throw Object.assign(new Error("missing"), { code: "ENOENT" });
+      }),
+      getDiagnostics: vi.fn(async () => diagnostics),
+      collectSnapshots: vi.fn((value) => snapshotsFromDiagnostics(value)),
+      applyTarget: vi.fn(
+        async (
+          _serviceId: ServiceId,
+          _gameId: GameId,
+          snapshot: GameInstallPathTargetSnapshot,
+          installPath: string,
+        ): Promise<GameInstallPathTargetApplyResult> => ({
+          targetId: snapshot.targetId,
+          status: "applied",
+          path: installPath,
+        }),
+      ),
+    };
+    service = new GameInstallPathSelectionService(dependencies);
+  });
+
+  it("uses the first existing registry candidate as the picker default path", async () => {
+    markDirectory(compatibilityPath, configPath);
+
+    await expect(service.getDefaultPath("Kakao Games", "POE2")).resolves.toBe(
+      compatibilityPath,
+    );
+    expect(dependencies.fsStat).toHaveBeenCalledWith(primaryPath);
+    expect(dependencies.fsStat).toHaveBeenCalledWith(compatibilityPath);
+    expect(dependencies.fsStat).not.toHaveBeenCalledWith(configPath);
+  });
+
+  it("falls back to an existing config directory after registry candidates", async () => {
+    markDirectory(configPath);
+
+    await expect(service.getDefaultPath("Kakao Games", "POE2")).resolves.toBe(
+      configPath,
+    );
+  });
+
+  it("omits the picker default path when no diagnostic path is a directory", async () => {
+    await expect(
+      service.getDefaultPath("Kakao Games", "POE2"),
+    ).resolves.toBeUndefined();
+  });
+
+  it("creates a normalized verified selection without applying a target", async () => {
+    const selection = await createValidSelection();
+
+    expect(selection).toMatchObject({
+      selectionId: "selection-1",
+      serviceId: "Kakao Games",
+      gameId: "POE2",
+      path: selectedPath,
+    });
+    expect(selection.targets).toEqual([
+      expect.objectContaining({
+        targetId: "registry-primary",
+        selectedByDefault: true,
+        disabled: false,
+        registryPath: String.raw`HKCU:\Software\Primary\POE2`,
+        registryValueName: "InstallPath",
+      }),
+      expect.objectContaining({
+        targetId: "registry-compatibility",
+        selectedByDefault: false,
+        disabled: false,
+      }),
+      expect.objectContaining({
+        targetId: "config",
+        selectedByDefault: true,
+        disabled: false,
+      }),
+    ]);
+    expect(dependencies.applyTarget).not.toHaveBeenCalled();
+  });
+
+  it("returns a typed invalid result when the selected executable is missing", async () => {
+    const result = await service.createSelection(
+      1,
+      "Kakao Games",
+      "POE2",
+      selectedPath,
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      status: "invalid",
+      code: "install-path-invalid",
+      verification: "missing",
+    });
+    expect(dependencies.getDiagnostics).not.toHaveBeenCalled();
+    expect(dependencies.collectSnapshots).not.toHaveBeenCalled();
+    expect(dependencies.applyTarget).not.toHaveBeenCalled();
+  });
+
+  it("isolates selections by owner without leaking their context", async () => {
+    const selection = await createValidSelection(11);
+
+    const result = await service.applySelection(12, {
+      selectionId: selection.selectionId,
+      targetIds: ["config"],
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      overall: "failed",
+      failureCode: "selection-owner-mismatch",
+      results: [],
+      retryableTargetIds: [],
+    });
+    expect(dependencies.applyTarget).not.toHaveBeenCalled();
+  });
+
+  it("discards the previous selection when the same owner creates a new one", async () => {
+    const first = await createValidSelection(11);
+    const secondPath = String.raw`F:\Games\Second POE2`;
+    const second = await createValidSelection(
+      11,
+      "Kakao Games",
+      "POE2",
+      secondPath,
+    );
+
+    await expect(
+      service.applySelection(11, {
+        selectionId: first.selectionId,
+        targetIds: ["config"],
+      }),
+    ).resolves.toMatchObject({
+      ok: false,
+      failureCode: "selection-not-found",
+    });
+    await expect(
+      service.applySelection(11, {
+        selectionId: second.selectionId,
+        targetIds: ["config"],
+      }),
+    ).resolves.toMatchObject({ ok: true, overall: "success" });
+  });
+
+  it("never reissues a replaced selection ID to the same live owner", async () => {
+    dependencies.randomUUID = vi
+      .fn()
+      .mockReturnValueOnce("selection-x")
+      .mockReturnValueOnce("selection-x")
+      .mockReturnValueOnce("selection-y");
+    const first = await createValidSelection(11);
+    const replacement = await createValidSelection(
+      11,
+      "Kakao Games",
+      "POE2",
+      String.raw`F:\Games\Replacement POE2`,
+    );
+
+    const staleResult = await service.applySelection(11, {
+      selectionId: first.selectionId,
+      targetIds: ["config"],
+    });
+
+    expect(first.selectionId).toBe("selection-x");
+    expect(replacement.selectionId).toBe("selection-y");
+    expect(staleResult).toEqual({
+      ok: false,
+      overall: "failed",
+      failureCode: "selection-not-found",
+      results: [],
+      retryableTargetIds: [],
+    });
+    expect(dependencies.randomUUID).toHaveBeenCalledTimes(3);
+    expect(dependencies.applyTarget).not.toHaveBeenCalled();
+  });
+
+  it("regenerates a colliding active selection ID without crossing owners", async () => {
+    dependencies.randomUUID = vi
+      .fn()
+      .mockReturnValueOnce("shared-selection")
+      .mockReturnValueOnce("shared-selection")
+      .mockReturnValueOnce("owner-b-selection");
+    const ownerA = await createValidSelection(11);
+    const ownerB = await createValidSelection(12);
+
+    expect(ownerA.selectionId).toBe("shared-selection");
+    expect(ownerB.selectionId).toBe("owner-b-selection");
+
+    service.disposeOwner(11);
+    await expect(
+      service.applySelection(12, {
+        selectionId: ownerB.selectionId,
+        targetIds: ["config"],
+      }),
+    ).resolves.toMatchObject({ ok: true });
+  });
+
+  it("fails closed after bounded active selection ID collisions", async () => {
+    dependencies.randomUUID = vi.fn(() => "shared-selection");
+    await createValidSelection(11);
+
+    const result = await service.createSelection(
+      12,
+      "Kakao Games",
+      "POE2",
+      selectedPath,
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      status: "unavailable",
+      code: "selection-id-unavailable",
+    });
+    expect(dependencies.randomUUID).toHaveBeenCalledTimes(9);
+  });
+
+  it("does not insert a delayed selection after owner disposal during fsStat", async () => {
+    const deferredStat = createDeferred<typeof fileStats>();
+    vi.mocked(dependencies.fsStat).mockReturnValueOnce(deferredStat.promise);
+
+    const creation = service.createSelection(
+      41,
+      "Kakao Games",
+      "POE2",
+      selectedPath,
+    );
+    service.disposeOwner(41);
+    deferredStat.resolve(fileStats);
+
+    await expect(creation).resolves.toEqual({
+      ok: false,
+      status: "canceled",
+    });
+    expect(dependencies.collectSnapshots).not.toHaveBeenCalled();
+  });
+
+  it("does not insert a delayed selection after owner disposal during diagnostics", async () => {
+    markValidInstall(selectedPath);
+    const deferredDiagnostics = createDeferred<GameInstallPathDiagnostics>();
+    vi.mocked(dependencies.getDiagnostics).mockReturnValueOnce(
+      deferredDiagnostics.promise,
+    );
+
+    const creation = service.createSelection(
+      42,
+      "Kakao Games",
+      "POE2",
+      selectedPath,
+    );
+    await vi.waitFor(() =>
+      expect(dependencies.getDiagnostics).toHaveBeenCalledTimes(1),
+    );
+    service.disposeOwner(42);
+    deferredDiagnostics.resolve(diagnostics);
+
+    await expect(creation).resolves.toEqual({
+      ok: false,
+      status: "canceled",
+    });
+    expect(dependencies.collectSnapshots).not.toHaveBeenCalled();
+  });
+
+  it("disposes every selection owned by a destroyed renderer", async () => {
+    const selection = await createValidSelection(11);
+
+    service.disposeOwner(11);
+
+    await expect(
+      service.applySelection(11, {
+        selectionId: selection.selectionId,
+        targetIds: ["config"],
+      }),
+    ).resolves.toMatchObject({
+      ok: false,
+      failureCode: "selection-not-found",
+    });
+  });
+
+  it("expires selections lazily without a timer", async () => {
+    const selection = await createValidSelection(11);
+    now += GAME_INSTALL_PATH_SELECTION_TTL_MS;
+
+    await expect(
+      service.applySelection(11, {
+        selectionId: selection.selectionId,
+        targetIds: ["config"],
+      }),
+    ).resolves.toEqual({
+      ok: false,
+      overall: "failed",
+      failureCode: "selection-expired",
+      results: [],
+      retryableTargetIds: [],
+    });
+    expect(dependencies.applyTarget).not.toHaveBeenCalled();
+  });
+
+  it("does not reissue an expired selection ID while its owner remains live", async () => {
+    dependencies.randomUUID = vi
+      .fn()
+      .mockReturnValueOnce("selection-x")
+      .mockReturnValueOnce("selection-x")
+      .mockReturnValueOnce("selection-y");
+    const expired = await createValidSelection(11);
+    now += GAME_INSTALL_PATH_SELECTION_TTL_MS;
+    await service.applySelection(11, {
+      selectionId: expired.selectionId,
+      targetIds: ["config"],
+    });
+
+    const replacement = await createValidSelection(
+      11,
+      "Kakao Games",
+      "POE2",
+      String.raw`F:\Games\After Expiry POE2`,
+    );
+
+    expect(replacement.selectionId).toBe("selection-y");
+    expect(dependencies.randomUUID).toHaveBeenCalledTimes(3);
+    expect(dependencies.applyTarget).not.toHaveBeenCalled();
+  });
+
+  it("marks read-failed targets disabled and never creates GGG compatibility", async () => {
+    diagnostics = createDiagnostics("GGG", "POE2", {
+      primaryState: "read-failed",
+      includeCompatibility: true,
+    });
+
+    const selection = await createValidSelection(7, "GGG");
+
+    expect(selection.targets).toEqual([
+      expect.objectContaining({
+        targetId: "registry-primary",
+        selectedByDefault: true,
+        disabled: true,
+        disabledReason: "target-read-failed",
+      }),
+      expect.objectContaining({
+        targetId: "config",
+        selectedByDefault: true,
+        disabled: false,
+      }),
+    ]);
+  });
+
+  it("keeps a persistently read-failed target disabled and non-retryable", async () => {
+    diagnostics = createDiagnostics("Kakao Games", "POE2", {
+      primaryState: "read-failed",
+    });
+    const selection = await createValidSelection(56);
+
+    const result = await service.applySelection(56, {
+      selectionId: selection.selectionId,
+      targetIds: ["registry-primary"],
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      overall: "failed",
+      results: [
+        {
+          targetId: "registry-primary",
+          status: "failed",
+          code: "target-read-failed",
+          retryable: false,
+        },
+      ],
+      retryableTargetIds: [],
+      selection: {
+        targets: expect.arrayContaining([
+          expect.objectContaining({
+            targetId: "registry-primary",
+            disabled: true,
+            disabledReason: "target-read-failed",
+          }),
+        ]),
+      },
+    });
+    expect(dependencies.applyTarget).not.toHaveBeenCalled();
+  });
+
+  it("reenables retry when a preflight read failure recovers in the final observation", async () => {
+    const readFailedDiagnostics = createDiagnostics("Kakao Games", "POE2", {
+      primaryState: "read-failed",
+    });
+    diagnostics = readFailedDiagnostics;
+    const selection = await createValidSelection(59);
+    const recoveredDiagnostics = createDiagnostics();
+    vi.mocked(dependencies.getDiagnostics)
+      .mockResolvedValueOnce(readFailedDiagnostics)
+      .mockResolvedValueOnce(recoveredDiagnostics);
+
+    const result = await service.applySelection(59, {
+      selectionId: selection.selectionId,
+      targetIds: ["registry-primary"],
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      overall: "failed",
+      results: [
+        {
+          targetId: "registry-primary",
+          status: "failed",
+          code: "target-read-failed",
+          retryable: true,
+        },
+      ],
+      retryableTargetIds: ["registry-primary"],
+      selection: {
+        targets: expect.arrayContaining([
+          expect.objectContaining({
+            targetId: "registry-primary",
+            currentPath: primaryPath,
+            disabled: false,
+          }),
+        ]),
+      },
+    });
+    expect(dependencies.applyTarget).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["empty", [], "invalid-target-ids"],
+    ["duplicate", ["config", "config"], "duplicate-target-ids"],
+    ["blank", [""], "invalid-target-ids"],
+    ["arbitrary", ["registry-admin"], "target-not-allowed"],
+  ] as const)(
+    "rejects %s target IDs before mutation",
+    async (_label, targetIds, code) => {
+      const selection = await createValidSelection();
+
+      const result = await service.applySelection(1, {
+        selectionId: selection.selectionId,
+        targetIds: [...targetIds] as GameInstallPathTargetId[],
+      });
+
+      expect(result).toMatchObject({
+        ok: false,
+        overall: "failed",
+        failureCode: code,
+        results: [],
+        retryableTargetIds: [],
+      });
+      expect(dependencies.applyTarget).not.toHaveBeenCalled();
+    },
+  );
+
+  it("rejects a completed target before mutating any other requested target", async () => {
+    const selection = await createValidSelection();
+    await service.applySelection(1, {
+      selectionId: selection.selectionId,
+      targetIds: ["config"],
+    });
+    expect(dependencies.applyTarget).toHaveBeenCalledTimes(1);
+
+    const result = await service.applySelection(1, {
+      selectionId: selection.selectionId,
+      targetIds: ["config", "registry-primary"],
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      failureCode: "target-completed",
+    });
+    expect(dependencies.applyTarget).toHaveBeenCalledTimes(1);
+  });
+
+  it("applies targets serially in primary, compatibility, config order", async () => {
+    const selection = await createValidSelection();
+
+    await service.applySelection(1, {
+      selectionId: selection.selectionId,
+      targetIds: ["config", "registry-compatibility", "registry-primary"],
+    });
+
+    expect(dependencies.applyTarget).toHaveBeenCalledTimes(3);
+    expect(
+      vi
+        .mocked(dependencies.applyTarget)
+        .mock.calls.map((call) => call[2].targetId),
+    ).toEqual(["registry-primary", "registry-compatibility", "config"]);
+  });
+
+  it("rejects a same-selection replay while the first target mutation is in flight", async () => {
+    const selection = await createValidSelection(57);
+    const deferredApply = createDeferred<GameInstallPathTargetApplyResult>();
+    vi.mocked(dependencies.applyTarget).mockReturnValueOnce(
+      deferredApply.promise,
+    );
+
+    const firstApply = service.applySelection(57, {
+      selectionId: selection.selectionId,
+      targetIds: ["config"],
+    });
+    await vi.waitFor(() =>
+      expect(dependencies.applyTarget).toHaveBeenCalledTimes(1),
+    );
+
+    const replayResult = await service.applySelection(57, {
+      selectionId: selection.selectionId,
+      targetIds: ["config"],
+    });
+    deferredApply.resolve({
+      targetId: "config",
+      status: "applied",
+      path: selectedPath,
+    });
+    const firstResult = await firstApply;
+
+    expect(replayResult).toEqual({
+      ok: false,
+      overall: "failed",
+      failureCode: "selection-busy",
+      results: [],
+      retryableTargetIds: [],
+    });
+    expect(firstResult).toMatchObject({ ok: true, overall: "success" });
+    expect(dependencies.applyTarget).toHaveBeenCalledTimes(1);
+  });
+
+  it("holds the same-selection apply lock through the final refresh", async () => {
+    const selection = await createValidSelection(58);
+    const deferredRefresh = createDeferred<GameInstallPathDiagnostics>();
+    vi.mocked(dependencies.getDiagnostics)
+      .mockResolvedValueOnce(diagnostics)
+      .mockReturnValueOnce(deferredRefresh.promise);
+
+    const firstApply = service.applySelection(58, {
+      selectionId: selection.selectionId,
+      targetIds: ["config"],
+    });
+    await vi.waitFor(() =>
+      expect(dependencies.getDiagnostics).toHaveBeenCalledTimes(3),
+    );
+
+    const replayResult = await service.applySelection(58, {
+      selectionId: selection.selectionId,
+      targetIds: ["config"],
+    });
+    deferredRefresh.resolve(diagnostics);
+    await firstApply;
+
+    expect(replayResult).toEqual({
+      ok: false,
+      overall: "failed",
+      failureCode: "selection-busy",
+      results: [],
+      retryableTargetIds: [],
+    });
+    expect(dependencies.applyTarget).toHaveBeenCalledTimes(1);
+  });
+
+  it("rechecks liveness after deferred apply path verification", async () => {
+    const selection = await createValidSelection(51);
+    const deferredStat = createDeferred<typeof fileStats>();
+    vi.mocked(dependencies.fsStat).mockReturnValueOnce(deferredStat.promise);
+
+    const applying = service.applySelection(51, {
+      selectionId: selection.selectionId,
+      targetIds: ["config"],
+    });
+    service.disposeOwner(51);
+    deferredStat.resolve(fileStats);
+
+    await expect(applying).resolves.toMatchObject({
+      ok: false,
+      failureCode: "selection-invalidated",
+    });
+    expect(dependencies.getDiagnostics).toHaveBeenCalledTimes(1);
+    expect(dependencies.applyTarget).not.toHaveBeenCalled();
+  });
+
+  it("classifies a deferred fresh diagnostics preflight before any mutation", async () => {
+    const selection = await createValidSelection(52);
+    const deferredDiagnostics = createDeferred<GameInstallPathDiagnostics>();
+    vi.mocked(dependencies.getDiagnostics).mockReturnValueOnce(
+      deferredDiagnostics.promise,
+    );
+
+    const applying = service.applySelection(52, {
+      selectionId: selection.selectionId,
+      targetIds: ["registry-primary", "config"],
+    });
+    await vi.waitFor(() =>
+      expect(dependencies.getDiagnostics).toHaveBeenCalledTimes(2),
+    );
+    service.disposeOwner(52);
+    deferredDiagnostics.resolve(diagnostics);
+
+    await expect(applying).resolves.toMatchObject({
+      ok: false,
+      failureCode: "selection-invalidated",
+    });
+    expect(dependencies.applyTarget).not.toHaveBeenCalled();
+  });
+
+  it("stops later target mutations when a replacement invalidates an in-flight apply", async () => {
+    const oldSelection = await createValidSelection(53);
+    const deferredApply = createDeferred<GameInstallPathTargetApplyResult>();
+    vi.mocked(dependencies.applyTarget).mockReturnValueOnce(
+      deferredApply.promise,
+    );
+
+    const applying = service.applySelection(53, {
+      selectionId: oldSelection.selectionId,
+      targetIds: ["registry-primary", "config"],
+    });
+    await vi.waitFor(() =>
+      expect(dependencies.applyTarget).toHaveBeenCalledTimes(1),
+    );
+    await createValidSelection(
+      53,
+      "Kakao Games",
+      "POE2",
+      String.raw`F:\Games\Replacement POE2`,
+    );
+    deferredApply.resolve({
+      targetId: "registry-primary",
+      status: "applied",
+      path: selectedPath,
+    });
+
+    const result = await applying;
+    expect(dependencies.applyTarget).toHaveBeenCalledTimes(1);
+    expect(result).toMatchObject({
+      ok: true,
+      overall: "partial",
+      failureCode: "selection-invalidated",
+      results: [
+        expect.objectContaining({
+          targetId: "registry-primary",
+          status: "applied",
+        }),
+        expect.objectContaining({
+          targetId: "config",
+          status: "failed",
+          code: "selection-invalidated",
+        }),
+      ],
+    });
+  });
+
+  it("preflights every requested fresh snapshot before mutating valid targets", async () => {
+    const selection = await createValidSelection(54);
+    diagnostics = createDiagnostics("Kakao Games", "POE2", {
+      primaryPath: String.raw`C:\Games\Changed Primary`,
+    });
+
+    const result = await service.applySelection(54, {
+      selectionId: selection.selectionId,
+      targetIds: ["registry-primary", "config"],
+    });
+
+    expect(dependencies.applyTarget).toHaveBeenCalledTimes(1);
+    expect(dependencies.applyTarget).toHaveBeenCalledWith(
+      "Kakao Games",
+      "POE2",
+      { targetId: "config", currentPath: configPath },
+      selectedPath,
+    );
+    expect(result.results).toEqual([
+      {
+        targetId: "registry-primary",
+        status: "failed",
+        code: "target-changed",
+        retryable: true,
+      },
+      {
+        targetId: "config",
+        status: "applied",
+        path: selectedPath,
+      },
+    ]);
+  });
+
+  it("derives mutation authority and response display from coherent B then C diagnostics", async () => {
+    const stateB = createDiagnostics("Kakao Games", "POE2", {
+      compatibilityPath: String.raw`D:\Games\State B`,
+    });
+    diagnostics = stateB;
+    const selection = await createValidSelection(55);
+    const stateC = createDiagnostics("Kakao Games", "POE2", {
+      compatibilityPath: String.raw`D:\Games\State C`,
+    });
+    vi.mocked(dependencies.getDiagnostics)
+      .mockResolvedValueOnce(stateB)
+      .mockResolvedValueOnce(stateC);
+    vi.mocked(dependencies.applyTarget).mockResolvedValueOnce({
+      targetId: "registry-compatibility",
+      status: "failed",
+      code: "target-changed",
+      retryable: true,
+    });
+
+    const result = await service.applySelection(55, {
+      selectionId: selection.selectionId,
+      targetIds: ["registry-compatibility"],
+    });
+
+    expect(dependencies.getDiagnostics).toHaveBeenCalledTimes(3);
+    expect(dependencies.applyTarget).toHaveBeenCalledWith(
+      "Kakao Games",
+      "POE2",
+      {
+        targetId: "registry-compatibility",
+        currentPath: String.raw`D:\Games\State B`,
+        registryState: "found",
+      },
+      selectedPath,
+    );
+    expect(result).toMatchObject({
+      diagnostics: stateC,
+      selection: {
+        targets: expect.arrayContaining([
+          expect.objectContaining({
+            targetId: "registry-compatibility",
+            currentPath: String.raw`D:\Games\State C`,
+          }),
+        ]),
+      },
+    });
+  });
+
+  it("preserves partial success without rollback and exposes retryable failures only", async () => {
+    vi.mocked(dependencies.applyTarget).mockImplementation(
+      async (_serviceId, _gameId, snapshot, installPath) => {
+        if (snapshot.targetId === "registry-primary") {
+          return {
+            targetId: snapshot.targetId,
+            status: "applied",
+            path: installPath,
+          };
+        }
+        if (snapshot.targetId === "registry-compatibility") {
+          return {
+            targetId: snapshot.targetId,
+            status: "failed",
+            code: "target-changed",
+            retryable: true,
+          };
+        }
+        return {
+          targetId: snapshot.targetId,
+          status: "unchanged",
+          path: installPath,
+        };
+      },
+    );
+    const selection = await createValidSelection();
+
+    const result = await service.applySelection(1, {
+      selectionId: selection.selectionId,
+      targetIds: ["config", "registry-compatibility", "registry-primary"],
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      overall: "partial",
+      retryableTargetIds: ["registry-compatibility"],
+    });
+    expect(
+      result.results.map(({ targetId, status }) => ({ targetId, status })),
+    ).toEqual([
+      { targetId: "registry-primary", status: "applied" },
+      { targetId: "registry-compatibility", status: "failed" },
+      { targetId: "config", status: "unchanged" },
+    ]);
+    expect(dependencies.applyTarget).toHaveBeenCalledTimes(3);
+    if ("selection" in result) {
+      expect(
+        result.selection.targets
+          .filter((target) => target.completed)
+          .map((target) => target.targetId),
+      ).toEqual(["registry-primary", "config"]);
+    }
+  });
+
+  it("refreshes only failed expected snapshots before an explicit retry", async () => {
+    const selection = await createValidSelection();
+    const preflightDiagnostics = diagnostics;
+    const refreshedCompatibilityPath = String.raw`D:\Games\Changed Compatibility`;
+    diagnostics = createDiagnostics("Kakao Games", "POE2", {
+      compatibilityPath: refreshedCompatibilityPath,
+    });
+    vi.mocked(dependencies.getDiagnostics)
+      .mockResolvedValueOnce(preflightDiagnostics)
+      .mockResolvedValueOnce(diagnostics);
+    vi.mocked(dependencies.applyTarget)
+      .mockResolvedValueOnce({
+        targetId: "registry-compatibility",
+        status: "failed",
+        code: "target-changed",
+        retryable: true,
+      })
+      .mockResolvedValueOnce({
+        targetId: "registry-compatibility",
+        status: "applied",
+        path: selectedPath,
+      });
+
+    const firstResult = await service.applySelection(1, {
+      selectionId: selection.selectionId,
+      targetIds: ["registry-compatibility"],
+    });
+    expect(firstResult).toMatchObject({
+      ok: false,
+      overall: "failed",
+      retryableTargetIds: ["registry-compatibility"],
+    });
+    if ("selection" in firstResult) {
+      expect(
+        firstResult.selection.targets.find(
+          (target) => target.targetId === "registry-compatibility",
+        )?.currentPath,
+      ).toBe(refreshedCompatibilityPath);
+    }
+
+    await service.applySelection(1, {
+      selectionId: selection.selectionId,
+      targetIds: ["registry-compatibility"],
+    });
+
+    expect(dependencies.applyTarget).toHaveBeenNthCalledWith(
+      2,
+      "Kakao Games",
+      "POE2",
+      {
+        targetId: "registry-compatibility",
+        currentPath: refreshedCompatibilityPath,
+        registryState: "found",
+      },
+      selectedPath,
+    );
+  });
+
+  it("excludes non-retryable failures from retryable target IDs", async () => {
+    vi.mocked(dependencies.applyTarget).mockImplementation(
+      async (_serviceId, _gameId, snapshot) => ({
+        targetId: snapshot.targetId,
+        status: "failed",
+        code:
+          snapshot.targetId === "registry-primary"
+            ? "target-changed"
+            : "invalid-snapshot",
+        retryable: snapshot.targetId === "registry-primary",
+      }),
+    );
+    const selection = await createValidSelection();
+
+    const result = await service.applySelection(1, {
+      selectionId: selection.selectionId,
+      targetIds: ["registry-primary", "config"],
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      overall: "failed",
+      retryableTargetIds: ["registry-primary"],
+    });
+  });
+
+  it("binds apply calls to the stored selection context and normalized path", async () => {
+    const selection = await createValidSelection();
+    const tamperedRequest = {
+      selectionId: selection.selectionId,
+      targetIds: ["config"],
+      serviceId: "GGG",
+      gameId: "POE1",
+      path: String.raw`Z:\Attacker Controlled`,
+    } as const;
+
+    await service.applySelection(1, tamperedRequest);
+
+    expect(dependencies.applyTarget).toHaveBeenCalledWith(
+      "Kakao Games",
+      "POE2",
+      { targetId: "config", currentPath: configPath },
+      selectedPath,
+    );
+  });
+
+  it("freshly verifies the stored selected path before applying the batch", async () => {
+    const selection = await createValidSelection();
+    files.clear();
+
+    const result = await service.applySelection(1, {
+      selectionId: selection.selectionId,
+      targetIds: ["registry-primary", "config"],
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      overall: "failed",
+      retryableTargetIds: [],
+      results: [
+        expect.objectContaining({
+          targetId: "registry-primary",
+          status: "failed",
+          code: "install-path-invalid",
+        }),
+        expect.objectContaining({
+          targetId: "config",
+          status: "failed",
+          code: "install-path-invalid",
+        }),
+      ],
+    });
+    expect(dependencies.applyTarget).not.toHaveBeenCalled();
+  });
+});

--- a/src/main/tests/GameInstallStatusReconciler.test.ts
+++ b/src/main/tests/GameInstallStatusReconciler.test.ts
@@ -8,19 +8,28 @@ import {
   type ConfigChangeEvent,
 } from "../events/types";
 import {
+  GAME_INSTALL_STATUS_REFRESH_TTL_MS,
   getGameInstallStatusContextsForConfigChange,
+  reconcileAllGameInstallStatuses,
+  reconcileCurrentGameInstallStatusIfStale,
   reconcileGameInstallStatus,
+  resetGameInstallStatusReconcilerForTests,
+  runManualGameInstallPathAction,
+  setGameInstallStatusClockForTests,
 } from "../game/GameInstallStatusReconciler";
 import {
   resetGameStatusCacheForTests,
   updateGameStatusCache,
 } from "../state/GameStatusStore";
-import { getGameInstallationStatus } from "../utils/registry";
+import { getGameInstallPathHealth } from "../utils/registry";
+
+import type { GameInstallPathHealth } from "../../shared/types";
 
 const mocks = vi.hoisted(() => ({
   eventBusEmit: vi.fn(),
-  getGameInstallationStatus: vi.fn(),
+  getGameInstallPathHealth: vi.fn(),
   loggerLog: vi.fn(),
+  loggerWarn: vi.fn(),
 }));
 
 vi.mock("../events/EventBus", () => ({
@@ -32,13 +41,13 @@ vi.mock("../events/EventBus", () => ({
 vi.mock("../utils/logger", () => ({
   logger: {
     log: mocks.loggerLog,
-    warn: vi.fn(),
+    warn: mocks.loggerWarn,
     error: vi.fn(),
   },
 }));
 
 vi.mock("../utils/registry", () => ({
-  getGameInstallationStatus: mocks.getGameInstallationStatus,
+  getGameInstallPathHealth: mocks.getGameInstallPathHealth,
 }));
 
 const createContext = (processRunning = false) =>
@@ -56,10 +65,16 @@ describe("GameInstallStatusReconciler", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     resetGameStatusCacheForTests();
+    resetGameInstallStatusReconcilerForTests();
+    vi.mocked(getGameInstallPathHealth).mockImplementation(
+      async (_serviceId, _gameId, checkedAt) => ({
+        installationStatus: "installed",
+        checkedAt: checkedAt ?? Date.now(),
+      }),
+    );
   });
 
   it("emits idle when the install path is valid", async () => {
-    vi.mocked(getGameInstallationStatus).mockResolvedValue("installed");
     const context = createContext();
 
     await reconcileGameInstallStatus(context, "Kakao Games", "POE2");
@@ -67,16 +82,22 @@ describe("GameInstallStatusReconciler", () => {
     expect(eventBus.emit).toHaveBeenCalledWith(
       EventType.GAME_STATUS_CHANGE,
       context,
-      {
+      expect.objectContaining({
         gameId: "POE2",
         serviceId: "Kakao Games",
         status: "idle",
-      },
+        installPathHealth: expect.objectContaining({
+          installationStatus: "installed",
+        }),
+      }),
     );
   });
 
   it("emits install_check_blocked when install status cannot be verified", async () => {
-    vi.mocked(getGameInstallationStatus).mockResolvedValue("unknown");
+    vi.mocked(getGameInstallPathHealth).mockResolvedValue({
+      installationStatus: "unknown",
+      checkedAt: Date.now(),
+    });
     const context = createContext();
 
     await reconcileGameInstallStatus(context, "Kakao Games", "POE2");
@@ -84,43 +105,463 @@ describe("GameInstallStatusReconciler", () => {
     expect(eventBus.emit).toHaveBeenCalledWith(
       EventType.GAME_STATUS_CHANGE,
       context,
-      {
+      expect.objectContaining({
         gameId: "POE2",
         serviceId: "Kakao Games",
         status: "install_check_blocked",
         errorCode: "INSTALL_CHECK_UNKNOWN",
-      },
+      }),
     );
   });
 
-  it("does not downgrade an active runtime status", async () => {
+  it("refreshes install-path health without downgrading a running status", async () => {
     updateGameStatusCache({
       gameId: "POE2",
       serviceId: "Kakao Games",
       status: "running",
     });
+    vi.mocked(getGameInstallPathHealth).mockResolvedValue({
+      installationStatus: "installed",
+      checkedAt: 123,
+      registryAdvisory: { state: "absent" },
+    });
+    const context = createContext();
 
-    await reconcileGameInstallStatus(createContext(), "Kakao Games", "POE2");
+    await reconcileGameInstallStatus(context, "Kakao Games", "POE2");
 
-    expect(getGameInstallationStatus).not.toHaveBeenCalled();
-    expect(eventBus.emit).not.toHaveBeenCalled();
+    expect(getGameInstallPathHealth).toHaveBeenCalledOnce();
+    expect(eventBus.emit).toHaveBeenCalledWith(
+      EventType.GAME_STATUS_CHANGE,
+      context,
+      expect.objectContaining({
+        status: "running",
+        installPathHealth: expect.objectContaining({
+          registryAdvisory: { state: "absent" },
+        }),
+      }),
+    );
   });
 
-  it("keeps a detected running process stronger than install status", async () => {
+  it("refreshes health while keeping a detected running process stronger than install status", async () => {
     const context = createContext(true);
 
     await reconcileGameInstallStatus(context, "Kakao Games", "POE2");
 
-    expect(getGameInstallationStatus).not.toHaveBeenCalled();
+    expect(getGameInstallPathHealth).toHaveBeenCalledOnce();
     expect(eventBus.emit).toHaveBeenCalledWith(
       EventType.GAME_STATUS_CHANGE,
       context,
-      {
+      expect.objectContaining({
         gameId: "POE2",
         serviceId: "Kakao Games",
         status: "running",
-      },
+        installPathHealth: expect.objectContaining({
+          installationStatus: "installed",
+        }),
+      }),
     );
+  });
+
+  it("refreshes health and TTL while preserving a preparing status", async () => {
+    let currentTime = 2_000;
+    setGameInstallStatusClockForTests(() => currentTime);
+    updateGameStatusCache({
+      gameId: "POE2",
+      serviceId: "Kakao Games",
+      status: "preparing",
+    });
+    vi.mocked(getGameInstallPathHealth).mockResolvedValue({
+      installationStatus: "installed",
+      checkedAt: currentTime,
+      registryAdvisory: { state: "unknown" },
+    });
+    const context = createContext();
+
+    await reconcileGameInstallStatus(context, "Kakao Games", "POE2");
+    currentTime += 1;
+    await reconcileCurrentGameInstallStatusIfStale(context, {
+      reason: "window-focus",
+    });
+
+    expect(getGameInstallPathHealth).toHaveBeenCalledOnce();
+    expect(eventBus.emit).toHaveBeenCalledWith(
+      EventType.GAME_STATUS_CHANGE,
+      context,
+      expect.objectContaining({
+        status: "preparing",
+        installPathHealth: expect.objectContaining({
+          registryAdvisory: { state: "unknown" },
+        }),
+      }),
+    );
+  });
+
+  it("recovers stale uninstalled status after confirming the same config path", async () => {
+    updateGameStatusCache({
+      gameId: "POE2",
+      serviceId: "Kakao Games",
+      status: "uninstalled",
+    });
+    const context = createContext();
+    const action = vi.fn().mockResolvedValue({ ok: true as const });
+
+    await expect(
+      runManualGameInstallPathAction(
+        context,
+        "Kakao Games",
+        "POE2",
+        "manual-config-path-set",
+        action,
+      ),
+    ).resolves.toEqual({ ok: true });
+
+    expect(action).toHaveBeenCalledOnce();
+    expect(eventBus.emit).toHaveBeenCalledWith(
+      EventType.GAME_STATUS_CHANGE,
+      context,
+      expect.objectContaining({
+        gameId: "POE2",
+        serviceId: "Kakao Games",
+        status: "idle",
+      }),
+    );
+  });
+
+  it("reconciles installation status after a successful registry sync", async () => {
+    const context = createContext();
+
+    await runManualGameInstallPathAction(
+      context,
+      "Kakao Games",
+      "POE2",
+      "manual-path-conflict-sync-registry",
+      async () => ({ ok: true as const, action: "sync-registry" as const }),
+    );
+
+    expect(getGameInstallPathHealth).toHaveBeenCalledWith(
+      "Kakao Games",
+      "POE2",
+      expect.any(Number),
+    );
+    expect(eventBus.emit).toHaveBeenCalledWith(
+      EventType.GAME_STATUS_CHANGE,
+      context,
+      expect.objectContaining({ status: "idle" }),
+    );
+  });
+
+  it("clears advisory and refreshes TTL after a successful manual action while running", async () => {
+    let currentTime = 20_000;
+    setGameInstallStatusClockForTests(() => currentTime);
+    updateGameStatusCache({
+      gameId: "POE2",
+      serviceId: "Kakao Games",
+      status: "running",
+      installPathHealth: {
+        installationStatus: "installed",
+        checkedAt: 10_000,
+        registryAdvisory: { state: "invalid" },
+      },
+    });
+    vi.mocked(getGameInstallPathHealth).mockImplementation(
+      async (_serviceId, _gameId, checkedAt) => ({
+        installationStatus: "installed",
+        checkedAt: checkedAt ?? currentTime,
+      }),
+    );
+    const context = createContext();
+
+    await runManualGameInstallPathAction(
+      context,
+      "Kakao Games",
+      "POE2",
+      "manual-path-conflict-sync-registry",
+      async () => ({ ok: true as const }),
+    );
+    currentTime += 1;
+    await reconcileCurrentGameInstallStatusIfStale(context, {
+      reason: "window-focus",
+    });
+
+    expect(getGameInstallPathHealth).toHaveBeenCalledOnce();
+    expect(eventBus.emit).toHaveBeenCalledWith(
+      EventType.GAME_STATUS_CHANGE,
+      context,
+      expect.objectContaining({
+        status: "running",
+        installPathHealth: {
+          installationStatus: "installed",
+          checkedAt: 20_000,
+        },
+      }),
+    );
+  });
+
+  it("keeps a successful manual action result when reconciliation fails", async () => {
+    vi.mocked(getGameInstallPathHealth).mockRejectedValue(
+      new Error("install check failed"),
+    );
+
+    await expect(
+      runManualGameInstallPathAction(
+        createContext(),
+        "Kakao Games",
+        "POE2",
+        "manual-config-path-set",
+        async () => ({ ok: true as const, path: "C:\\Games\\POE2" }),
+      ),
+    ).resolves.toEqual({ ok: true, path: "C:\\Games\\POE2" });
+    expect(mocks.loggerWarn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "Manual path action succeeded but reconciliation failed",
+      ),
+    );
+  });
+
+  it("does not reconcile after a failed manual action", async () => {
+    await expect(
+      runManualGameInstallPathAction(
+        createContext(),
+        "Kakao Games",
+        "POE2",
+        "manual-config-path-set",
+        async () => ({ ok: false as const, error: "save failed" }),
+      ),
+    ).resolves.toEqual({ ok: false, error: "save failed" });
+
+    expect(getGameInstallPathHealth).not.toHaveBeenCalled();
+    expect(eventBus.emit).not.toHaveBeenCalled();
+  });
+
+  it("discards an older install check that finishes after a newer one", async () => {
+    let resolveOlderCheck:
+      ((health: GameInstallPathHealth) => void) | undefined;
+    vi.mocked(getGameInstallPathHealth)
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveOlderCheck = resolve;
+          }),
+      )
+      .mockResolvedValueOnce({
+        installationStatus: "installed",
+        checkedAt: Date.now(),
+      });
+    const context = createContext();
+
+    const older = reconcileGameInstallStatus(context, "Kakao Games", "POE2", {
+      reason: "older",
+    });
+    await vi.waitFor(() => {
+      expect(getGameInstallPathHealth).toHaveBeenCalledTimes(1);
+    });
+
+    await reconcileGameInstallStatus(context, "Kakao Games", "POE2", {
+      reason: "newer",
+    });
+    resolveOlderCheck?.({
+      installationStatus: "uninstalled",
+      checkedAt: Date.now(),
+    });
+    await older;
+
+    expect(eventBus.emit).toHaveBeenCalledTimes(1);
+    expect(eventBus.emit).toHaveBeenCalledWith(
+      EventType.GAME_STATUS_CHANGE,
+      context,
+      expect.objectContaining({ status: "idle" }),
+    );
+    expect(mocks.loggerLog).toHaveBeenCalledWith(
+      expect.stringContaining("Discarding stale install check"),
+    );
+  });
+
+  it("forces startup reconciliation for every supported context", async () => {
+    const context = createContext();
+
+    await reconcileAllGameInstallStatuses(context, {
+      reason: "initial-status-check",
+    });
+
+    expect(getGameInstallPathHealth).toHaveBeenCalledTimes(4);
+    expect(getGameInstallPathHealth).toHaveBeenNthCalledWith(
+      1,
+      "Kakao Games",
+      "POE1",
+      expect.any(Number),
+    );
+    expect(getGameInstallPathHealth).toHaveBeenNthCalledWith(
+      4,
+      "GGG",
+      "POE2",
+      expect.any(Number),
+    );
+  });
+
+  it("still completes startup health checks when a game process is detected", async () => {
+    const context = createContext(true);
+
+    await reconcileAllGameInstallStatuses(context, {
+      reason: "initial-status-check",
+    });
+
+    expect(getGameInstallPathHealth).toHaveBeenCalledTimes(4);
+    expect(eventBus.emit).toHaveBeenCalledTimes(4);
+    expect(eventBus.emit).toHaveBeenLastCalledWith(
+      EventType.GAME_STATUS_CHANGE,
+      context,
+      expect.objectContaining({
+        gameId: "POE2",
+        serviceId: "GGG",
+        status: "running",
+        installPathHealth: expect.objectContaining({
+          installationStatus: "installed",
+        }),
+      }),
+    );
+  });
+
+  it("skips current-context show or focus refresh below the 30-minute TTL", async () => {
+    let currentTime = 1_000;
+    setGameInstallStatusClockForTests(() => currentTime);
+    const context = createContext();
+
+    await reconcileGameInstallStatus(context, "Kakao Games", "POE2", {
+      reason: "initial-status-check",
+    });
+    currentTime += 30 * 60 * 1000 - 1;
+
+    await expect(
+      reconcileCurrentGameInstallStatusIfStale(context, {
+        reason: "window-focus",
+      }),
+    ).resolves.toBe(false);
+    expect(getGameInstallPathHealth).toHaveBeenCalledTimes(1);
+  });
+
+  it("refreshes only the selected context once its TTL expires", async () => {
+    let currentTime = 1_000;
+    setGameInstallStatusClockForTests(() => currentTime);
+    const context = createContext();
+
+    await reconcileAllGameInstallStatuses(context, {
+      reason: "initial-status-check",
+    });
+    currentTime += 30 * 60 * 1000;
+
+    await expect(
+      reconcileCurrentGameInstallStatusIfStale(context, {
+        reason: "window-show",
+      }),
+    ).resolves.toBe(true);
+    expect(getGameInstallPathHealth).toHaveBeenCalledTimes(5);
+    expect(getGameInstallPathHealth).toHaveBeenLastCalledWith(
+      "Kakao Games",
+      "POE2",
+      currentTime,
+    );
+  });
+
+  it("coalesces overlapping show and focus refreshes for the current context", async () => {
+    let resolveHealth!: (health: GameInstallPathHealth) => void;
+    vi.mocked(getGameInstallPathHealth).mockImplementationOnce(
+      (_serviceId, _gameId, checkedAt) =>
+        new Promise((resolve) => {
+          resolveHealth = resolve;
+          expect(checkedAt).toBe(10_000);
+        }),
+    );
+    setGameInstallStatusClockForTests(() => 10_000);
+    const context = createContext();
+
+    const show = reconcileCurrentGameInstallStatusIfStale(context, {
+      reason: "window-show",
+    });
+    const focus = reconcileCurrentGameInstallStatusIfStale(context, {
+      reason: "window-focus",
+    });
+    await vi.waitFor(() => {
+      expect(getGameInstallPathHealth).toHaveBeenCalledTimes(1);
+    });
+
+    resolveHealth({ installationStatus: "installed", checkedAt: 10_000 });
+    await expect(show).resolves.toBe(true);
+    await expect(focus).resolves.toBe(false);
+    expect(getGameInstallPathHealth).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses a successful manual force-refresh as the current TTL baseline", async () => {
+    let currentTime = 5_000;
+    setGameInstallStatusClockForTests(() => currentTime);
+    const context = createContext();
+
+    await runManualGameInstallPathAction(
+      context,
+      "Kakao Games",
+      "POE2",
+      "manual-config-path-set",
+      async () => ({ ok: true as const }),
+    );
+    currentTime += 1;
+
+    await reconcileCurrentGameInstallStatusIfStale(context, {
+      reason: "window-focus",
+    });
+    expect(getGameInstallPathHealth).toHaveBeenCalledTimes(1);
+  });
+
+  it("lets a pending manual action own consecutive show and focus races", async () => {
+    let currentTime = 10_000;
+    let resolveAction!: (result: { ok: true }) => void;
+    setGameInstallStatusClockForTests(() => currentTime);
+    const context = createContext();
+    const action = vi.fn(
+      () =>
+        new Promise<{ ok: true }>((resolve) => {
+          resolveAction = resolve;
+        }),
+    );
+
+    const manual = runManualGameInstallPathAction(
+      context,
+      "Kakao Games",
+      "POE2",
+      "manual-config-path-set",
+      action,
+    );
+    await vi.waitFor(() => expect(action).toHaveBeenCalledOnce());
+
+    await expect(
+      reconcileCurrentGameInstallStatusIfStale(context, {
+        reason: "window-show",
+      }),
+    ).resolves.toBe(false);
+    await expect(
+      reconcileCurrentGameInstallStatusIfStale(context, {
+        reason: "window-focus",
+      }),
+    ).resolves.toBe(false);
+    expect(getGameInstallPathHealth).not.toHaveBeenCalled();
+
+    resolveAction({ ok: true });
+    await manual;
+    expect(getGameInstallPathHealth).toHaveBeenCalledOnce();
+
+    currentTime += GAME_INSTALL_STATUS_REFRESH_TTL_MS - 1;
+    await expect(
+      reconcileCurrentGameInstallStatusIfStale(context, {
+        reason: "window-show",
+      }),
+    ).resolves.toBe(false);
+    expect(getGameInstallPathHealth).toHaveBeenCalledOnce();
+
+    currentTime += 1;
+    await expect(
+      reconcileCurrentGameInstallStatusIfStale(context, {
+        reason: "window-focus",
+      }),
+    ).resolves.toBe(true);
+    expect(getGameInstallPathHealth).toHaveBeenCalledTimes(2);
   });
 
   it("targets only service/game pairs whose saved install path changed", () => {

--- a/src/main/tests/GamePathDiagnosticQa.test.ts
+++ b/src/main/tests/GamePathDiagnosticQa.test.ts
@@ -1,0 +1,156 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  buildGamePathDiagnosticQaRendererUrl,
+  isAllowedGamePathDiagnosticQaRendererUrl,
+  resolveGamePathDiagnosticQaLaunch,
+} from "../qa/GamePathDiagnosticQa";
+
+const runId = "qa-ms64-12345678";
+const userDataPath = String.raw`C:\Temp\poe2-unofficial-launcher-codex-qa\qa-ms64-12345678`;
+const activeInput = {
+  isPackaged: false,
+  devServerUrl: "http://localhost:54321/",
+  startHidden: "true",
+  runId,
+  fixtureMode: "diagnostic",
+  userDataPath,
+} as const;
+
+describe("GamePathDiagnostic QA launch boundary", () => {
+  it("stays inactive when no fixture mode was requested", () => {
+    expect(
+      resolveGamePathDiagnosticQaLaunch({
+        ...activeInput,
+        fixtureMode: undefined,
+      }),
+    ).toEqual({ kind: "inactive" });
+  });
+
+  it("activates only for an owned hidden development run with an allowlisted fixture", () => {
+    expect(resolveGamePathDiagnosticQaLaunch(activeInput)).toEqual({
+      kind: "active",
+      request: {
+        runId,
+        fixtureMode: "diagnostic",
+        userDataPath,
+        devServerUrl: "http://localhost:54321/",
+      },
+    });
+  });
+
+  it.each([
+    ["packaged", { isPackaged: true }],
+    ["no dev server", { devServerUrl: undefined }],
+    ["visible", { startHidden: "false" }],
+    ["missing run id", { runId: undefined }],
+    ["invalid mode", { fixtureMode: "../../arbitrary.html" }],
+    ["missing profile", { userDataPath: undefined }],
+    [
+      "profile outside owned QA root",
+      { userDataPath: String.raw`C:\Users\qa-ms64-12345678` },
+    ],
+    [
+      "profile for another run",
+      {
+        userDataPath: String.raw`C:\Temp\poe2-unofficial-launcher-codex-qa\qa-ms64-foreign`,
+      },
+    ],
+  ])(
+    "keeps normal startup when %s makes fixture activation unsafe",
+    (_label, override) => {
+      const decision = resolveGamePathDiagnosticQaLaunch({
+        ...activeInput,
+        ...override,
+      });
+
+      expect(decision).toEqual({ kind: "inactive" });
+    },
+  );
+
+  it("builds only owned allowlisted renderer fixture URLs", () => {
+    const decision = resolveGamePathDiagnosticQaLaunch(activeInput);
+    if (decision.kind !== "active") throw new Error("expected active QA");
+
+    const url = buildGamePathDiagnosticQaRendererUrl(decision.request);
+
+    expect(url).toBe(
+      "http://localhost:54321/?codexQaFixture=diagnostic&codexQaRun=qa-ms64-12345678",
+    );
+    expect(
+      isAllowedGamePathDiagnosticQaRendererUrl(
+        url,
+        decision.request.devServerUrl,
+        runId,
+      ),
+    ).toBe(true);
+    expect(
+      isAllowedGamePathDiagnosticQaRendererUrl(
+        `${url}&script=alert(1)`,
+        decision.request.devServerUrl,
+        runId,
+      ),
+    ).toBe(false);
+    expect(
+      isAllowedGamePathDiagnosticQaRendererUrl(
+        url.replace("diagnostic", "../../arbitrary.html"),
+        decision.request.devServerUrl,
+        runId,
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("main bootstrap source contract", () => {
+  it("returns through the dedicated QA bootstrap before normal user-state paths", () => {
+    const source = fs.readFileSync(path.resolve("src/main/main.ts"), "utf8");
+    const ready = source.indexOf("app.whenReady().then(async () => {");
+    const qaDecision = source.indexOf(
+      "process.env.ELECTRON_QA_GAME_PATH_FIXTURE",
+      ready,
+    );
+    const qaWindow = source.indexOf(
+      "createGamePathDiagnosticQaWindow",
+      qaDecision,
+    );
+    const normalDiagnosticStore = source.indexOf(
+      "diagnosticLogStore.initialize",
+      ready,
+    );
+    const normalUac = source.indexOf(
+      'getEffectiveConfig("skipDaumGameStarterUac")',
+      ready,
+    );
+    const normalInstallSync = source.indexOf("syncInstallLocation()", ready);
+    const normalWindow = source.indexOf("await createWindow()", ready);
+
+    expect(ready).toBeGreaterThan(-1);
+    expect(qaDecision).toBeGreaterThan(ready);
+    expect(qaWindow).toBeGreaterThan(qaDecision);
+    expect(qaWindow).toBeLessThan(normalDiagnosticStore);
+    expect(source.slice(qaDecision, normalDiagnosticStore)).toMatch(
+      /createGamePathDiagnosticQaWindow[\s\S]*return;/,
+    );
+    expect(normalDiagnosticStore).toBeLessThan(normalUac);
+    expect(normalUac).toBeLessThan(normalInstallSync);
+    expect(normalInstallSync).toBeLessThan(normalWindow);
+  });
+
+  it("keeps registry and normal service calls out of the dedicated QA window function", () => {
+    const source = fs.readFileSync(path.resolve("src/main/main.ts"), "utf8");
+    const start = source.indexOf(
+      "async function createGamePathDiagnosticQaWindow",
+    );
+    const end = source.indexOf("async function createWindow", start);
+    const qaWindowSource = source.slice(start, end);
+
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+    expect(qaWindowSource).not.toMatch(
+      /syncInstallLocation|syncAutoLaunch|reconcileAllGameInstallStatuses|initializeCoreServices|SimpleUacBypass|getGameInstallPathDiagnostics/,
+    );
+  });
+});

--- a/src/main/tests/GameStatusStore.test.ts
+++ b/src/main/tests/GameStatusStore.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { GameStatusSyncHandler } from "../events/handlers/GameStatusSyncHandler";
+import { EventType } from "../events/types";
 import {
   getGameStatus,
   isLaunchBlockingStatus,
@@ -8,6 +10,8 @@ import {
   shouldResetStatusOnAutomationWindowClosed,
   updateGameStatusCache,
 } from "../state/GameStatusStore";
+
+import type { AppContext, GameStatusChangeEvent } from "../events/types";
 
 describe("GameStatusStore", () => {
   beforeEach(() => {
@@ -37,6 +41,179 @@ describe("GameStatusStore", () => {
 
     expect(status.timestamp).toBe(Date.now());
     expect(getGameStatus("POE2", "Kakao Games")).toEqual(status);
+  });
+
+  it("preserves install-path health across unrelated runtime status changes", () => {
+    const installPathHealth = {
+      installationStatus: "installed" as const,
+      checkedAt: 100,
+      registryAdvisory: { state: "absent" as const },
+    };
+    updateGameStatusCache({
+      gameId: "POE2",
+      serviceId: "Kakao Games",
+      status: "idle",
+      installPathHealth,
+    });
+
+    const runtime = updateGameStatusCache({
+      gameId: "POE2",
+      serviceId: "Kakao Games",
+      status: "running",
+    });
+
+    expect(runtime.installPathHealth).toEqual(installPathHealth);
+  });
+
+  it("lets a completed install reconciliation replace or clear its context health", () => {
+    updateGameStatusCache({
+      gameId: "POE2",
+      serviceId: "Kakao Games",
+      status: "idle",
+      installPathHealth: {
+        installationStatus: "installed",
+        checkedAt: 100,
+        registryAdvisory: { state: "invalid" },
+      },
+    });
+
+    const healthy = updateGameStatusCache({
+      gameId: "POE2",
+      serviceId: "Kakao Games",
+      status: "idle",
+      installPathHealth: {
+        installationStatus: "installed",
+        checkedAt: 200,
+      },
+    });
+
+    expect(healthy.installPathHealth).toEqual({
+      installationStatus: "installed",
+      checkedAt: 200,
+    });
+  });
+
+  it("does not let an older carried snapshot overwrite newer health", () => {
+    updateGameStatusCache({
+      gameId: "POE2",
+      serviceId: "Kakao Games",
+      status: "idle",
+      installPathHealth: {
+        installationStatus: "installed",
+        checkedAt: 200,
+      },
+    });
+
+    const delayedRuntimeEvent = updateGameStatusCache({
+      gameId: "POE2",
+      serviceId: "Kakao Games",
+      status: "running",
+      installPathHealth: {
+        installationStatus: "installed",
+        checkedAt: 100,
+        registryAdvisory: { state: "absent" },
+      },
+    });
+
+    expect(delayedRuntimeEvent.installPathHealth).toEqual({
+      installationStatus: "installed",
+      checkedAt: 200,
+    });
+  });
+
+  it("never spreads install-path health to another service or game context", () => {
+    updateGameStatusCache({
+      gameId: "POE1",
+      serviceId: "Kakao Games",
+      status: "idle",
+      installPathHealth: {
+        installationStatus: "installed",
+        checkedAt: 100,
+        registryAdvisory: { state: "unknown" },
+      },
+    });
+
+    expect(
+      updateGameStatusCache({
+        gameId: "POE2",
+        serviceId: "Kakao Games",
+        status: "running",
+      }).installPathHealth,
+    ).toBeUndefined();
+    expect(
+      updateGameStatusCache({
+        gameId: "POE1",
+        serviceId: "GGG",
+        status: "idle",
+      }).installPathHealth,
+    ).toBeUndefined();
+  });
+
+  it("broadcasts the preserved advisory for runtime events and the replaced health for reconciliation events", async () => {
+    const send = vi.fn();
+    const context = {
+      mainWindow: {
+        isDestroyed: () => false,
+        webContents: { send },
+      },
+    } as unknown as AppContext;
+    updateGameStatusCache({
+      gameId: "POE2",
+      serviceId: "Kakao Games",
+      status: "idle",
+      installPathHealth: {
+        installationStatus: "installed",
+        checkedAt: 100,
+        registryAdvisory: { state: "absent" },
+      },
+    });
+
+    await GameStatusSyncHandler.handle(
+      {
+        type: EventType.GAME_STATUS_CHANGE,
+        payload: {
+          gameId: "POE2",
+          serviceId: "Kakao Games",
+          status: "running",
+        },
+      } as GameStatusChangeEvent,
+      context,
+    );
+    expect(send).toHaveBeenLastCalledWith(
+      "game-status-update",
+      expect.objectContaining({
+        status: "running",
+        installPathHealth: expect.objectContaining({
+          registryAdvisory: { state: "absent" },
+        }),
+      }),
+    );
+
+    await GameStatusSyncHandler.handle(
+      {
+        type: EventType.GAME_STATUS_CHANGE,
+        payload: {
+          gameId: "POE2",
+          serviceId: "Kakao Games",
+          status: "idle",
+          installPathHealth: {
+            installationStatus: "installed",
+            checkedAt: 200,
+          },
+        },
+      } as GameStatusChangeEvent,
+      context,
+    );
+    expect(send).toHaveBeenLastCalledWith(
+      "game-status-update",
+      expect.objectContaining({
+        status: "idle",
+        installPathHealth: {
+          installationStatus: "installed",
+          checkedAt: 200,
+        },
+      }),
+    );
   });
 
   it("identifies statuses that keep a launch session active", () => {

--- a/src/main/tests/game-install-path-health-contract.test.ts
+++ b/src/main/tests/game-install-path-health-contract.test.ts
@@ -1,0 +1,49 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const readSource = (relativePath: string) =>
+  fs.readFileSync(path.join(process.cwd(), relativePath), "utf8");
+
+describe("game install path health integration contract", () => {
+  it("uses the existing status event channel and wires startup, show, and focus reconciliation", () => {
+    const main = readSource("src/main/main.ts");
+    const reconciler = readSource(
+      "src/main/game/GameInstallStatusReconciler.ts",
+    );
+
+    expect(main).toContain("reconcileAllGameInstallStatuses(appContext");
+    expect(main).toContain(
+      'refreshCurrentGameInstallStatusIfStale("window-show")',
+    );
+    expect(main).toContain(
+      'refreshCurrentGameInstallStatusIfStale("window-focus")',
+    );
+    expect(reconciler).toContain("EventType.GAME_STATUS_CHANGE");
+    expect(reconciler).not.toContain("setInterval(");
+  });
+
+  it("derives renderer warnings from active status without a diagnostics warning hook", () => {
+    const app = readSource("src/renderer/App.tsx");
+    const hooksDirectory = path.join(process.cwd(), "src/renderer/hooks");
+
+    expect(app).toContain("createGamePathRegistryWarning(activeGameStatus");
+    expect(app).not.toContain("useGamePathRegistryWarning");
+    expect(
+      fs.existsSync(path.join(hooksDirectory, "useGamePathRegistryWarning.ts")),
+    ).toBe(false);
+  });
+
+  it("keeps the existing game-status preload listener leak-free", () => {
+    const preload = readSource("src/main/preload.ts");
+    const sharedTypes = readSource("src/shared/types.ts");
+
+    expect(preload).toContain(
+      'return () => ipcRenderer.off("game-status-update", handler)',
+    );
+    expect(sharedTypes).toContain(
+      "callback: (status: GameStatusState) => void,\n  ) => () => void;",
+    );
+  });
+});

--- a/src/main/tests/game-install-path-register-ipc-contract.test.ts
+++ b/src/main/tests/game-install-path-register-ipc-contract.test.ts
@@ -1,0 +1,30 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+describe("game install path register IPC contract", () => {
+  it("keeps shared, preload, and main on the dedicated typed register channel", () => {
+    const sharedTypes = fs.readFileSync(
+      path.join(process.cwd(), "src/shared/types.ts"),
+      "utf8",
+    );
+    const preload = fs.readFileSync(
+      path.join(process.cwd(), "src/main/preload.ts"),
+      "utf8",
+    );
+    const main = fs.readFileSync(
+      path.join(process.cwd(), "src/main/main.ts"),
+      "utf8",
+    );
+
+    expect(sharedTypes).toContain("registerGameInstallPath: (");
+    expect(sharedTypes).toContain("request: GameInstallPathRegisterRequest");
+    expect(preload).toContain('"game-install-path:register"');
+    expect(preload).toContain("request: GameInstallPathRegisterRequest");
+    expect(main).toContain('ipcMain.handle(\n  "game-install-path:register"');
+    expect(main).toContain(
+      "() => registerGameInstallPath(serviceId, gameId, request)",
+    );
+  });
+});

--- a/src/main/tests/game-install-path-register-ipc-contract.test.ts
+++ b/src/main/tests/game-install-path-register-ipc-contract.test.ts
@@ -27,4 +27,249 @@ describe("game install path register IPC contract", () => {
       "() => registerGameInstallPath(serviceId, gameId, request)",
     );
   });
+
+  it("uses only the opaque selection picker and removes the legacy immediate-save bridge", () => {
+    const sharedTypes = fs.readFileSync(
+      path.join(process.cwd(), "src/shared/types.ts"),
+      "utf8",
+    );
+    const preload = fs.readFileSync(
+      path.join(process.cwd(), "src/main/preload.ts"),
+      "utf8",
+    );
+    const main = fs.readFileSync(
+      path.join(process.cwd(), "src/main/main.ts"),
+      "utf8",
+    );
+
+    expect(sharedTypes).toContain("pickGameInstallPathTargets: (");
+    expect(sharedTypes).toContain("applyGameInstallPathTargets: (");
+    expect(sharedTypes).toContain("selectionId: string");
+    expect(sharedTypes).toContain(
+      "targetIds: readonly GameInstallPathTargetId[]",
+    );
+    expect(preload).toContain('"game-install-path:pick-targets"');
+    expect(preload).toContain('"game-install-path:apply-targets"');
+    expect(main).toContain(
+      'ipcMain.handle(\n  "game-install-path:pick-targets"',
+    );
+    expect(main).toContain(
+      'ipcMain.handle(\n  "game-install-path:apply-targets"',
+    );
+
+    expect(sharedTypes).not.toContain("pickGameInstallPath: (");
+    expect(preload).not.toContain('"game-install-path:pick"');
+    expect(main).not.toContain('ipcMain.handle(\n  "game-install-path:pick"');
+  });
+
+  it("keeps registry delete authority to targetId and expectedPath only", () => {
+    const sharedTypes = fs.readFileSync(
+      path.join(process.cwd(), "src/shared/types.ts"),
+      "utf8",
+    );
+    const preload = fs.readFileSync(
+      path.join(process.cwd(), "src/main/preload.ts"),
+      "utf8",
+    );
+    const main = fs.readFileSync(
+      path.join(process.cwd(), "src/main/main.ts"),
+      "utf8",
+    );
+    const app = fs.readFileSync(
+      path.join(process.cwd(), "src/renderer/App.tsx"),
+      "utf8",
+    );
+    const requestMatch = sharedTypes.match(
+      /export interface GameInstallPathRegistryTargetDeleteRequest \{([\s\S]*?)\n\}/,
+    );
+
+    expect(requestMatch?.[1]).toContain(
+      "readonly targetId: GameInstallPathRegistryTargetId",
+    );
+    expect(requestMatch?.[1]).toContain("readonly expectedPath: string");
+    expect(requestMatch?.[1]).not.toMatch(/registryPath|registryValueName/);
+    expect(sharedTypes).toContain("deleteGameInstallPathRegistryTarget: (");
+    expect(preload).toContain('"game-install-path:delete-registry-target"');
+    expect(preload).not.toContain(
+      "registryTarget?: GameInstallPathRegistryTarget",
+    );
+    expect(main).toContain("gameInstallPathRegistryDeleteHandler");
+    expect(app).toContain("deleteGameInstallPathRegistryTarget(");
+    expect(app).not.toContain("pickGameInstallPath(");
+  });
+
+  it("keeps conflict mutation authority to an allowlisted targetId without raw registry identity", () => {
+    const sharedTypes = fs.readFileSync(
+      path.join(process.cwd(), "src/shared/types.ts"),
+      "utf8",
+    );
+    const preload = fs.readFileSync(
+      path.join(process.cwd(), "src/main/preload.ts"),
+      "utf8",
+    );
+    const main = fs.readFileSync(
+      path.join(process.cwd(), "src/main/main.ts"),
+      "utf8",
+    );
+    const app = fs.readFileSync(
+      path.join(process.cwd(), "src/renderer/App.tsx"),
+      "utf8",
+    );
+    const requestMatch = sharedTypes.match(
+      /export interface GameInstallPathConflictTarget \{([\s\S]*?)\n\}/,
+    );
+
+    expect(requestMatch?.[1]).toContain(
+      "readonly targetId: GameInstallPathRegistryTargetId",
+    );
+    expect(requestMatch?.[1]).toContain("readonly expectedPath: string");
+    expect(requestMatch?.[1]).toContain("readonly expectedConfigPath: string");
+    expect(requestMatch?.[1]).not.toMatch(/registryPath|registryValueName/);
+    expect(preload).toContain("registryTarget: GameInstallPathConflictTarget");
+    expect(preload).not.toMatch(
+      /resolveGameInstallPathConflict:[\s\S]*?registry(Path|ValueName)/,
+    );
+    expect(main).toContain("resolveGameInstallPathConflict(");
+    expect(app).not.toContain("getRegistryMutationTarget");
+  });
+
+  it("narrows the renderer clear bridge to config only", () => {
+    const sharedTypes = fs.readFileSync(
+      path.join(process.cwd(), "src/shared/types.ts"),
+      "utf8",
+    );
+    const preload = fs.readFileSync(
+      path.join(process.cwd(), "src/main/preload.ts"),
+      "utf8",
+    );
+    const main = fs.readFileSync(
+      path.join(process.cwd(), "src/main/main.ts"),
+      "utf8",
+    );
+
+    expect(preload).toContain('"game-install-path:clear-config"');
+    expect(preload).not.toContain('"game-install-path:clear"');
+    expect(main).toContain(
+      'ipcMain.handle(\n  "game-install-path:clear-config"',
+    );
+    expect(sharedTypes).not.toContain(
+      "registryTarget?: GameInstallPathRegistryTarget",
+    );
+  });
+
+  it("keeps apply authority to selectionId and targetIds only", () => {
+    const sharedTypes = fs.readFileSync(
+      path.join(process.cwd(), "src/shared/types.ts"),
+      "utf8",
+    );
+    const preload = fs.readFileSync(
+      path.join(process.cwd(), "src/main/preload.ts"),
+      "utf8",
+    );
+    const handlers = fs.readFileSync(
+      path.join(process.cwd(), "src/main/game/GameInstallPathIpcHandlers.ts"),
+      "utf8",
+    );
+    const requestMatch = sharedTypes.match(
+      /export interface GameInstallPathSelectionApplyRequest \{([\s\S]*?)\n\}/,
+    );
+    expect(requestMatch?.[1]).toBeDefined();
+    expect(requestMatch?.[1]).toContain("readonly selectionId: string");
+    expect(requestMatch?.[1]).toContain(
+      "readonly targetIds: readonly GameInstallPathTargetId[]",
+    );
+    expect(requestMatch?.[1]).not.toMatch(
+      /readonly\s+(serviceId|gameId|path|registryPath|registryValueName)\s*:/,
+    );
+
+    expect(preload).toMatch(
+      /"game-install-path:apply-targets",\s*\{\s*selectionId,\s*targetIds,?\s*\}/,
+    );
+    expect(handlers).toContain("request: GameInstallPathSelectionApplyRequest");
+    expect(handlers).toContain("const ownerWebContentsId = event.sender.id");
+    expect(handlers).toContain("request?.selectionId");
+  });
+
+  it("passes an optional defaultPath and cleans each owner up once", () => {
+    const handlers = fs.readFileSync(
+      path.join(process.cwd(), "src/main/game/GameInstallPathIpcHandlers.ts"),
+      "utf8",
+    );
+
+    expect(handlers).toContain(
+      "const defaultPath = await dependencies.selectionService.getDefaultPath",
+    );
+    expect(handlers).toContain("...(defaultPath ? { defaultPath } : {})");
+    expect(handlers).toContain('sender.once("destroyed"');
+    expect(handlers).toContain(
+      "dependencies.selectionService.disposeOwner(sender.id)",
+    );
+    expect(handlers).toContain("cleanupOwners.has(sender.id)");
+  });
+
+  it("resolves the owner-bound context and wraps a successful batch exactly once", () => {
+    const handlers = fs.readFileSync(
+      path.join(process.cwd(), "src/main/game/GameInstallPathIpcHandlers.ts"),
+      "utf8",
+    );
+    const handlerStart = handlers.indexOf("const applyGameInstallPathTargets");
+    const handlerEnd = handlers.indexOf(
+      "return { pickGameInstallPathTargets, applyGameInstallPathTargets }",
+      handlerStart,
+    );
+    const handler = handlers.slice(handlerStart, handlerEnd);
+
+    expect(handler).toContain("event.sender.id");
+    expect(handler).toContain(
+      "dependencies.selectionService.resolveSelectionContext",
+    );
+    expect(handler).toContain("resolved.context");
+    expect(handler.match(/dependencies\.runManualAction/g)).toHaveLength(1);
+    expect(
+      handler.match(/dependencies\.selectionService\.applySelection/g),
+    ).toHaveLength(1);
+  });
+
+  it("connects the production channels through the behavior-tested handler factory", () => {
+    const main = fs.readFileSync(
+      path.join(process.cwd(), "src/main/main.ts"),
+      "utf8",
+    );
+
+    expect(main).toContain("createGameInstallPathIpcHandlers");
+    expect(main).toContain(
+      "gameInstallPathIpcHandlers.pickGameInstallPathTargets",
+    );
+    expect(main).toContain(
+      "gameInstallPathIpcHandlers.applyGameInstallPathTargets",
+    );
+  });
+
+  it("wires modal generations and synchronous operation tokens through every async mutation flow", () => {
+    const app = fs.readFileSync(
+      path.join(process.cwd(), "src/renderer/App.tsx"),
+      "utf8",
+    );
+    const stateHelper = fs.readFileSync(
+      path.join(process.cwd(), "src/renderer/utils/game-path-modal-state.ts"),
+      "utf8",
+    );
+
+    expect(app).toContain("gamePathModalGenerationRef");
+    expect(app).toContain("gamePathModalOperationTrackerRef");
+    for (const operation of [
+      "diagnostics",
+      "picker",
+      "apply",
+      "delete",
+      "config-clear",
+      "conflict",
+      "register",
+    ]) {
+      expect(app).toContain(`"${operation}"`);
+    }
+    expect(stateHelper).toContain("createGamePathModalOperationTracker");
+    expect(stateHelper).toContain("selectionId");
+    expect(stateHelper).toContain("generation");
+  });
 });

--- a/src/main/tests/kakao-registry-source-contract.test.ts
+++ b/src/main/tests/kakao-registry-source-contract.test.ts
@@ -1,0 +1,106 @@
+import { createRequire } from "node:module";
+
+import { describe, expect, it } from "vitest";
+
+type RegistryContract = {
+  RegistryRoot: string;
+  RegistryPath: string[];
+};
+
+type RegistrySource = {
+  gameId: "POE" | "POE2";
+  documentKey: "poe" | "poe2";
+  url: string;
+  expected: RegistryContract;
+};
+
+type ExtractResult = {
+  contract: RegistryContract | null;
+  issues: string[];
+};
+
+type RegistrySourceAuditModule = {
+  EXPECTED_SOURCES: RegistrySource[];
+  extractRegistryContract: (
+    document: unknown,
+    documentKey: string,
+  ) => ExtractResult;
+  compareRegistryContract: (
+    actual: RegistryContract,
+    expected: RegistryContract,
+    documentKey: string,
+  ) => string[];
+};
+
+const require = createRequire(import.meta.url);
+const { EXPECTED_SOURCES, compareRegistryContract, extractRegistryContract } =
+  require("../../../scripts/check-kakao-registry-source.cjs") as RegistrySourceAuditModule;
+
+const poeFixture = {
+  poe: {
+    live: {
+      RegistryRoot: "HKCU",
+      RegistryPath: ["SOFTWARE\\Kakaogames\\POE", "SOFTWARE\\DaumGames\\POE"],
+    },
+  },
+};
+
+const poe2Fixture = {
+  poe2: {
+    live: {
+      RegistryRoot: "HKCU",
+      RegistryPath: ["SOFTWARE\\Kakaogames\\POE2", "SOFTWARE\\DaumGames\\POE2"],
+    },
+  },
+};
+
+const sourceFor = (gameId: RegistrySource["gameId"]) => {
+  const source = EXPECTED_SOURCES.find(
+    (candidate) => candidate.gameId === gameId,
+  );
+  if (!source) throw new Error(`Missing expected source for ${gameId}`);
+  return source;
+};
+
+describe("KakaoGames registry source contract", () => {
+  it.each([
+    ["POE", poeFixture],
+    ["POE2", poe2Fixture],
+  ] as const)("extracts the nested %s contract", (gameId, fixture) => {
+    const source = sourceFor(gameId);
+
+    expect(extractRegistryContract(fixture, source.documentKey)).toEqual({
+      contract: source.expected,
+      issues: [],
+    });
+  });
+
+  it("reports a missing top-level game key with its full field path", () => {
+    expect(extractRegistryContract({}, "poe")).toEqual({
+      contract: null,
+      issues: ["poe must be a JSON object"],
+    });
+  });
+
+  it("reports a missing live object with its full field path", () => {
+    expect(extractRegistryContract({ poe2: {} }, "poe2")).toEqual({
+      contract: null,
+      issues: ["poe2.live must be a JSON object"],
+    });
+  });
+
+  it("detects candidate order drift using full field paths", () => {
+    const source = sourceFor("POE");
+    const reversed = {
+      RegistryRoot: "HKCU",
+      RegistryPath: [...source.expected.RegistryPath].reverse(),
+    };
+
+    expect(
+      compareRegistryContract(reversed, source.expected, source.documentKey),
+    ).toEqual([
+      'poe.live.RegistryPath[0]: expected "SOFTWARE\\\\Kakaogames\\\\POE", received "SOFTWARE\\\\DaumGames\\\\POE"',
+      'poe.live.RegistryPath[1]: expected "SOFTWARE\\\\DaumGames\\\\POE", received "SOFTWARE\\\\Kakaogames\\\\POE"',
+    ]);
+  });
+});

--- a/src/main/tests/registry-install-status.test.ts
+++ b/src/main/tests/registry-install-status.test.ts
@@ -1,7 +1,18 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { DEFAULT_CONFIG } from "../../shared/config";
-import { ACTIVE_GAMES, SERVICE_CHANNELS } from "../../shared/types";
+import {
+  ACTIVE_GAMES,
+  SERVICE_CHANNELS,
+  type ActiveGame,
+  type GameInstallPathDiagnostics,
+  type GameInstallPathRegistryTargetDeleteRequest,
+  type GameInstallPathRegistryTargetDeleteResult,
+  type GameInstallPathTargetApplyResult,
+  type GameInstallPathTargetSnapshot,
+  type ServiceChannel,
+} from "../../shared/types";
+import * as registryModule from "../utils/registry";
 import {
   clearGameInstallPath,
   GAME_INSTALL_REGISTRY_MAP,
@@ -92,6 +103,52 @@ const mockRegQuery = (implementation: RegQueryImplementation) => {
 
 const registryRead = (stdout: string) => ({ stdout, stderr: "", code: 0 });
 
+type GameInstallPathTargetApi = {
+  resolveGameInstallPathTarget: (
+    serviceId: ServiceChannel,
+    gameId: ActiveGame,
+    targetId: string,
+  ) =>
+    | {
+        ok: true;
+        target: {
+          targetId: string;
+          kind: "config" | "registry";
+          registryPath?: string;
+          registryValueName?: string;
+        };
+      }
+    | { ok: false; code: string; retryable: boolean };
+  collectGameInstallPathTargetSnapshots: (
+    serviceId: ServiceChannel,
+    gameId: ActiveGame,
+  ) => Promise<readonly GameInstallPathTargetSnapshot[]>;
+  deriveGameInstallPathTargetSnapshots: (
+    diagnostics: GameInstallPathDiagnostics,
+  ) => readonly GameInstallPathTargetSnapshot[];
+  applyGameInstallPathTarget: (
+    serviceId: ServiceChannel,
+    gameId: ActiveGame,
+    snapshot: GameInstallPathTargetSnapshot,
+    installPath: string,
+  ) => Promise<GameInstallPathTargetApplyResult>;
+  deleteGameInstallPathRegistryTarget: (
+    serviceId: ServiceChannel,
+    gameId: ActiveGame,
+    request: GameInstallPathRegistryTargetDeleteRequest,
+  ) => Promise<GameInstallPathRegistryTargetDeleteResult>;
+};
+
+const requireGameInstallPathTargetFunction = <
+  Name extends keyof GameInstallPathTargetApi,
+>(
+  name: Name,
+): GameInstallPathTargetApi[Name] => {
+  const candidate = (registryModule as Partial<GameInstallPathTargetApi>)[name];
+  expect(candidate, `${name} must be implemented`).toBeTypeOf("function");
+  return candidate as GameInstallPathTargetApi[Name];
+};
+
 const commandReadsRegistryPath = (command: string, registryPath: string) =>
   command.includes(
     registryPath.replace("HKCU:\\", "Registry::HKEY_CURRENT_USER\\"),
@@ -115,7 +172,11 @@ const kakaoPoe2ConflictTarget = (
   expectedRegistryPath: string,
   candidateIndex: 0 | 1 = 0,
 ) => ({
-  ...kakaoPoe2RegistryTarget(expectedRegistryPath, candidateIndex),
+  targetId:
+    candidateIndex === 0
+      ? ("registry-primary" as const)
+      : ("registry-compatibility" as const),
+  expectedPath: expectedRegistryPath,
   expectedConfigPath,
 });
 
@@ -134,6 +195,883 @@ describe("registry install status", () => {
       stderr: "",
       code: 0,
     });
+  });
+
+  describe("MS6.1 game install path targets", () => {
+    it("maps Kakao and GGG registry diagnostics to stable target IDs", async () => {
+      const kakaoPrimaryPath = String.raw`C:\Games\Kakao POE2`;
+      const kakaoCompatibilityPath = String.raw`D:\Games\Kakao POE2`;
+      mocks.powershellExecute.mockImplementation(async (command: string) => {
+        if (
+          commandReadsRegistryPath(
+            command,
+            GAME_INSTALL_REGISTRY_MAP["Kakao Games"].POE2[0].path,
+          )
+        ) {
+          return registryRead(kakaoPrimaryPath);
+        }
+        if (
+          commandReadsRegistryPath(
+            command,
+            GAME_INSTALL_REGISTRY_MAP["Kakao Games"].POE2[1].path,
+          )
+        ) {
+          return registryRead(kakaoCompatibilityPath);
+        }
+        return registryRead(String.raw`E:\Games\GGG POE2`);
+      });
+      mocks.stat.mockResolvedValue({ isFile: () => true });
+
+      const kakaoDiagnostics = await getGameInstallPathDiagnostics(
+        "Kakao Games",
+        "POE2",
+      );
+      const gggDiagnostics = await getGameInstallPathDiagnostics("GGG", "POE2");
+
+      expect(
+        kakaoDiagnostics.registry.candidates.map(({ targetId }) => targetId),
+      ).toEqual(["registry-primary", "registry-compatibility"]);
+      expect(
+        gggDiagnostics.registry.candidates.map(({ targetId }) => targetId),
+      ).toEqual(["registry-primary"]);
+    });
+
+    it("collects registry read state and config path in target snapshots", async () => {
+      const collectGameInstallPathTargetSnapshots =
+        requireGameInstallPathTargetFunction(
+          "collectGameInstallPathTargetSnapshots",
+        );
+      const primaryPath = String.raw`C:\Games\Kakao POE2`;
+      const configPath = String.raw`D:\Games\Configured POE2`;
+      mocks.contextProviderGet.mockReturnValue(
+        createContext({
+          "Kakao Games": { POE1: "", POE2: configPath },
+          GGG: { POE1: "", POE2: "" },
+        }),
+      );
+      mocks.powershellExecute.mockImplementation(async (command: string) =>
+        commandReadsRegistryPath(
+          command,
+          GAME_INSTALL_REGISTRY_MAP["Kakao Games"].POE2[0].path,
+        )
+          ? registryRead(primaryPath)
+          : registryRead("__REG_VALUE_MISSING__"),
+      );
+      mocks.stat.mockResolvedValue({ isFile: () => true });
+
+      await expect(
+        collectGameInstallPathTargetSnapshots("Kakao Games", "POE2"),
+      ).resolves.toEqual([
+        {
+          targetId: "registry-primary",
+          currentPath: primaryPath,
+          registryState: "found",
+        },
+        {
+          targetId: "registry-compatibility",
+          currentPath: null,
+          registryState: "value-missing",
+        },
+        { targetId: "config", currentPath: configPath },
+      ]);
+    });
+
+    it("purely derives target snapshots from one diagnostics value", () => {
+      const deriveGameInstallPathTargetSnapshots =
+        requireGameInstallPathTargetFunction(
+          "deriveGameInstallPathTargetSnapshots",
+        );
+      const diagnostics = {
+        serviceId: "Kakao Games",
+        gameId: "POE2",
+        executableName: "PathOfExile_KG.exe",
+        config: {
+          source: "config",
+          path: String.raw`E:\Games\Config`,
+          state: "found",
+          verification: "valid",
+        },
+        registry: {
+          source: "registry",
+          path: String.raw`C:\Games\Primary`,
+          state: "found",
+          verification: "valid",
+          registryPath: String.raw`HKCU:\Software\Kakaogames\POE2`,
+          registryValueName: "InstallPath",
+          aggregateState: "valid",
+          candidates: [
+            {
+              targetId: "registry-primary",
+              path: String.raw`C:\Games\Primary`,
+              state: "found",
+              verification: "valid",
+              registryPath: String.raw`HKCU:\Software\Kakaogames\POE2`,
+              registryValueName: "InstallPath",
+              isActive: true,
+            },
+            {
+              targetId: "registry-compatibility",
+              path: null,
+              state: "value-missing",
+              verification: "not-checked",
+              registryPath: String.raw`HKCU:\Software\DaumGames\POE2`,
+              registryValueName: "InstallPath",
+              isActive: false,
+            },
+          ],
+        },
+        hasPathConflict: true,
+        isPathConflictAcknowledged: false,
+        recommendedSource: "registry",
+      } as const satisfies GameInstallPathDiagnostics;
+
+      expect(deriveGameInstallPathTargetSnapshots(diagnostics)).toEqual([
+        {
+          targetId: "registry-primary",
+          currentPath: String.raw`C:\Games\Primary`,
+          registryState: "found",
+        },
+        {
+          targetId: "registry-compatibility",
+          currentPath: null,
+          registryState: "value-missing",
+        },
+        { targetId: "config", currentPath: String.raw`E:\Games\Config` },
+      ]);
+      expect(mocks.powershellExecute).not.toHaveBeenCalled();
+      expect(mocks.contextProviderGet).not.toHaveBeenCalled();
+      expect(mocks.stat).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      {
+        label: "Kakao primary",
+        serviceId: "Kakao Games",
+        targetId: "registry-primary",
+        registryPath: GAME_INSTALL_REGISTRY_MAP["Kakao Games"].POE2[0].path,
+      },
+      {
+        label: "Kakao compatibility",
+        serviceId: "Kakao Games",
+        targetId: "registry-compatibility",
+        registryPath: GAME_INSTALL_REGISTRY_MAP["Kakao Games"].POE2[1].path,
+      },
+      {
+        label: "GGG primary",
+        serviceId: "GGG",
+        targetId: "registry-primary",
+        registryPath: GAME_INSTALL_REGISTRY_MAP.GGG.POE2[0].path,
+      },
+    ] as const)(
+      "deletes the allowlisted $label value through one atomic command",
+      async ({ serviceId, targetId, registryPath }) => {
+        const deleteGameInstallPathRegistryTarget =
+          requireGameInstallPathTargetFunction(
+            "deleteGameInstallPathRegistryTarget",
+          );
+        const expectedPath = String.raw`C:\Games\Installed POE2`;
+        const request = { targetId, expectedPath };
+        mocks.powershellExecute.mockResolvedValue(
+          registryRead("__GAME_INSTALL_TARGET_DELETE_DELETED__"),
+        );
+
+        const result = await deleteGameInstallPathRegistryTarget(
+          serviceId,
+          "POE2",
+          request,
+        );
+
+        expect(Object.keys(request).sort()).toEqual([
+          "expectedPath",
+          "targetId",
+        ]);
+        expect(result).toEqual({ targetId, status: "deleted" });
+        expect(mocks.powershellExecute).toHaveBeenCalledTimes(1);
+        const command = String(mocks.powershellExecute.mock.calls[0][0]);
+        expect(command).toContain(
+          registryPath.replace("HKCU:\\", "Registry::HKEY_CURRENT_USER\\"),
+        );
+        expect(command).toContain(`$expectedPath = '${expectedPath}'`);
+        expect(command).toContain(
+          "Remove-ItemProperty -LiteralPath $path -Name $name",
+        );
+        expect(command).toContain(
+          "$readBackItem.GetValueNames() -contains $name",
+        );
+        expect(command).toContain("__GAME_INSTALL_TARGET_DELETE_DELETED__");
+        expect(
+          command.indexOf("$currentPath -ine $expectedNormalized"),
+        ).toBeLessThan(command.indexOf("Remove-ItemProperty"));
+        expect(command.indexOf("Remove-ItemProperty")).toBeLessThan(
+          command.indexOf("$readBackItem.GetValueNames() -contains $name"),
+        );
+        expect(command).not.toMatch(/(^|[\r\n;])\s*Remove-Item(?:\s|$)/);
+      },
+    );
+
+    it.each([
+      ["GGG compatibility", "GGG", "registry-compatibility"],
+      ["arbitrary target ID", "Kakao Games", "registry-admin"],
+    ] as const)(
+      "rejects deletion of %s before registry access",
+      async (_label, serviceId, targetId) => {
+        const deleteGameInstallPathRegistryTarget =
+          requireGameInstallPathTargetFunction(
+            "deleteGameInstallPathRegistryTarget",
+          );
+
+        await expect(
+          deleteGameInstallPathRegistryTarget(serviceId, "POE2", {
+            targetId,
+            expectedPath: String.raw`C:\Games\Installed POE2`,
+          } as GameInstallPathRegistryTargetDeleteRequest),
+        ).resolves.toEqual({
+          targetId,
+          status: "failed",
+          code: "target-not-allowed",
+          retryable: false,
+        });
+        expect(mocks.powershellExecute).not.toHaveBeenCalled();
+      },
+    );
+
+    it.each([
+      [
+        "stale expected path",
+        "__GAME_INSTALL_TARGET_DELETE_CHANGED__",
+        "target-changed",
+      ],
+      [
+        "missing key container",
+        "__GAME_INSTALL_TARGET_DELETE_MISSING__",
+        "target-missing",
+      ],
+      [
+        "registry read failure",
+        "__GAME_INSTALL_TARGET_DELETE_READ_FAILED__\naccess denied",
+        "target-read-failed",
+      ],
+      [
+        "mutation failure",
+        "__GAME_INSTALL_TARGET_DELETE_MUTATION_FAILED__\naccess denied",
+        "mutation-failed",
+      ],
+      [
+        "read-back failure",
+        "__GAME_INSTALL_TARGET_DELETE_READBACK_FAILED__",
+        "readback-failed",
+      ],
+    ] as const)(
+      "returns a stable deletion failure for %s",
+      async (_label, marker, code) => {
+        const deleteGameInstallPathRegistryTarget =
+          requireGameInstallPathTargetFunction(
+            "deleteGameInstallPathRegistryTarget",
+          );
+        const expectedPath = String.raw`C:\Games\Expected POE2`;
+        mocks.powershellExecute.mockResolvedValue(registryRead(marker));
+
+        const result = await deleteGameInstallPathRegistryTarget(
+          "Kakao Games",
+          "POE2",
+          { targetId: "registry-primary", expectedPath },
+        );
+
+        expect(result).toEqual({
+          targetId: "registry-primary",
+          status: "failed",
+          code,
+          retryable: true,
+        });
+        expect(mocks.powershellExecute).toHaveBeenCalledTimes(1);
+        const command = String(mocks.powershellExecute.mock.calls[0][0]);
+        expect(command).toContain(`$expectedPath = '${expectedPath}'`);
+        expect(command).toContain(marker.split("\n")[0]);
+        expect(command).not.toMatch(/(^|[\r\n;])\s*Remove-Item(?:\s|$)/);
+      },
+    );
+
+    it("returns unchanged when the allowlisted target value is already absent", async () => {
+      const deleteGameInstallPathRegistryTarget =
+        requireGameInstallPathTargetFunction(
+          "deleteGameInstallPathRegistryTarget",
+        );
+      mocks.powershellExecute.mockResolvedValue(
+        registryRead("__GAME_INSTALL_TARGET_DELETE_UNCHANGED__"),
+      );
+
+      const result = await deleteGameInstallPathRegistryTarget(
+        "Kakao Games",
+        "POE2",
+        {
+          targetId: "registry-compatibility",
+          expectedPath: String.raw`C:\Games\Expected POE2`,
+        },
+      );
+
+      expect(result).toEqual({
+        targetId: "registry-compatibility",
+        status: "unchanged",
+      });
+      const command = String(mocks.powershellExecute.mock.calls[0][0]);
+      expect(command).toContain("$item.GetValueNames() -notcontains $name");
+      expect(
+        command.indexOf("__GAME_INSTALL_TARGET_DELETE_UNCHANGED__"),
+      ).toBeLessThan(command.indexOf("Remove-ItemProperty"));
+      expect(command).not.toMatch(/(^|[\r\n;])\s*Remove-Item(?:\s|$)/);
+    });
+
+    it("preserves a drive-root expected path in atomic registry deletion", async () => {
+      const deleteGameInstallPathRegistryTarget =
+        requireGameInstallPathTargetFunction(
+          "deleteGameInstallPathRegistryTarget",
+        );
+      const expectedPath = "E:\\";
+      mocks.powershellExecute.mockResolvedValue(
+        registryRead("__GAME_INSTALL_TARGET_DELETE_DELETED__"),
+      );
+
+      await expect(
+        deleteGameInstallPathRegistryTarget("Kakao Games", "POE2", {
+          targetId: "registry-primary",
+          expectedPath,
+        }),
+      ).resolves.toEqual({
+        targetId: "registry-primary",
+        status: "deleted",
+      });
+
+      const command = String(mocks.powershellExecute.mock.calls[0][0]);
+      expect(command).toContain(`$expectedPath = '${expectedPath}'`);
+      expect(command).toContain(
+        "$root = [System.IO.Path]::GetPathRoot($normalized)",
+      );
+      expect(command).toContain("$normalized.Length -gt $root.Length");
+    });
+
+    it.each([
+      {
+        label: "primary create",
+        targetId: "registry-primary",
+        registryState: "key-missing",
+        currentPath: null,
+        registryPath: GAME_INSTALL_REGISTRY_MAP["Kakao Games"].POE2[0].path,
+      },
+      {
+        label: "primary overwrite",
+        targetId: "registry-primary",
+        registryState: "found",
+        currentPath: String.raw`C:\Games\Old Primary POE2`,
+        registryPath: GAME_INSTALL_REGISTRY_MAP["Kakao Games"].POE2[0].path,
+      },
+      {
+        label: "compatibility create",
+        targetId: "registry-compatibility",
+        registryState: "value-missing",
+        currentPath: null,
+        registryPath: GAME_INSTALL_REGISTRY_MAP["Kakao Games"].POE2[1].path,
+      },
+      {
+        label: "compatibility overwrite",
+        targetId: "registry-compatibility",
+        registryState: "found",
+        currentPath: String.raw`D:\Games\Old Compatibility POE2`,
+        registryPath: GAME_INSTALL_REGISTRY_MAP["Kakao Games"].POE2[1].path,
+      },
+    ] as const)(
+      "applies $label through one atomic allowlisted PowerShell command",
+      async ({ targetId, registryState, currentPath, registryPath }) => {
+        const applyGameInstallPathTarget = requireGameInstallPathTargetFunction(
+          "applyGameInstallPathTarget",
+        );
+        const selectedPath = String.raw`E:\Games\Selected POE2`;
+        mocks.stat.mockResolvedValue({ isFile: () => true });
+        mocks.powershellExecute.mockResolvedValue(
+          registryRead("__GAME_INSTALL_TARGET_APPLIED__"),
+        );
+
+        const result = await applyGameInstallPathTarget(
+          "Kakao Games",
+          "POE2",
+          { targetId, currentPath, registryState },
+          selectedPath,
+        );
+
+        expect(result).toEqual({
+          targetId,
+          status: "applied",
+          path: selectedPath,
+        });
+        expect(mocks.powershellExecute).toHaveBeenCalledTimes(1);
+        const command = String(mocks.powershellExecute.mock.calls[0][0]);
+        expect(command).toContain(
+          registryPath.replace("HKCU:\\", "Registry::HKEY_CURRENT_USER\\"),
+        );
+        expect(command).toContain(`$expectedState = '${registryState}'`);
+        if (currentPath) {
+          expect(command).toContain(`$expectedPath = '${currentPath}'`);
+        }
+        expect(command).toContain("New-Item -Path $path");
+        expect(command).toContain("New-ItemProperty -LiteralPath $path");
+        expect(command).toContain("-PropertyType String -Force");
+        expect(command).toContain("$readBackItem.GetValue");
+        expect(command).not.toContain("Remove-Item");
+      },
+    );
+
+    it("preserves drive-root expected and selected paths in atomic registry apply", async () => {
+      const applyGameInstallPathTarget = requireGameInstallPathTargetFunction(
+        "applyGameInstallPathTarget",
+      );
+      const expectedPath = "E:\\";
+      const selectedPath = "F:\\";
+      mocks.stat.mockResolvedValue({ isFile: () => true });
+      mocks.powershellExecute.mockResolvedValue(
+        registryRead("__GAME_INSTALL_TARGET_APPLIED__"),
+      );
+
+      await expect(
+        applyGameInstallPathTarget(
+          "Kakao Games",
+          "POE2",
+          {
+            targetId: "registry-primary",
+            currentPath: expectedPath,
+            registryState: "found",
+          },
+          selectedPath,
+        ),
+      ).resolves.toEqual({
+        targetId: "registry-primary",
+        status: "applied",
+        path: selectedPath,
+      });
+
+      const command = String(mocks.powershellExecute.mock.calls[0][0]);
+      expect(command).toContain(`$expectedPath = '${expectedPath}'`);
+      expect(command).toContain(`$selectedPath = '${selectedPath}'`);
+      expect(command).toContain(
+        "$root = [System.IO.Path]::GetPathRoot($normalized)",
+      );
+      expect(command).toContain("$normalized.Length -gt $root.Length");
+    });
+
+    it.each([
+      {
+        label: "stale expected state",
+        snapshot: {
+          targetId: "registry-primary",
+          currentPath: null,
+          registryState: "value-missing",
+        },
+      },
+      {
+        label: "stale expected path",
+        snapshot: {
+          targetId: "registry-primary",
+          currentPath: String.raw`C:\Games\Previous POE2`,
+          registryState: "found",
+        },
+      },
+    ] as const)(
+      "rejects $label reported by the atomic command",
+      async ({ snapshot }) => {
+        const applyGameInstallPathTarget = requireGameInstallPathTargetFunction(
+          "applyGameInstallPathTarget",
+        );
+        mocks.stat.mockResolvedValue({ isFile: () => true });
+        mocks.powershellExecute.mockResolvedValue(
+          registryRead("__GAME_INSTALL_TARGET_CHANGED__"),
+        );
+
+        const result = await applyGameInstallPathTarget(
+          "Kakao Games",
+          "POE2",
+          snapshot,
+          String.raw`E:\Games\Selected POE2`,
+        );
+
+        expect(result).toEqual({
+          targetId: "registry-primary",
+          status: "failed",
+          code: "target-changed",
+          retryable: true,
+        });
+        expect(mocks.powershellExecute).toHaveBeenCalledTimes(1);
+        const command = String(mocks.powershellExecute.mock.calls[0][0]);
+        expect(command).toContain(
+          `$expectedState = '${snapshot.registryState}'`,
+        );
+        if (snapshot.currentPath) {
+          expect(command).toContain(
+            `$expectedPath = '${snapshot.currentPath}'`,
+          );
+        }
+      },
+    );
+
+    it("rejects a registry snapshot captured from a read failure", async () => {
+      const applyGameInstallPathTarget = requireGameInstallPathTargetFunction(
+        "applyGameInstallPathTarget",
+      );
+      mocks.stat.mockResolvedValue({ isFile: () => true });
+
+      const result = await applyGameInstallPathTarget(
+        "Kakao Games",
+        "POE2",
+        {
+          targetId: "registry-primary",
+          currentPath: null,
+          registryState: "read-failed",
+        },
+        String.raw`E:\Games\Selected POE2`,
+      );
+
+      expect(result).toEqual({
+        targetId: "registry-primary",
+        status: "failed",
+        code: "target-read-failed",
+        retryable: true,
+      });
+      expect(mocks.powershellExecute).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      [
+        "write failure",
+        "__GAME_INSTALL_TARGET_MUTATION_FAILED__\naccess denied",
+        "mutation-failed",
+      ],
+      [
+        "read-back failure",
+        "__GAME_INSTALL_TARGET_READBACK_FAILED__",
+        "readback-failed",
+      ],
+    ] as const)(
+      "returns a stable failure result for registry $label",
+      async (_label, marker, code) => {
+        const applyGameInstallPathTarget = requireGameInstallPathTargetFunction(
+          "applyGameInstallPathTarget",
+        );
+        mocks.stat.mockResolvedValue({ isFile: () => true });
+        mocks.powershellExecute.mockResolvedValue(registryRead(marker));
+
+        const result = await applyGameInstallPathTarget(
+          "Kakao Games",
+          "POE2",
+          {
+            targetId: "registry-primary",
+            currentPath: String.raw`C:\Games\Old POE2`,
+            registryState: "found",
+          },
+          String.raw`E:\Games\Selected POE2`,
+        );
+
+        expect(result).toEqual({
+          targetId: "registry-primary",
+          status: "failed",
+          code,
+          retryable: true,
+        });
+        expect(mocks.powershellExecute).toHaveBeenCalledTimes(1);
+        expect(String(mocks.powershellExecute.mock.calls[0][0])).toContain(
+          marker.split("\n")[0],
+        );
+      },
+    );
+
+    it("returns unchanged only after the atomic command rechecks the same registry path", async () => {
+      const applyGameInstallPathTarget = requireGameInstallPathTargetFunction(
+        "applyGameInstallPathTarget",
+      );
+      const selectedPath = String.raw`E:\Games\Selected POE2`;
+      mocks.stat.mockResolvedValue({ isFile: () => true });
+      mocks.powershellExecute.mockResolvedValue(
+        registryRead("__GAME_INSTALL_TARGET_UNCHANGED__"),
+      );
+
+      const result = await applyGameInstallPathTarget(
+        "Kakao Games",
+        "POE2",
+        {
+          targetId: "registry-primary",
+          currentPath: selectedPath,
+          registryState: "found",
+        },
+        `${selectedPath}\\`,
+      );
+
+      expect(result).toEqual({
+        targetId: "registry-primary",
+        status: "unchanged",
+        path: selectedPath,
+      });
+      const command = String(mocks.powershellExecute.mock.calls[0][0]);
+      expect(command).toContain("__GAME_INSTALL_TARGET_UNCHANGED__");
+      expect(command.indexOf("__GAME_INSTALL_TARGET_UNCHANGED__")).toBeLessThan(
+        command.indexOf("New-ItemProperty"),
+      );
+    });
+
+    it("compares the config snapshot and immutably updates only the selected nested path", async () => {
+      const applyGameInstallPathTarget = requireGameInstallPathTargetFunction(
+        "applyGameInstallPathTarget",
+      );
+      const currentPath = String.raw`C:\Games\Old POE2`;
+      const selectedPath = String.raw`E:\Games\Selected POE2`;
+      const originalPaths = {
+        "Kakao Games": { POE1: "C:\\Games\\Kakao POE1\\", POE2: currentPath },
+        GGG: {
+          POE1: "D:\\Games\\GGG POE1\\",
+          POE2: "D:\\Games\\GGG POE2\\",
+        },
+      };
+      const originalKakaoPaths = originalPaths["Kakao Games"];
+      mocks.contextProviderGet.mockReturnValue(createContext(originalPaths));
+      mocks.stat.mockResolvedValue({ isFile: () => true });
+
+      const result = await applyGameInstallPathTarget(
+        "Kakao Games",
+        "POE2",
+        { targetId: "config", currentPath },
+        `${selectedPath}\\`,
+      );
+
+      expect(result).toEqual({
+        targetId: "config",
+        status: "applied",
+        path: selectedPath,
+      });
+      expect(originalPaths["Kakao Games"]).toBe(originalKakaoPaths);
+      expect(originalPaths["Kakao Games"].POE2).toBe(currentPath);
+      expect(mocks.setConfigWithEvent).toHaveBeenCalledWith(
+        "gameInstallPaths",
+        {
+          "Kakao Games": {
+            POE1: "C:\\Games\\Kakao POE1\\",
+            POE2: selectedPath,
+          },
+          GGG: {
+            POE1: "D:\\Games\\GGG POE1\\",
+            POE2: "D:\\Games\\GGG POE2\\",
+          },
+        },
+      );
+      const writtenPaths = mocks.setConfigWithEvent.mock.calls[0][1];
+      expect(writtenPaths).not.toBe(originalPaths);
+      expect(writtenPaths["Kakao Games"]).not.toBe(originalKakaoPaths);
+    });
+
+    it("applies a config target from a partial persisted shape while preserving unrelated default slots", async () => {
+      const applyGameInstallPathTarget = requireGameInstallPathTargetFunction(
+        "applyGameInstallPathTarget",
+      );
+      const currentPath = String.raw`C:\Games\Current POE2`;
+      const selectedPath = String.raw`E:\Games\Selected POE2`;
+      const partialPaths = {
+        "Kakao Games": { POE2: currentPath },
+      };
+      mocks.contextProviderGet.mockReturnValue({
+        getConfig: () => ({ gameInstallPaths: partialPaths }),
+      });
+      mocks.stat.mockResolvedValue({ isFile: () => true });
+
+      await expect(
+        applyGameInstallPathTarget(
+          "Kakao Games",
+          "POE2",
+          { targetId: "config", currentPath },
+          selectedPath,
+        ),
+      ).resolves.toEqual({
+        targetId: "config",
+        status: "applied",
+        path: selectedPath,
+      });
+      expect(mocks.setConfigWithEvent).toHaveBeenCalledWith(
+        "gameInstallPaths",
+        {
+          "Kakao Games": {
+            POE1: DEFAULT_CONFIG.gameInstallPaths["Kakao Games"].POE1,
+            POE2: selectedPath,
+          },
+          GGG: { ...DEFAULT_CONFIG.gameInstallPaths.GGG },
+        },
+      );
+      expect(partialPaths).toEqual({
+        "Kakao Games": { POE2: currentPath },
+      });
+    });
+
+    it("returns a stable stale-snapshot failure for a missing service in a partial persisted shape", async () => {
+      const applyGameInstallPathTarget = requireGameInstallPathTargetFunction(
+        "applyGameInstallPathTarget",
+      );
+      mocks.contextProviderGet.mockReturnValue({
+        getConfig: () => ({
+          gameInstallPaths: {
+            "Kakao Games": { POE2: String.raw`C:\Games\Kakao POE2` },
+          },
+        }),
+      });
+      mocks.stat.mockResolvedValue({ isFile: () => true });
+
+      await expect(
+        applyGameInstallPathTarget(
+          "GGG",
+          "POE2",
+          {
+            targetId: "config",
+            currentPath: String.raw`C:\Games\Expected GGG POE2`,
+          },
+          String.raw`E:\Games\Selected GGG POE2`,
+        ),
+      ).resolves.toEqual({
+        targetId: "config",
+        status: "failed",
+        code: "target-changed",
+        retryable: true,
+      });
+      expect(mocks.setConfigWithEvent).not.toHaveBeenCalled();
+    });
+
+    it("rejects a stale config snapshot without writing", async () => {
+      const applyGameInstallPathTarget = requireGameInstallPathTargetFunction(
+        "applyGameInstallPathTarget",
+      );
+      mocks.contextProviderGet.mockReturnValue(
+        createContext({
+          "Kakao Games": {
+            POE1: "",
+            POE2: String.raw`C:\Games\Current POE2`,
+          },
+          GGG: { POE1: "", POE2: "" },
+        }),
+      );
+      mocks.stat.mockResolvedValue({ isFile: () => true });
+
+      const result = await applyGameInstallPathTarget(
+        "Kakao Games",
+        "POE2",
+        {
+          targetId: "config",
+          currentPath: String.raw`C:\Games\Expected POE2`,
+        },
+        String.raw`E:\Games\Selected POE2`,
+      );
+
+      expect(result).toEqual({
+        targetId: "config",
+        status: "failed",
+        code: "target-changed",
+        retryable: true,
+      });
+      expect(mocks.setConfigWithEvent).not.toHaveBeenCalled();
+      expect(mocks.powershellExecute).not.toHaveBeenCalled();
+    });
+
+    it("returns unchanged for the same config path without writing", async () => {
+      const applyGameInstallPathTarget = requireGameInstallPathTargetFunction(
+        "applyGameInstallPathTarget",
+      );
+      const selectedPath = String.raw`E:\Games\Selected POE2`;
+      mocks.contextProviderGet.mockReturnValue(
+        createContext({
+          "Kakao Games": { POE1: "", POE2: selectedPath },
+          GGG: { POE1: "", POE2: "" },
+        }),
+      );
+      mocks.stat.mockResolvedValue({ isFile: () => true });
+
+      await expect(
+        applyGameInstallPathTarget(
+          "Kakao Games",
+          "POE2",
+          { targetId: "config", currentPath: selectedPath },
+          `${selectedPath}\\`,
+        ),
+      ).resolves.toEqual({
+        targetId: "config",
+        status: "unchanged",
+        path: selectedPath,
+      });
+      expect(mocks.setConfigWithEvent).not.toHaveBeenCalled();
+    });
+
+    it("freshly verifies the selected executable before applying any target", async () => {
+      const applyGameInstallPathTarget = requireGameInstallPathTargetFunction(
+        "applyGameInstallPathTarget",
+      );
+      const selectedPath = String.raw`E:\Games\Missing POE2`;
+      mocks.stat.mockRejectedValue(
+        Object.assign(new Error("missing"), { code: "ENOENT" }),
+      );
+
+      const result = await applyGameInstallPathTarget(
+        "Kakao Games",
+        "POE2",
+        {
+          targetId: "registry-primary",
+          currentPath: null,
+          registryState: "key-missing",
+        },
+        selectedPath,
+      );
+
+      expect(mocks.stat).toHaveBeenCalledWith(
+        `${selectedPath}\\PathOfExile_KG.exe`,
+      );
+      expect(result).toEqual({
+        targetId: "registry-primary",
+        status: "failed",
+        code: "install-path-invalid",
+        retryable: false,
+      });
+      expect(mocks.powershellExecute).not.toHaveBeenCalled();
+      expect(mocks.setConfigWithEvent).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      ["GGG compatibility", "GGG", "registry-compatibility"],
+      ["arbitrary target ID", "Kakao Games", "registry-admin"],
+    ] as const)(
+      "rejects $label before mutation",
+      async (_label, serviceId, targetId) => {
+        const resolveGameInstallPathTarget =
+          requireGameInstallPathTargetFunction("resolveGameInstallPathTarget");
+        const applyGameInstallPathTarget = requireGameInstallPathTargetFunction(
+          "applyGameInstallPathTarget",
+        );
+
+        expect(
+          resolveGameInstallPathTarget(serviceId, "POE2", targetId),
+        ).toEqual({
+          ok: false,
+          code: "target-not-allowed",
+          retryable: false,
+        });
+        await expect(
+          applyGameInstallPathTarget(
+            serviceId,
+            "POE2",
+            {
+              targetId,
+              currentPath: null,
+              registryState: "key-missing",
+            } as GameInstallPathTargetSnapshot,
+            String.raw`E:\Games\Selected POE2`,
+          ),
+        ).resolves.toEqual({
+          targetId,
+          status: "failed",
+          code: "target-not-allowed",
+          retryable: false,
+        });
+        expect(mocks.stat).not.toHaveBeenCalled();
+        expect(mocks.powershellExecute).not.toHaveBeenCalled();
+        expect(mocks.setConfigWithEvent).not.toHaveBeenCalled();
+      },
+    );
   });
 
   it("falls back to reg.exe when the PowerShell session cannot start", async () => {
@@ -975,6 +1913,53 @@ HKEY_CURRENT_USER\\Software\\DaumGames\\POE2
     },
   );
 
+  it("derives the conflict mutation registry identity from targetId and ignores raw spoof fields", async () => {
+    const configPath = String.raw`C:\Games\Path of Exile 2`;
+    const registryPath = String.raw`D:\Games\Path of Exile 2`;
+    const primaryRegistryPath =
+      GAME_INSTALL_REGISTRY_MAP["Kakao Games"].POE2[0].path;
+    const legacyRegistryPath =
+      GAME_INSTALL_REGISTRY_MAP["Kakao Games"].POE2[1].path;
+    let mutationCommand = "";
+    mocks.contextProviderGet.mockReturnValue(
+      createContext({
+        "Kakao Games": { POE1: "", POE2: configPath },
+        GGG: { POE1: "", POE2: "" },
+      }),
+    );
+    mocks.stat.mockResolvedValue({ isFile: () => true });
+    mocks.powershellExecute.mockImplementation(async (command: string) => {
+      if (command.includes("Set-ItemProperty")) {
+        mutationCommand = command;
+        return registryRead("__REG_CONDITIONAL_MUTATED__");
+      }
+      if (commandReadsRegistryPath(command, primaryRegistryPath)) {
+        return registryRead(mutationCommand ? configPath : registryPath);
+      }
+      if (commandReadsRegistryPath(command, legacyRegistryPath)) {
+        return registryRead("__REG_VALUE_MISSING__");
+      }
+      throw new Error(`Unexpected PowerShell command: ${command}`);
+    });
+
+    const result = await resolveGameInstallPathConflict(
+      "Kakao Games",
+      "POE2",
+      "sync-registry",
+      {
+        targetId: "registry-primary",
+        expectedPath: registryPath,
+        expectedConfigPath: configPath,
+        registryPath: legacyRegistryPath,
+        registryValueName: "InstallPath",
+      } as never,
+    );
+
+    expect(result.ok).toBe(true);
+    expect(mutationCommand).toContain("Kakaogames\\POE2");
+    expect(mutationCommand).not.toContain("DaumGames\\POE2");
+  });
+
   it("rejects a registry target outside the service/game allowlist", async () => {
     const configPath = String.raw`C:\Games\Path of Exile 2`;
     const registryPath = String.raw`D:\Games\Path of Exile 2`;
@@ -992,11 +1977,10 @@ HKEY_CURRENT_USER\\Software\\DaumGames\\POE2
       "POE2",
       "sync-registry",
       {
-        registryPath: String.raw`HKCU:\Software\Unexpected\POE2`,
-        registryValueName: "InstallPath",
+        targetId: "untrusted-target",
         expectedPath: registryPath,
         expectedConfigPath: configPath,
-      },
+      } as never,
     );
 
     expect(result.ok).toBe(false);
@@ -1009,7 +1993,7 @@ HKEY_CURRENT_USER\\Software\\DaumGames\\POE2
     expect(result.error).toContain("not allowed");
   });
 
-  it("rejects an allowlisted registry path with the wrong value name", async () => {
+  it("rejects a non-registry target ID for conflict mutation", async () => {
     const configPath = String.raw`C:\Games\Path of Exile 2`;
     const registryPath = String.raw`D:\Games\Path of Exile 2`;
     mocks.contextProviderGet.mockReturnValue(
@@ -1026,9 +2010,10 @@ HKEY_CURRENT_USER\\Software\\DaumGames\\POE2
       "POE2",
       "sync-registry",
       {
-        ...kakaoPoe2ConflictTarget(configPath, registryPath),
-        registryValueName: "UnexpectedValue",
-      },
+        targetId: "config",
+        expectedPath: registryPath,
+        expectedConfigPath: configPath,
+      } as never,
     );
 
     expect(result.ok).toBe(false);

--- a/src/main/tests/registry-install-status.test.ts
+++ b/src/main/tests/registry-install-status.test.ts
@@ -7,8 +7,10 @@ import {
   GAME_INSTALL_REGISTRY_MAP,
   getGameInstallPath,
   getGameInstallPathDiagnostics,
+  getGameInstallPathHealth,
   getGameInstallationStatus,
   isGameInstalled,
+  registerGameInstallPath,
   resolveGameInstallPathConflict,
   setGameInstallPath,
 } from "../utils/registry";
@@ -88,6 +90,35 @@ const mockRegQuery = (implementation: RegQueryImplementation) => {
   mocks.execFile.mockImplementation(implementation);
 };
 
+const registryRead = (stdout: string) => ({ stdout, stderr: "", code: 0 });
+
+const commandReadsRegistryPath = (command: string, registryPath: string) =>
+  command.includes(
+    registryPath.replace("HKCU:\\", "Registry::HKEY_CURRENT_USER\\"),
+  );
+
+const kakaoPoe2RegistryTarget = (
+  expectedPath: string,
+  candidateIndex: 0 | 1 = 0,
+) => {
+  const candidate =
+    GAME_INSTALL_REGISTRY_MAP["Kakao Games"].POE2[candidateIndex];
+  return {
+    registryPath: candidate.path,
+    registryValueName: candidate.key,
+    expectedPath,
+  };
+};
+
+const kakaoPoe2ConflictTarget = (
+  expectedConfigPath: string,
+  expectedRegistryPath: string,
+  candidateIndex: 0 | 1 = 0,
+) => ({
+  ...kakaoPoe2RegistryTarget(expectedRegistryPath, candidateIndex),
+  expectedConfigPath,
+});
+
 describe("registry install status", () => {
   beforeEach(() => {
     mocks.execFile.mockReset();
@@ -109,6 +140,13 @@ describe("registry install status", () => {
     const installPath = String.raw`C:\Games\Path of Exile 2`;
     mocks.powershellExecute.mockRejectedValue(new Error("spawn EPERM"));
     mockRegQuery((_command, args, _options, callback) => {
+      const registryPath = args[1];
+
+      if (registryPath === "HKCU\\Software\\Kakaogames\\POE2") {
+        callback(Object.assign(new Error("missing"), { code: 1 }), "", "");
+        return {} as ChildProcess;
+      }
+
       expect(args).toEqual([
         "query",
         "HKCU\\Software\\DaumGames\\POE2",
@@ -151,7 +189,328 @@ HKEY_CURRENT_USER\\Software\\DaumGames\\POE2
     );
 
     expect(mocks.stat).toHaveBeenCalledWith(`${installPath}\\PathOfExile.exe`);
+    expect(GAME_INSTALL_REGISTRY_MAP.GGG.POE2).toHaveLength(1);
   });
+
+  it.each(["absent", "invalid", "unknown"] as const)(
+    "keeps a valid Kakao config installed with a %s registry advisory",
+    async (registryState) => {
+      const configPath = String.raw`C:\Games\Path of Exile 2`;
+      const invalidRegistryPath = String.raw`D:\Old\Path of Exile 2`;
+      mocks.contextProviderGet.mockReturnValue(
+        createContext({
+          "Kakao Games": { POE1: "", POE2: configPath },
+          GGG: { POE1: "", POE2: "" },
+        }),
+      );
+      mocks.stat.mockImplementation(async (filePath: string) => {
+        if (filePath.startsWith(configPath)) return { isFile: () => true };
+        throw Object.assign(new Error("missing"), { code: "ENOENT" });
+      });
+
+      if (registryState === "unknown") {
+        mocks.powershellExecute.mockRejectedValue(new Error("spawn EPERM"));
+        mockRegQuery((_command, _args, _options, callback) => {
+          callback(
+            Object.assign(new Error("access denied"), { code: "EPERM" }),
+            "",
+            "access denied",
+          );
+          return {} as ChildProcess;
+        });
+      } else {
+        mocks.powershellExecute.mockResolvedValue(
+          registryRead(
+            registryState === "absent"
+              ? "__REG_VALUE_MISSING__"
+              : invalidRegistryPath,
+          ),
+        );
+      }
+
+      await expect(
+        getGameInstallPathHealth("Kakao Games", "POE2", 1234),
+      ).resolves.toEqual({
+        installationStatus: "installed",
+        checkedAt: 1234,
+        registryAdvisory: { state: registryState },
+      });
+    },
+  );
+
+  it.each([0, 1] as const)(
+    "clears the advisory when Kakao registry candidate %i is valid",
+    async (activeCandidateIndex) => {
+      const configPath = String.raw`C:\Games\Path of Exile 2`;
+      const registryPath = String.raw`D:\Games\Path of Exile 2`;
+      mocks.contextProviderGet.mockReturnValue(
+        createContext({
+          "Kakao Games": { POE1: "", POE2: configPath },
+          GGG: { POE1: "", POE2: "" },
+        }),
+      );
+      mocks.powershellExecute.mockImplementation(async (command: string) => {
+        const activeCandidate =
+          GAME_INSTALL_REGISTRY_MAP["Kakao Games"].POE2[activeCandidateIndex];
+        return commandReadsRegistryPath(command, activeCandidate.path)
+          ? registryRead(registryPath)
+          : registryRead("__REG_VALUE_MISSING__");
+      });
+      mocks.stat.mockResolvedValue({ isFile: () => true });
+
+      await expect(
+        getGameInstallPathHealth("Kakao Games", "POE2", 5678),
+      ).resolves.toEqual({
+        installationStatus: "installed",
+        checkedAt: 5678,
+      });
+    },
+  );
+
+  it("does not read registry advisory health for a valid GGG config path", async () => {
+    const configPath = String.raw`C:\Games\Path of Exile 2`;
+    mocks.contextProviderGet.mockReturnValue(
+      createContext({
+        "Kakao Games": { POE1: "", POE2: "" },
+        GGG: { POE1: "", POE2: configPath },
+      }),
+    );
+    mocks.stat.mockResolvedValue({ isFile: () => true });
+
+    await expect(
+      getGameInstallPathHealth("GGG", "POE2", 9012),
+    ).resolves.toEqual({
+      installationStatus: "installed",
+      checkedAt: 9012,
+    });
+    expect(mocks.powershellExecute).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["ENOENT", "uninstalled"],
+    ["EACCES", "unknown"],
+  ] as const)(
+    "keeps an invalid config and absent registry install result honest (%s)",
+    async (errorCode, installationStatus) => {
+      const stalePath = String.raw`C:\Old\Path of Exile 2`;
+      mocks.contextProviderGet.mockReturnValue(
+        createContext({
+          "Kakao Games": { POE1: "", POE2: stalePath },
+          GGG: { POE1: "", POE2: "" },
+        }),
+      );
+      mocks.stat.mockRejectedValue(
+        Object.assign(new Error("path check failed"), { code: errorCode }),
+      );
+      mocks.powershellExecute.mockResolvedValue(
+        registryRead("__REG_VALUE_MISSING__"),
+      );
+
+      await expect(
+        getGameInstallPathHealth("Kakao Games", "POE2", 3456),
+      ).resolves.toEqual({
+        installationStatus,
+        checkedAt: 3456,
+      });
+    },
+  );
+
+  it("selects the primary Kakaogames candidate when both candidates are valid", async () => {
+    const primaryPath = String.raw`C:\Games\Path of Exile 2`;
+    const legacyPath = String.raw`D:\Games\Path of Exile 2`;
+    mocks.powershellExecute.mockImplementation(async (command: string) => {
+      if (
+        commandReadsRegistryPath(
+          command,
+          GAME_INSTALL_REGISTRY_MAP["Kakao Games"].POE2[0].path,
+        )
+      ) {
+        return registryRead(primaryPath);
+      }
+
+      return registryRead(legacyPath);
+    });
+    mocks.stat.mockResolvedValue({ isFile: () => true });
+
+    const diagnostics = await getGameInstallPathDiagnostics(
+      "Kakao Games",
+      "POE2",
+    );
+
+    expect(diagnostics.registry.path).toBe(primaryPath);
+    expect(diagnostics.registry.registryPath).toBe(
+      GAME_INSTALL_REGISTRY_MAP["Kakao Games"].POE2[0].path,
+    );
+    expect(diagnostics.registry.aggregateState).toBe("valid");
+    expect(diagnostics.registry.candidates).toEqual([
+      expect.objectContaining({ path: primaryPath, isActive: true }),
+      expect.objectContaining({ path: legacyPath, isActive: false }),
+    ]);
+  });
+
+  it.each([
+    "missing",
+    "empty",
+    "invalid",
+    "read-failed",
+    "verify-unknown",
+  ] as const)(
+    "continues to the legacy candidate when the primary candidate is %s",
+    async (primaryState) => {
+      const primaryPath = String.raw`C:\Broken\Path of Exile 2`;
+      const legacyPath = String.raw`D:\Games\Path of Exile 2`;
+      mocks.contextProviderGet.mockReturnValue(
+        createContext({
+          "Kakao Games": { POE1: "", POE2: "" },
+          GGG: { POE1: "", POE2: "" },
+        }),
+      );
+      const primaryRegistryPath =
+        GAME_INSTALL_REGISTRY_MAP["Kakao Games"].POE2[0].path;
+      const legacyRegistryPath =
+        GAME_INSTALL_REGISTRY_MAP["Kakao Games"].POE2[1].path;
+
+      mocks.powershellExecute.mockImplementation(async (command: string) => {
+        if (commandReadsRegistryPath(command, primaryRegistryPath)) {
+          if (primaryState === "missing") {
+            return registryRead("__REG_KEY_MISSING__");
+          }
+          if (primaryState === "empty") {
+            return registryRead("__REG_VALUE_EMPTY__");
+          }
+          if (primaryState === "read-failed") {
+            return { stdout: "", stderr: "access denied", code: 5 };
+          }
+          return registryRead(primaryPath);
+        }
+
+        if (commandReadsRegistryPath(command, legacyRegistryPath)) {
+          return registryRead(legacyPath);
+        }
+
+        throw new Error(`Unexpected PowerShell command: ${command}`);
+      });
+      mockRegQuery((_command, _args, _options, callback) => {
+        callback(
+          Object.assign(new Error("access denied"), { code: "EPERM" }),
+          "",
+          "access denied",
+        );
+        return {} as ChildProcess;
+      });
+      mocks.stat.mockImplementation(async (targetPath: string) => {
+        if (targetPath === `${primaryPath}\\PathOfExile_KG.exe`) {
+          if (primaryState === "invalid") {
+            throw Object.assign(new Error("missing"), { code: "ENOENT" });
+          }
+          if (primaryState === "verify-unknown") {
+            throw Object.assign(new Error("access denied"), {
+              code: "EACCES",
+            });
+          }
+        }
+
+        return { isFile: () => true };
+      });
+
+      const diagnostics = await getGameInstallPathDiagnostics(
+        "Kakao Games",
+        "POE2",
+      );
+
+      expect(diagnostics.registry.path).toBe(legacyPath);
+      expect(diagnostics.registry.registryPath).toBe(legacyRegistryPath);
+      expect(diagnostics.registry.aggregateState).toBe("valid");
+      expect(diagnostics.registry.candidates[1]).toEqual(
+        expect.objectContaining({ path: legacyPath, isActive: true }),
+      );
+      await expect(getGameInstallPath("Kakao Games", "POE2")).resolves.toBe(
+        legacyPath,
+      );
+      await expect(
+        getGameInstallationStatus("Kakao Games", "POE2"),
+      ).resolves.toBe("installed");
+      expect(mocks.setConfigWithEvent).toHaveBeenCalledWith(
+        "gameInstallPaths",
+        expect.objectContaining({
+          "Kakao Games": expect.objectContaining({ POE2: legacyPath }),
+        }),
+      );
+    },
+  );
+
+  it("resolves and caches the POE1 legacy candidate when the primary key is missing", async () => {
+    const legacyPath = String.raw`D:\Games\Path of Exile`;
+    mocks.contextProviderGet.mockReturnValue(
+      createContext({
+        "Kakao Games": { POE1: "", POE2: "" },
+        GGG: { POE1: "", POE2: "" },
+      }),
+    );
+    mocks.powershellExecute.mockImplementation(async (command: string) => {
+      if (
+        commandReadsRegistryPath(
+          command,
+          GAME_INSTALL_REGISTRY_MAP["Kakao Games"].POE1[0].path,
+        )
+      ) {
+        return registryRead("__REG_KEY_MISSING__");
+      }
+      return registryRead(legacyPath);
+    });
+    mocks.stat.mockResolvedValue({ isFile: () => true });
+
+    await expect(getGameInstallPath("Kakao Games", "POE1")).resolves.toBe(
+      legacyPath,
+    );
+    await expect(
+      getGameInstallationStatus("Kakao Games", "POE1"),
+    ).resolves.toBe("installed");
+    expect(mocks.setConfigWithEvent).toHaveBeenCalledWith(
+      "gameInstallPaths",
+      expect.objectContaining({
+        "Kakao Games": expect.objectContaining({ POE1: legacyPath }),
+      }),
+    );
+  });
+
+  it.each(["absent", "invalid"] as const)(
+    "returns unknown when the primary read fails and the legacy candidate is %s",
+    async (legacyState) => {
+      const legacyPath = String.raw`D:\Broken\Path of Exile 2`;
+      mocks.powershellExecute.mockImplementation(async (command: string) => {
+        if (
+          commandReadsRegistryPath(
+            command,
+            GAME_INSTALL_REGISTRY_MAP["Kakao Games"].POE2[0].path,
+          )
+        ) {
+          return { stdout: "", stderr: "access denied", code: 5 };
+        }
+        return registryRead(
+          legacyState === "absent" ? "__REG_VALUE_MISSING__" : legacyPath,
+        );
+      });
+      mockRegQuery((_command, _args, _options, callback) => {
+        callback(
+          Object.assign(new Error("access denied"), { code: "EPERM" }),
+          "",
+          "access denied",
+        );
+        return {} as ChildProcess;
+      });
+      mocks.stat.mockRejectedValue(
+        Object.assign(new Error("missing"), { code: "ENOENT" }),
+      );
+
+      await expect(
+        getGameInstallationStatus("Kakao Games", "POE2"),
+      ).resolves.toBe("unknown");
+      expect(mocks.loggerWarn).toHaveBeenCalledWith(
+        expect.stringContaining("registry=read-failed"),
+      );
+    },
+  );
 
   it("returns unknown instead of uninstalled when registry access fails", async () => {
     mocks.powershellExecute.mockRejectedValue(new Error("spawn EPERM"));
@@ -168,8 +527,18 @@ HKEY_CURRENT_USER\\Software\\DaumGames\\POE2
       getGameInstallationStatus("Kakao Games", "POE2"),
     ).resolves.toBe("unknown");
     await expect(isGameInstalled("Kakao Games", "POE2")).resolves.toBe(false);
+    const diagnostics = await getGameInstallPathDiagnostics(
+      "Kakao Games",
+      "POE2",
+    );
 
     expect(mocks.stat).not.toHaveBeenCalled();
+    expect(diagnostics.registry.aggregateState).toBe("unknown");
+    expect(
+      diagnostics.registry.candidates.every(
+        (candidate) => candidate.state === "read-failed",
+      ),
+    ).toBe(true);
     expect(mocks.loggerWarn).toHaveBeenCalledWith(
       expect.stringContaining("registry=read-failed"),
     );
@@ -212,7 +581,7 @@ HKEY_CURRENT_USER\\Software\\DaumGames\\POE2
     );
   });
 
-  it("uses a configured install path before checking the registry", async () => {
+  it("keeps a valid configured path installed without reading missing registry candidates", async () => {
     const installPath = String.raw`C:\Games\Path of Exile 2`;
     mocks.contextProviderGet.mockReturnValue(
       createContext({
@@ -231,6 +600,9 @@ HKEY_CURRENT_USER\\Software\\DaumGames\\POE2
     await expect(getGameInstallPath("Kakao Games", "POE2")).resolves.toBe(
       installPath,
     );
+    await expect(
+      getGameInstallationStatus("Kakao Games", "POE2"),
+    ).resolves.toBe("installed");
 
     expect(mocks.powershellExecute).not.toHaveBeenCalled();
     expect(mocks.execFile).not.toHaveBeenCalled();
@@ -379,6 +751,7 @@ HKEY_CURRENT_USER\\Software\\DaumGames\\POE2
       "Kakao Games",
       "POE2",
       "launcher-config-only",
+      kakaoPoe2ConflictTarget(configPath, registryPath),
     );
 
     expect(result.ok).toBe(true);
@@ -471,12 +844,22 @@ HKEY_CURRENT_USER\\Software\\DaumGames\\POE2
         code: 0,
       })
       .mockResolvedValueOnce({
-        stdout: "",
+        stdout: "__REG_VALUE_MISSING__",
+        stderr: "",
+        code: 0,
+      })
+      .mockResolvedValueOnce({
+        stdout: "__REG_CONDITIONAL_MUTATED__",
         stderr: "",
         code: 0,
       })
       .mockResolvedValueOnce({
         stdout: configPath,
+        stderr: "",
+        code: 0,
+      })
+      .mockResolvedValueOnce({
+        stdout: "__REG_VALUE_MISSING__",
         stderr: "",
         code: 0,
       });
@@ -485,19 +868,17 @@ HKEY_CURRENT_USER\\Software\\DaumGames\\POE2
       "Kakao Games",
       "POE2",
       "sync-registry",
+      kakaoPoe2ConflictTarget(configPath, registryPath),
     );
 
     expect(result.ok).toBe(true);
-    expect(mocks.powershellExecute).toHaveBeenNthCalledWith(
-      2,
-      expect.stringContaining("New-ItemProperty"),
-      false,
+    const conditionalCommand = mocks.powershellExecute.mock.calls[2][0];
+    expect(conditionalCommand).toContain(`$expectedPath = '${registryPath}'`);
+    expect(conditionalCommand).toContain(
+      "$currentNormalized -ine $expectedNormalized",
     );
-    expect(mocks.powershellExecute).toHaveBeenNthCalledWith(
-      2,
-      expect.stringContaining(configPath),
-      false,
-    );
+    expect(conditionalCommand).toContain("Set-ItemProperty");
+    expect(conditionalCommand).toContain(configPath);
     expect(mocks.setConfigWithEvent).toHaveBeenCalledWith(
       "gameInstallPathConflictResolutions",
       {
@@ -511,6 +892,511 @@ HKEY_CURRENT_USER\\Software\\DaumGames\\POE2
         },
       },
     );
+  });
+
+  it.each([
+    ["launcher-config-only", "mismatch"],
+    ["launcher-config-only", "missing"],
+    ["launcher-config-only", "read-failed"],
+    ["sync-registry", "mismatch"],
+    ["sync-registry", "missing"],
+    ["sync-registry", "read-failed"],
+  ] as const)(
+    "rejects %s when the exact target fresh read is %s",
+    async (action, freshState) => {
+      const configPath = String.raw`C:\Games\Path of Exile 2`;
+      const registryPath = String.raw`D:\Games\Path of Exile 2`;
+      const changedPath = String.raw`E:\Moved\Path of Exile 2`;
+      const primaryRegistryPath =
+        GAME_INSTALL_REGISTRY_MAP["Kakao Games"].POE2[0].path;
+      let primaryReadCount = 0;
+      mocks.contextProviderGet.mockReturnValue(
+        createContext({
+          "Kakao Games": { POE1: "", POE2: configPath },
+          GGG: { POE1: "", POE2: "" },
+        }),
+      );
+      mocks.stat.mockResolvedValue({ isFile: () => true });
+      mocks.powershellExecute.mockImplementation(async (command: string) => {
+        if (command.includes("Set-ItemProperty")) {
+          expect(action).toBe("sync-registry");
+          if (freshState === "missing") {
+            return registryRead("__REG_CONDITIONAL_MISSING__");
+          }
+          if (freshState === "read-failed") {
+            return registryRead(
+              "__REG_CONDITIONAL_READ_FAILED__\naccess denied",
+            );
+          }
+          return registryRead("__REG_CONDITIONAL_CHANGED__");
+        }
+        if (commandReadsRegistryPath(command, primaryRegistryPath)) {
+          primaryReadCount += 1;
+          if (primaryReadCount === 2) {
+            if (freshState === "missing") {
+              return registryRead("__REG_VALUE_MISSING__");
+            }
+            if (freshState === "read-failed") {
+              return { stdout: "", stderr: "access denied", code: 5 };
+            }
+            return registryRead(changedPath);
+          }
+          return registryRead(registryPath);
+        }
+        return registryRead("__REG_VALUE_MISSING__");
+      });
+      mockRegQuery((_command, _args, _options, callback) => {
+        callback(
+          Object.assign(new Error("access denied"), { code: "EPERM" }),
+          "",
+          "access denied",
+        );
+        return {} as ChildProcess;
+      });
+
+      const result = await resolveGameInstallPathConflict(
+        "Kakao Games",
+        "POE2",
+        action,
+        kakaoPoe2ConflictTarget(configPath, registryPath),
+      );
+
+      expect(result.ok).toBe(false);
+      const conditionalCommands = mocks.powershellExecute.mock.calls.filter(
+        ([command]) => String(command).includes("Set-ItemProperty"),
+      );
+      expect(conditionalCommands).toHaveLength(
+        action === "sync-registry" ? 1 : 0,
+      );
+      expect(mocks.setConfigWithEvent).not.toHaveBeenCalled();
+      if (result.ok) throw new Error("Expected target validation to fail");
+      expect(result.diagnostics).toBeDefined();
+      expect(result.error).toMatch(/changed|missing|could not be read/i);
+    },
+  );
+
+  it("rejects a registry target outside the service/game allowlist", async () => {
+    const configPath = String.raw`C:\Games\Path of Exile 2`;
+    const registryPath = String.raw`D:\Games\Path of Exile 2`;
+    mocks.contextProviderGet.mockReturnValue(
+      createContext({
+        "Kakao Games": { POE1: "", POE2: configPath },
+        GGG: { POE1: "", POE2: "" },
+      }),
+    );
+    mocks.stat.mockResolvedValue({ isFile: () => true });
+    mocks.powershellExecute.mockResolvedValue(registryRead(registryPath));
+
+    const result = await resolveGameInstallPathConflict(
+      "Kakao Games",
+      "POE2",
+      "sync-registry",
+      {
+        registryPath: String.raw`HKCU:\Software\Unexpected\POE2`,
+        registryValueName: "InstallPath",
+        expectedPath: registryPath,
+        expectedConfigPath: configPath,
+      },
+    );
+
+    expect(result.ok).toBe(false);
+    expect(
+      mocks.powershellExecute.mock.calls.some(([command]) =>
+        String(command).includes("Set-ItemProperty"),
+      ),
+    ).toBe(false);
+    if (result.ok) throw new Error("Expected allowlist validation to fail");
+    expect(result.error).toContain("not allowed");
+  });
+
+  it("rejects an allowlisted registry path with the wrong value name", async () => {
+    const configPath = String.raw`C:\Games\Path of Exile 2`;
+    const registryPath = String.raw`D:\Games\Path of Exile 2`;
+    mocks.contextProviderGet.mockReturnValue(
+      createContext({
+        "Kakao Games": { POE1: "", POE2: configPath },
+        GGG: { POE1: "", POE2: "" },
+      }),
+    );
+    mocks.stat.mockResolvedValue({ isFile: () => true });
+    mocks.powershellExecute.mockResolvedValue(registryRead(registryPath));
+
+    const result = await resolveGameInstallPathConflict(
+      "Kakao Games",
+      "POE2",
+      "sync-registry",
+      {
+        ...kakaoPoe2ConflictTarget(configPath, registryPath),
+        registryValueName: "UnexpectedValue",
+      },
+    );
+
+    expect(result.ok).toBe(false);
+    expect(
+      mocks.powershellExecute.mock.calls.some(([command]) =>
+        String(command).includes("Set-ItemProperty"),
+      ),
+    ).toBe(false);
+    if (result.ok) throw new Error("Expected value-name allowlist failure");
+    expect(result.error).toContain("not allowed");
+  });
+
+  it("rejects conflict actions when the launcher config changed after confirmation", async () => {
+    const currentConfigPath = String.raw`C:\Current\Path of Exile 2`;
+    const expectedConfigPath = String.raw`C:\Previous\Path of Exile 2`;
+    const registryPath = String.raw`D:\Games\Path of Exile 2`;
+    mocks.contextProviderGet.mockReturnValue(
+      createContext({
+        "Kakao Games": { POE1: "", POE2: currentConfigPath },
+        GGG: { POE1: "", POE2: "" },
+      }),
+    );
+    mocks.stat.mockResolvedValue({ isFile: () => true });
+    mocks.powershellExecute.mockResolvedValue(registryRead(registryPath));
+
+    const result = await resolveGameInstallPathConflict(
+      "Kakao Games",
+      "POE2",
+      "sync-registry",
+      kakaoPoe2ConflictTarget(expectedConfigPath, registryPath),
+    );
+
+    expect(result.ok).toBe(false);
+    expect(
+      mocks.powershellExecute.mock.calls.some(([command]) =>
+        String(command).includes("Set-ItemProperty"),
+      ),
+    ).toBe(false);
+    expect(mocks.setConfigWithEvent).not.toHaveBeenCalled();
+    if (result.ok) throw new Error("Expected config snapshot mismatch");
+    expect(result.error).toContain("config path changed");
+  });
+
+  it("returns fresh diagnostics when conditional registry sync mutation fails", async () => {
+    const configPath = String.raw`C:\Games\Path of Exile 2`;
+    const registryPath = String.raw`D:\Games\Path of Exile 2`;
+    const changedPath = String.raw`E:\Moved\Path of Exile 2`;
+    const primaryRegistryPath =
+      GAME_INSTALL_REGISTRY_MAP["Kakao Games"].POE2[0].path;
+    let mutationAttempted = false;
+    mocks.contextProviderGet.mockReturnValue(
+      createContext({
+        "Kakao Games": { POE1: "", POE2: configPath },
+        GGG: { POE1: "", POE2: "" },
+      }),
+    );
+    mocks.stat.mockResolvedValue({ isFile: () => true });
+    mocks.powershellExecute.mockImplementation(async (command: string) => {
+      if (command.includes("Set-ItemProperty")) {
+        mutationAttempted = true;
+        return registryRead(
+          "__REG_CONDITIONAL_MUTATION_FAILED__\naccess denied",
+        );
+      }
+      if (commandReadsRegistryPath(command, primaryRegistryPath)) {
+        return registryRead(mutationAttempted ? changedPath : registryPath);
+      }
+      return registryRead("__REG_VALUE_MISSING__");
+    });
+
+    const result = await resolveGameInstallPathConflict(
+      "Kakao Games",
+      "POE2",
+      "sync-registry",
+      kakaoPoe2ConflictTarget(configPath, registryPath),
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("Expected conditional mutation failure");
+    expect(result.error).toContain("mutation failed");
+    expect(result.diagnostics?.registry.path).toBe(changedPath);
+    expect(mocks.setConfigWithEvent).not.toHaveBeenCalled();
+  });
+
+  it("rejects a mutated marker when PowerShell exits nonzero", async () => {
+    const configPath = String.raw`C:\Games\Path of Exile 2`;
+    const registryPath = String.raw`D:\Games\Path of Exile 2`;
+    const primaryRegistryPath =
+      GAME_INSTALL_REGISTRY_MAP["Kakao Games"].POE2[0].path;
+    mocks.contextProviderGet.mockReturnValue(
+      createContext({
+        "Kakao Games": { POE1: "", POE2: configPath },
+        GGG: { POE1: "", POE2: "" },
+      }),
+    );
+    mocks.stat.mockResolvedValue({ isFile: () => true });
+    mocks.powershellExecute.mockImplementation(async (command: string) => {
+      if (command.includes("Set-ItemProperty")) {
+        return {
+          stdout: "__REG_CONDITIONAL_MUTATED__",
+          stderr: "process failed",
+          code: 1,
+        };
+      }
+      if (commandReadsRegistryPath(command, primaryRegistryPath)) {
+        return registryRead(registryPath);
+      }
+      return registryRead("__REG_VALUE_MISSING__");
+    });
+
+    const result = await resolveGameInstallPathConflict(
+      "Kakao Games",
+      "POE2",
+      "sync-registry",
+      kakaoPoe2ConflictTarget(configPath, registryPath),
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("Expected nonzero mutation marker failure");
+    expect(result.error).toContain("mutation failed");
+    expect(result.error).toContain("code 1");
+    expect(mocks.setConfigWithEvent).not.toHaveBeenCalled();
+  });
+
+  it("syncs the exact legacy target when the primary candidate cannot be read", async () => {
+    const configPath = String.raw`C:\Games\Path of Exile 2`;
+    const legacyPath = String.raw`D:\Games\Path of Exile 2`;
+    const primaryRegistryPath =
+      GAME_INSTALL_REGISTRY_MAP["Kakao Games"].POE2[0].path;
+    const legacyRegistryPath =
+      GAME_INSTALL_REGISTRY_MAP["Kakao Games"].POE2[1].path;
+    let writeCompleted = false;
+    mocks.contextProviderGet.mockReturnValue(
+      createContext({
+        "Kakao Games": { POE1: "", POE2: configPath },
+        GGG: { POE1: "", POE2: "" },
+      }),
+    );
+    mocks.stat.mockResolvedValue({ isFile: () => true });
+    mocks.powershellExecute.mockImplementation(async (command: string) => {
+      if (command.includes("Set-ItemProperty")) {
+        expect(command).toContain("DaumGames\\POE2");
+        expect(command).toContain(`$expectedPath = '${legacyPath}'`);
+        writeCompleted = true;
+        return registryRead("__REG_CONDITIONAL_MUTATED__");
+      }
+      if (commandReadsRegistryPath(command, primaryRegistryPath)) {
+        return { stdout: "", stderr: "access denied", code: 5 };
+      }
+      if (commandReadsRegistryPath(command, legacyRegistryPath)) {
+        return registryRead(writeCompleted ? configPath : legacyPath);
+      }
+      throw new Error(`Unexpected PowerShell command: ${command}`);
+    });
+    mockRegQuery((_command, _args, _options, callback) => {
+      callback(
+        Object.assign(new Error("access denied"), { code: "EPERM" }),
+        "",
+        "access denied",
+      );
+      return {} as ChildProcess;
+    });
+
+    const result = await resolveGameInstallPathConflict(
+      "Kakao Games",
+      "POE2",
+      "sync-registry",
+      kakaoPoe2ConflictTarget(configPath, legacyPath, 1),
+    );
+
+    expect(result.ok).toBe(true);
+    expect(writeCompleted).toBe(true);
+  });
+
+  it("registers only the canonical Kakaogames value after checking both candidates in one command", async () => {
+    const configPath = String.raw`C:\Games\Path of Exile 2`;
+    const primaryRegistryPath =
+      GAME_INSTALL_REGISTRY_MAP["Kakao Games"].POE2[0].path;
+    const legacyRegistryPath =
+      GAME_INSTALL_REGISTRY_MAP["Kakao Games"].POE2[1].path;
+    let registered = false;
+    mocks.contextProviderGet.mockReturnValue(
+      createContext({
+        "Kakao Games": { POE1: "", POE2: configPath },
+        GGG: { POE1: "", POE2: "" },
+      }),
+    );
+    mocks.stat.mockResolvedValue({ isFile: () => true });
+    mocks.powershellExecute.mockImplementation(async (command: string) => {
+      if (command.includes("__REG_REGISTERED__")) {
+        registered = true;
+        return registryRead("__REG_REGISTERED__");
+      }
+      if (commandReadsRegistryPath(command, primaryRegistryPath)) {
+        return registryRead(registered ? configPath : "__REG_VALUE_MISSING__");
+      }
+      if (commandReadsRegistryPath(command, legacyRegistryPath)) {
+        return registryRead("__REG_VALUE_MISSING__");
+      }
+      throw new Error(`Unexpected PowerShell command: ${command}`);
+    });
+
+    const result = await registerGameInstallPath("Kakao Games", "POE2", {
+      expectedConfigPath: configPath,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok)
+      throw new Error("Expected registry registration to succeed");
+    expect(result.registryPath).toBe(primaryRegistryPath);
+    expect(result.registryValueName).toBe("InstallPath");
+    expect(result.diagnostics.registry.path).toBe(configPath);
+
+    const registrationCommands = mocks.powershellExecute.mock.calls.filter(
+      ([command]) => String(command).includes("__REG_REGISTERED__"),
+    );
+    expect(registrationCommands).toHaveLength(1);
+    const registrationCommand = String(registrationCommands[0][0]);
+    expect(registrationCommand).toContain("Kakaogames\\POE2");
+    expect(registrationCommand).toContain("DaumGames\\POE2");
+    expect(registrationCommand).toContain(
+      "Assert-RegistryValueAbsent $canonicalPath $canonicalName",
+    );
+    expect(registrationCommand).toContain(
+      "Assert-RegistryValueAbsent $legacyPath $legacyName",
+    );
+    expect(registrationCommand).toContain(
+      "New-ItemProperty -LiteralPath $canonicalPath",
+    );
+    expect(registrationCommand).not.toContain(
+      "New-ItemProperty -LiteralPath $legacyPath",
+    );
+    expect(registrationCommand).not.toContain("Remove-Item");
+    expect(registrationCommand).toContain("-PropertyType String");
+    expect(registrationCommand).toContain("$createdItem.GetValue");
+  });
+
+  it.each([
+    ["a nonempty candidate", "__REG_REGISTER_CHANGED__", /changed/i],
+    [
+      "a candidate read failure",
+      "__REG_REGISTER_READ_FAILED__\naccess denied",
+      /could not be read/i,
+    ],
+    [
+      "a mutation failure",
+      "__REG_REGISTER_MUTATION_FAILED__\naccess denied",
+      /registration failed/i,
+    ],
+    [
+      "a read-back failure",
+      "__REG_REGISTER_READBACK_FAILED__",
+      /could not be verified/i,
+    ],
+  ] as const)(
+    "does not report registry registration success for %s",
+    async (_failureCase, marker, expectedError) => {
+      const configPath = String.raw`C:\Games\Path of Exile 2`;
+      mocks.contextProviderGet.mockReturnValue(
+        createContext({
+          "Kakao Games": { POE1: "", POE2: configPath },
+          GGG: { POE1: "", POE2: "" },
+        }),
+      );
+      mocks.stat.mockResolvedValue({ isFile: () => true });
+      mocks.powershellExecute.mockImplementation(async (command: string) => {
+        if (command.includes("__REG_REGISTERED__")) {
+          return registryRead(marker);
+        }
+        return registryRead("__REG_VALUE_MISSING__");
+      });
+
+      const result = await registerGameInstallPath("Kakao Games", "POE2", {
+        expectedConfigPath: configPath,
+      });
+
+      expect(result.ok).toBe(false);
+      if (result.ok) throw new Error("Expected registry registration to fail");
+      expect(result.error).toMatch(expectedError);
+      expect(result.diagnostics).toBeDefined();
+      const registrationCommands = mocks.powershellExecute.mock.calls.filter(
+        ([command]) => String(command).includes("__REG_REGISTERED__"),
+      );
+      expect(registrationCommands).toHaveLength(1);
+      const registrationCommand = String(registrationCommands[0][0]);
+      expect(registrationCommand.indexOf("$canonicalAbsent")).toBeLessThan(
+        registrationCommand.indexOf("New-ItemProperty"),
+      );
+      expect(registrationCommand.indexOf("$legacyAbsent")).toBeLessThan(
+        registrationCommand.indexOf("New-ItemProperty"),
+      );
+    },
+  );
+
+  it("rejects a registered marker when PowerShell exits nonzero", async () => {
+    const configPath = String.raw`C:\Games\Path of Exile 2`;
+    mocks.contextProviderGet.mockReturnValue(
+      createContext({
+        "Kakao Games": { POE1: "", POE2: configPath },
+        GGG: { POE1: "", POE2: "" },
+      }),
+    );
+    mocks.stat.mockResolvedValue({ isFile: () => true });
+    mocks.powershellExecute.mockImplementation(async (command: string) => {
+      if (command.includes("__REG_REGISTERED__")) {
+        return {
+          stdout: "__REG_REGISTERED__",
+          stderr: "process failed",
+          code: 1,
+        };
+      }
+      return registryRead("__REG_VALUE_MISSING__");
+    });
+
+    const result = await registerGameInstallPath("Kakao Games", "POE2", {
+      expectedConfigPath: configPath,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("Expected nonzero registration failure");
+    expect(result.error).toContain("registration failed");
+    expect(result.error).toContain("code 1");
+  });
+
+  it("does not start registry registration when the config snapshot changed", async () => {
+    const configPath = String.raw`C:\Games\Current Path of Exile 2`;
+    mocks.contextProviderGet.mockReturnValue(
+      createContext({
+        "Kakao Games": { POE1: "", POE2: configPath },
+        GGG: { POE1: "", POE2: "" },
+      }),
+    );
+    mocks.stat.mockResolvedValue({ isFile: () => true });
+    mocks.powershellExecute.mockResolvedValue(
+      registryRead("__REG_VALUE_MISSING__"),
+    );
+
+    const result = await registerGameInstallPath("Kakao Games", "POE2", {
+      expectedConfigPath: String.raw`C:\Games\Previous Path of Exile 2`,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(
+      mocks.powershellExecute.mock.calls.some(([command]) =>
+        String(command).includes("__REG_REGISTERED__"),
+      ),
+    ).toBe(false);
+    if (result.ok) throw new Error("Expected config snapshot mismatch");
+    expect(result.error).toContain("config path changed");
+  });
+
+  it("rejects registry registration for GGG without creating a value", async () => {
+    mocks.powershellExecute.mockResolvedValue(
+      registryRead("__REG_VALUE_MISSING__"),
+    );
+
+    const result = await registerGameInstallPath("GGG", "POE2", {
+      expectedConfigPath: String.raw`C:\Games\Path of Exile 2`,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(
+      mocks.powershellExecute.mock.calls.some(([command]) =>
+        String(command).includes("__REG_REGISTERED__"),
+      ),
+    ).toBe(false);
+    if (result.ok) throw new Error("Expected GGG registration rejection");
+    expect(result.error).toContain("only supported for Kakao Games");
   });
 
   it("saves a manually selected install path only after executable verification", async () => {
@@ -634,7 +1520,7 @@ HKEY_CURRENT_USER\\Software\\DaumGames\\POE2
     );
     mocks.powershellExecute
       .mockResolvedValueOnce({
-        stdout: "",
+        stdout: "__REG_CONDITIONAL_MUTATED__",
         stderr: "",
         code: 0,
       })
@@ -648,6 +1534,7 @@ HKEY_CURRENT_USER\\Software\\DaumGames\\POE2
       "Kakao Games",
       "POE2",
       "registry",
+      kakaoPoe2RegistryTarget(installPath),
     );
 
     expect(result.ok).toBe(true);
@@ -655,7 +1542,74 @@ HKEY_CURRENT_USER\\Software\\DaumGames\\POE2
       expect.stringContaining("Remove-ItemProperty"),
       false,
     );
+    const conditionalCommand = mocks.powershellExecute.mock.calls[0][0];
+    expect(conditionalCommand).toContain(`$expectedPath = '${installPath}'`);
+    expect(conditionalCommand).toContain(
+      "$currentNormalized -ine $expectedNormalized",
+    );
   });
+
+  it("does not delete when the exact registry target changed after diagnostics", async () => {
+    const expectedPath = String.raw`D:\Games\Path of Exile 2`;
+    const changedPath = String.raw`E:\Moved\Path of Exile 2`;
+    mocks.powershellExecute.mockImplementation(async (command: string) =>
+      command.includes("Remove-ItemProperty")
+        ? registryRead("__REG_CONDITIONAL_CHANGED__")
+        : registryRead(changedPath),
+    );
+    mocks.stat.mockResolvedValue({ isFile: () => true });
+
+    const result = await clearGameInstallPath(
+      "Kakao Games",
+      "POE2",
+      "registry",
+      kakaoPoe2RegistryTarget(expectedPath),
+    );
+
+    expect(result.ok).toBe(false);
+    expect(
+      mocks.powershellExecute.mock.calls.filter(([command]) =>
+        String(command).includes("Remove-ItemProperty"),
+      ),
+    ).toHaveLength(1);
+    if (result.ok) throw new Error("Expected exact target validation to fail");
+    expect(result.error).toContain("changed since diagnostics");
+    expect(result.diagnostics).toBeDefined();
+  });
+
+  it.each(["missing", "read-failed"] as const)(
+    "does not clear the registry when the conditional target is %s",
+    async (targetState) => {
+      const expectedPath = String.raw`D:\Games\Path of Exile 2`;
+      mocks.powershellExecute.mockImplementation(async (command: string) => {
+        if (command.includes("Remove-ItemProperty")) {
+          return registryRead(
+            targetState === "missing"
+              ? "__REG_CONDITIONAL_MISSING__"
+              : "__REG_CONDITIONAL_READ_FAILED__\naccess denied",
+          );
+        }
+        return registryRead("__REG_VALUE_MISSING__");
+      });
+
+      const result = await clearGameInstallPath(
+        "Kakao Games",
+        "POE2",
+        "registry",
+        kakaoPoe2RegistryTarget(expectedPath),
+      );
+
+      expect(result.ok).toBe(false);
+      if (result.ok) throw new Error("Expected conditional clear to fail");
+      expect(result.error).toMatch(/missing|could not be read/i);
+      expect(result.diagnostics).toBeDefined();
+      expect(
+        mocks.powershellExecute.mock.calls.filter(([command]) =>
+          String(command).includes("Remove-ItemProperty"),
+        ),
+      ).toHaveLength(1);
+    },
+  );
 
   it("logs both configured path and registry diagnostics when both fail", async () => {
     const stalePath = String.raw`C:\Old\Path of Exile 2`;
@@ -717,6 +1671,28 @@ HKEY_CURRENT_USER\\Software\\DaumGames\\POE2
   });
 
   it("defines registry and cached config slots for every supported service/game", () => {
+    expect(GAME_INSTALL_REGISTRY_MAP["Kakao Games"]).toEqual({
+      POE1: [
+        {
+          path: String.raw`HKCU:\Software\Kakaogames\POE`,
+          key: "InstallPath",
+        },
+        {
+          path: String.raw`HKCU:\Software\DaumGames\POE`,
+          key: "InstallPath",
+        },
+      ],
+      POE2: [
+        {
+          path: String.raw`HKCU:\Software\Kakaogames\POE2`,
+          key: "InstallPath",
+        },
+        {
+          path: String.raw`HKCU:\Software\DaumGames\POE2`,
+          key: "InstallPath",
+        },
+      ],
+    });
     expect(Object.keys(GAME_INSTALL_REGISTRY_MAP).sort()).toEqual(
       [...SERVICE_CHANNELS].sort(),
     );
@@ -741,16 +1717,19 @@ HKEY_CURRENT_USER\\Software\\DaumGames\\POE2
       ).toEqual([...ACTIVE_GAMES].sort());
 
       for (const gameId of ACTIVE_GAMES) {
-        const registryInfo = GAME_INSTALL_REGISTRY_MAP[serviceId][gameId];
+        const registryCandidates = GAME_INSTALL_REGISTRY_MAP[serviceId][gameId];
 
-        expect(
-          registryInfo.path,
-          `${serviceId}/${gameId} registry path is required`,
-        ).not.toBe("");
-        expect(
-          registryInfo.key,
-          `${serviceId}/${gameId} registry value name is required`,
-        ).not.toBe("");
+        expect(registryCandidates.length).toBeGreaterThan(0);
+        for (const registryInfo of registryCandidates) {
+          expect(
+            registryInfo.path,
+            `${serviceId}/${gameId} registry path is required`,
+          ).not.toBe("");
+          expect(
+            registryInfo.key,
+            `${serviceId}/${gameId} registry value name is required`,
+          ).not.toBe("");
+        }
         expect(DEFAULT_CONFIG.gameInstallPaths[serviceId][gameId]).toBe("");
         expect(
           DEFAULT_CONFIG.gameInstallPathConflictResolutions[serviceId][gameId],

--- a/src/main/utils/registry.ts
+++ b/src/main/utils/registry.ts
@@ -24,9 +24,17 @@ import {
   GameInstallPathRegistryCandidateDiagnostic,
   GameInstallPathRegistryDiagnostic,
   GameInstallPathRegistryTarget,
+  GameInstallPathRegistryTargetDeleteFailureCode,
+  GameInstallPathRegistryTargetDeleteRequest,
+  GameInstallPathRegistryTargetDeleteResult,
+  GameInstallPathRegistryTargetId,
   GameInstallPathRegisterRequest,
   GameInstallPathRegisterResult,
   GameInstallPathSaveResult,
+  GameInstallPathTargetApplyFailureCode,
+  GameInstallPathTargetApplyResult,
+  GameInstallPathTargetId,
+  GameInstallPathTargetSnapshot,
   GameInstallPathVerificationStatus,
   GameInstallationStatus,
   ServiceChannel,
@@ -108,6 +116,46 @@ type AtomicRegistryRegistrationResult =
   | { status: "registered" }
   | {
       status: "changed" | "read-failed" | "mutation-failed" | "readback-failed";
+      error?: string;
+    };
+
+type ResolvedGameInstallPathTarget =
+  | {
+      targetId: "config";
+      kind: "config";
+    }
+  | {
+      targetId: GameInstallPathRegistryTargetId;
+      kind: "registry";
+      registryPath: string;
+      registryValueName: string;
+      registryInfo: RegistryInstallPathInfo;
+    };
+
+type GameInstallPathTargetResolution =
+  | { ok: true; target: ResolvedGameInstallPathTarget }
+  | {
+      ok: false;
+      code: "target-not-allowed";
+      retryable: false;
+    };
+
+type AtomicGameInstallPathTargetApplyResult =
+  | { status: "applied" | "unchanged" }
+  | {
+      status: "changed" | "read-failed" | "mutation-failed" | "readback-failed";
+      error?: string;
+    };
+
+type AtomicGameInstallPathRegistryTargetDeleteResult =
+  | { status: "deleted" | "unchanged" }
+  | {
+      status:
+        | "changed"
+        | "missing"
+        | "read-failed"
+        | "mutation-failed"
+        | "readback-failed";
       error?: string;
     };
 
@@ -204,12 +252,16 @@ const toRegExePath = (regPath: string): string | null => {
 };
 
 /**
- * Normalize installation path by removing trailing slashes and ensuring consistent separators
+ * Normalize installation path while preserving a root trailing separator.
  */
 const normalizePath = (rawPath: string): string => {
   if (!rawPath) return "";
   let normalized = path.normalize(rawPath.trim());
-  while (normalized.endsWith("\\") || normalized.endsWith("/")) {
+  const root = path.parse(normalized).root;
+  while (
+    normalized.length > root.length &&
+    (normalized.endsWith("\\") || normalized.endsWith("/"))
+  ) {
     normalized = normalized.slice(0, -1);
   }
   return normalized;
@@ -228,10 +280,10 @@ const createDefaultGameInstallPathConflictResolutions =
     GGG: { ...DEFAULT_CONFIG.gameInstallPathConflictResolutions.GGG },
   });
 
-const normalizeGameInstallPaths = (value: unknown): GameInstallPaths => {
-  const normalized = createDefaultGameInstallPaths();
+const completeGameInstallPaths = (value: unknown): GameInstallPaths => {
+  const completed = createDefaultGameInstallPaths();
 
-  if (!value || typeof value !== "object") return normalized;
+  if (!value || typeof value !== "object") return completed;
 
   const rawPaths = value as Partial<
     Record<
@@ -240,15 +292,34 @@ const normalizeGameInstallPaths = (value: unknown): GameInstallPaths => {
     >
   >;
 
+  for (const serviceId of Object.keys(completed) as Array<
+    AppConfig["serviceChannel"]
+  >) {
+    for (const gameId of Object.keys(completed[serviceId]) as Array<
+      AppConfig["activeGame"]
+    >) {
+      const rawPath = rawPaths[serviceId]?.[gameId];
+      if (typeof rawPath === "string") {
+        completed[serviceId][gameId] = rawPath;
+      }
+    }
+  }
+
+  return completed;
+};
+
+const normalizeGameInstallPaths = (value: unknown): GameInstallPaths => {
+  const normalized = completeGameInstallPaths(value);
+
   for (const serviceId of Object.keys(normalized) as Array<
     AppConfig["serviceChannel"]
   >) {
     for (const gameId of Object.keys(normalized[serviceId]) as Array<
       AppConfig["activeGame"]
     >) {
-      const rawPath = rawPaths[serviceId]?.[gameId];
-      normalized[serviceId][gameId] =
-        typeof rawPath === "string" ? normalizePath(rawPath) : "";
+      normalized[serviceId][gameId] = normalizePath(
+        normalized[serviceId][gameId],
+      );
     }
   }
 
@@ -717,6 +788,57 @@ const getRegistryInstallPathCandidates = (
 ): readonly RegistryInstallPathInfo[] =>
   GAME_INSTALL_REGISTRY_MAP[serviceId][gameId];
 
+const getRegistryInstallPathTargetId = (
+  serviceId: AppConfig["serviceChannel"],
+  candidateIndex: number,
+): GameInstallPathRegistryTargetId | null => {
+  if (candidateIndex === 0) return "registry-primary";
+  if (serviceId === "Kakao Games" && candidateIndex === 1) {
+    return "registry-compatibility";
+  }
+  return null;
+};
+
+export const resolveGameInstallPathTarget = (
+  serviceId: AppConfig["serviceChannel"],
+  gameId: AppConfig["activeGame"],
+  targetId: string,
+): GameInstallPathTargetResolution => {
+  if (targetId === "config") {
+    return { ok: true, target: { targetId, kind: "config" } };
+  }
+
+  const candidateIndex =
+    targetId === "registry-primary"
+      ? 0
+      : targetId === "registry-compatibility" && serviceId === "Kakao Games"
+        ? 1
+        : -1;
+  const registryInfo =
+    candidateIndex >= 0
+      ? getRegistryInstallPathCandidates(serviceId, gameId)[candidateIndex]
+      : undefined;
+
+  if (!registryInfo) {
+    return {
+      ok: false,
+      code: "target-not-allowed",
+      retryable: false,
+    };
+  }
+
+  return {
+    ok: true,
+    target: {
+      targetId: targetId as GameInstallPathRegistryTargetId,
+      kind: "registry",
+      registryPath: registryInfo.path,
+      registryValueName: registryInfo.key,
+      registryInfo,
+    },
+  };
+};
+
 const getRegistryInstallPathCandidate = (
   serviceId: AppConfig["serviceChannel"],
   gameId: AppConfig["activeGame"],
@@ -735,10 +857,11 @@ const inspectRegistryInstallPaths = async (
 ): Promise<RegistryInstallPathInspection> => {
   const candidates: GameInstallPathRegistryCandidateDiagnostic[] = [];
 
-  for (const registryInfo of getRegistryInstallPathCandidates(
-    serviceId,
-    gameId,
-  )) {
+  const registryInfos = getRegistryInstallPathCandidates(serviceId, gameId);
+  for (const [candidateIndex, registryInfo] of registryInfos.entries()) {
+    const targetId = getRegistryInstallPathTargetId(serviceId, candidateIndex);
+    if (!targetId) continue;
+
     const registryResult = await readRegistryValueDetailed(
       registryInfo.path,
       registryInfo.key,
@@ -746,6 +869,7 @@ const inspectRegistryInstallPaths = async (
 
     if (!registryResult.ok) {
       candidates.push({
+        targetId,
         path: null,
         state: "read-failed",
         verification: "not-checked",
@@ -761,6 +885,7 @@ const inspectRegistryInstallPaths = async (
       ? normalizePath(registryResult.value)
       : null;
     const candidate: GameInstallPathRegistryCandidateDiagnostic = {
+      targetId,
       path: installPath,
       state: registryResult.state,
       verification: "not-checked",
@@ -1093,6 +1218,309 @@ const formatRegistryRegistrationError = (
   }
 };
 
+const applyRegistryInstallPathTargetAtomically = async (
+  registryInfo: RegistryInstallPathInfo,
+  snapshot: Extract<
+    GameInstallPathTargetSnapshot,
+    { targetId: GameInstallPathRegistryTargetId }
+  >,
+  installPath: string,
+): Promise<AtomicGameInstallPathTargetApplyResult> => {
+  const safePath = escapePowerShellSingleQuotedString(
+    standardizeRegPath(registryInfo.path),
+  );
+  const safeName = escapePowerShellSingleQuotedString(registryInfo.key);
+  const safeExpectedState = escapePowerShellSingleQuotedString(
+    snapshot.registryState,
+  );
+  const safeExpectedPath = escapePowerShellSingleQuotedString(
+    snapshot.currentPath ? normalizePath(snapshot.currentPath) : "",
+  );
+  const safeSelectedPath = escapePowerShellSingleQuotedString(
+    normalizePath(installPath),
+  );
+
+  const psCommand = `
+    $path = '${safePath}'
+    $name = '${safeName}'
+    $expectedState = '${safeExpectedState}'
+    $expectedPath = '${safeExpectedPath}'
+    $selectedPath = '${safeSelectedPath}'
+
+    function Normalize-InstallPath([string]$rawPath) {
+      if ([string]::IsNullOrWhiteSpace($rawPath)) {
+        return $null
+      }
+
+      $normalized = [System.IO.Path]::GetFullPath($rawPath.Trim())
+      $root = [System.IO.Path]::GetPathRoot($normalized)
+      while ($normalized.Length -gt $root.Length -and ($normalized.EndsWith('\\') -or $normalized.EndsWith('/'))) {
+        $normalized = $normalized.Substring(0, $normalized.Length - 1)
+      }
+      return $normalized
+    }
+
+    try {
+      if (-not (Test-Path -LiteralPath $path -ErrorAction Stop)) {
+        $currentState = 'key-missing'
+        $currentPath = $null
+      } else {
+        $item = Get-Item -LiteralPath $path -ErrorAction Stop
+        if ($item.GetValueNames() -notcontains $name) {
+          $currentState = 'value-missing'
+          $currentPath = $null
+        } else {
+          $currentValue = $item.GetValue($name, $null)
+          if ($null -eq $currentValue -or [string]::IsNullOrWhiteSpace([string]$currentValue)) {
+            $currentState = 'value-empty'
+            $currentPath = $null
+          } else {
+            $currentState = 'found'
+            $currentPath = Normalize-InstallPath ([string]$currentValue)
+          }
+        }
+      }
+    } catch {
+      Write-Output '__GAME_INSTALL_TARGET_READ_FAILED__'
+      Write-Output $_.Exception.Message
+      return
+    }
+
+    if ($currentState -ine $expectedState) {
+      Write-Output '__GAME_INSTALL_TARGET_CHANGED__'
+      return
+    }
+
+    if ($expectedState -ieq 'found') {
+      $expectedNormalized = Normalize-InstallPath $expectedPath
+      if ($currentPath -ine $expectedNormalized) {
+        Write-Output '__GAME_INSTALL_TARGET_CHANGED__'
+        return
+      }
+    }
+
+    $selectedNormalized = Normalize-InstallPath $selectedPath
+    if ($currentState -ieq 'found' -and $currentPath -ieq $selectedNormalized) {
+      Write-Output '__GAME_INSTALL_TARGET_UNCHANGED__'
+      return
+    }
+
+    try {
+      if ($currentState -ieq 'key-missing') {
+        New-Item -Path $path -Force -ErrorAction Stop | Out-Null
+      }
+      New-ItemProperty -LiteralPath $path -Name $name -Value $selectedNormalized -PropertyType String -Force -ErrorAction Stop | Out-Null
+    } catch {
+      Write-Output '__GAME_INSTALL_TARGET_MUTATION_FAILED__'
+      Write-Output $_.Exception.Message
+      return
+    }
+
+    try {
+      $readBackItem = Get-Item -LiteralPath $path -ErrorAction Stop
+      if ($readBackItem.GetValueNames() -notcontains $name) {
+        Write-Output '__GAME_INSTALL_TARGET_READBACK_FAILED__'
+        return
+      }
+      $readBackValue = $readBackItem.GetValue($name, $null)
+      if ((Normalize-InstallPath ([string]$readBackValue)) -ine $selectedNormalized) {
+        Write-Output '__GAME_INSTALL_TARGET_READBACK_FAILED__'
+        return
+      }
+    } catch {
+      Write-Output '__GAME_INSTALL_TARGET_READBACK_FAILED__'
+      Write-Output $_.Exception.Message
+      return
+    }
+
+    Write-Output '__GAME_INSTALL_TARGET_APPLIED__'
+  `.trim();
+
+  try {
+    const { stdout, stderr, code } = await runPowerShell(psCommand);
+    const lines = stdout
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean);
+    const marker = lines[0];
+    const detail = lines.slice(1).join("; ");
+
+    if (marker === "__GAME_INSTALL_TARGET_APPLIED__") {
+      return code === 0
+        ? { status: "applied" }
+        : {
+            status: "mutation-failed",
+            error: `PowerShell exited with code ${code} after reporting mutation.`,
+          };
+    }
+    if (marker === "__GAME_INSTALL_TARGET_UNCHANGED__") {
+      return code === 0
+        ? { status: "unchanged" }
+        : {
+            status: "read-failed",
+            error: `PowerShell exited with code ${code} after reporting an unchanged target.`,
+          };
+    }
+    if (marker === "__GAME_INSTALL_TARGET_CHANGED__") {
+      return { status: "changed" };
+    }
+    if (marker === "__GAME_INSTALL_TARGET_READ_FAILED__") {
+      return { status: "read-failed", error: detail || stderr };
+    }
+    if (marker === "__GAME_INSTALL_TARGET_MUTATION_FAILED__") {
+      return { status: "mutation-failed", error: detail || stderr };
+    }
+    if (marker === "__GAME_INSTALL_TARGET_READBACK_FAILED__") {
+      return { status: "readback-failed", error: detail || stderr };
+    }
+
+    return {
+      status: "read-failed",
+      error: `Unexpected registry target result (code=${code}, output=${stdout || stderr || "empty"}).`,
+    };
+  } catch (error) {
+    return { status: "read-failed", error: formatError(error) };
+  }
+};
+
+const deleteRegistryInstallPathTargetAtomically = async (
+  registryInfo: RegistryInstallPathInfo,
+  expectedPath: string,
+): Promise<AtomicGameInstallPathRegistryTargetDeleteResult> => {
+  const safePath = escapePowerShellSingleQuotedString(
+    standardizeRegPath(registryInfo.path),
+  );
+  const safeName = escapePowerShellSingleQuotedString(registryInfo.key);
+  const safeExpectedPath = escapePowerShellSingleQuotedString(
+    normalizePath(expectedPath),
+  );
+
+  const psCommand = `
+    $path = '${safePath}'
+    $name = '${safeName}'
+    $expectedPath = '${safeExpectedPath}'
+
+    function Normalize-InstallPath([string]$rawPath) {
+      if ([string]::IsNullOrWhiteSpace($rawPath)) {
+        return $null
+      }
+
+      $normalized = [System.IO.Path]::GetFullPath($rawPath.Trim())
+      $root = [System.IO.Path]::GetPathRoot($normalized)
+      while ($normalized.Length -gt $root.Length -and ($normalized.EndsWith('\\') -or $normalized.EndsWith('/'))) {
+        $normalized = $normalized.Substring(0, $normalized.Length - 1)
+      }
+      return $normalized
+    }
+
+    try {
+      if (-not (Test-Path -LiteralPath $path -ErrorAction Stop)) {
+        Write-Output '__GAME_INSTALL_TARGET_DELETE_MISSING__'
+        return
+      }
+
+      $item = Get-Item -LiteralPath $path -ErrorAction Stop
+      if ($item.GetValueNames() -notcontains $name) {
+        Write-Output '__GAME_INSTALL_TARGET_DELETE_UNCHANGED__'
+        return
+      }
+
+      $currentValue = $item.GetValue($name, $null)
+      if ($null -eq $currentValue -or [string]::IsNullOrWhiteSpace([string]$currentValue)) {
+        Write-Output '__GAME_INSTALL_TARGET_DELETE_CHANGED__'
+        return
+      }
+
+      $currentPath = Normalize-InstallPath ([string]$currentValue)
+      $expectedNormalized = Normalize-InstallPath $expectedPath
+      if ($currentPath -ine $expectedNormalized) {
+        Write-Output '__GAME_INSTALL_TARGET_DELETE_CHANGED__'
+        return
+      }
+    } catch {
+      Write-Output '__GAME_INSTALL_TARGET_DELETE_READ_FAILED__'
+      Write-Output $_.Exception.Message
+      return
+    }
+
+    try {
+      Remove-ItemProperty -LiteralPath $path -Name $name -ErrorAction Stop
+    } catch {
+      Write-Output '__GAME_INSTALL_TARGET_DELETE_MUTATION_FAILED__'
+      Write-Output $_.Exception.Message
+      return
+    }
+
+    try {
+      if (-not (Test-Path -LiteralPath $path -ErrorAction Stop)) {
+        Write-Output '__GAME_INSTALL_TARGET_DELETE_READBACK_FAILED__'
+        return
+      }
+
+      $readBackItem = Get-Item -LiteralPath $path -ErrorAction Stop
+      if ($readBackItem.GetValueNames() -contains $name) {
+        Write-Output '__GAME_INSTALL_TARGET_DELETE_READBACK_FAILED__'
+        return
+      }
+    } catch {
+      Write-Output '__GAME_INSTALL_TARGET_DELETE_READBACK_FAILED__'
+      Write-Output $_.Exception.Message
+      return
+    }
+
+    Write-Output '__GAME_INSTALL_TARGET_DELETE_DELETED__'
+  `.trim();
+
+  try {
+    const { stdout, stderr, code } = await runPowerShell(psCommand);
+    const lines = stdout
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean);
+    const marker = lines[0];
+    const detail = lines.slice(1).join("; ");
+
+    if (marker === "__GAME_INSTALL_TARGET_DELETE_DELETED__") {
+      return code === 0
+        ? { status: "deleted" }
+        : {
+            status: "mutation-failed",
+            error: `PowerShell exited with code ${code} after reporting deletion.`,
+          };
+    }
+    if (marker === "__GAME_INSTALL_TARGET_DELETE_UNCHANGED__") {
+      return code === 0
+        ? { status: "unchanged" }
+        : {
+            status: "read-failed",
+            error: `PowerShell exited with code ${code} after reporting an absent target value.`,
+          };
+    }
+    if (marker === "__GAME_INSTALL_TARGET_DELETE_CHANGED__") {
+      return { status: "changed" };
+    }
+    if (marker === "__GAME_INSTALL_TARGET_DELETE_MISSING__") {
+      return { status: "missing" };
+    }
+    if (marker === "__GAME_INSTALL_TARGET_DELETE_READ_FAILED__") {
+      return { status: "read-failed", error: detail || stderr };
+    }
+    if (marker === "__GAME_INSTALL_TARGET_DELETE_MUTATION_FAILED__") {
+      return { status: "mutation-failed", error: detail || stderr };
+    }
+    if (marker === "__GAME_INSTALL_TARGET_DELETE_READBACK_FAILED__") {
+      return { status: "readback-failed", error: detail || stderr };
+    }
+
+    return {
+      status: "read-failed",
+      error: `Unexpected registry target deletion result (code=${code}, output=${stdout || stderr || "empty"}).`,
+    };
+  } catch (error) {
+    return { status: "read-failed", error: formatError(error) };
+  }
+};
+
 const getRegistryInstallPathLabel = (
   candidate: Pick<
     GameInstallPathRegistryCandidateDiagnostic,
@@ -1273,12 +1701,53 @@ const resolveRegistryTarget = (
   return { ok: true, expectedPath, registryInfo };
 };
 
+const resolveConflictRegistryTarget = (
+  serviceId: AppConfig["serviceChannel"],
+  gameId: AppConfig["activeGame"],
+  target: GameInstallPathConflictTarget | undefined,
+): RegistryTargetResolution => {
+  if (
+    !target ||
+    typeof target.targetId !== "string" ||
+    typeof target.expectedPath !== "string"
+  ) {
+    return { ok: false, error: "Registry target is missing or malformed." };
+  }
+
+  const targetResolution = resolveGameInstallPathTarget(
+    serviceId,
+    gameId,
+    target.targetId,
+  );
+  if (!targetResolution.ok || targetResolution.target.kind !== "registry") {
+    return {
+      ok: false,
+      error: "Registry target is not allowed for this game context.",
+    };
+  }
+
+  const expectedPath = normalizePath(target.expectedPath);
+  if (!expectedPath) {
+    return { ok: false, error: "Expected registry install path is empty." };
+  }
+
+  return {
+    ok: true,
+    expectedPath,
+    registryInfo: targetResolution.target.registryInfo,
+  };
+};
+
 const validateRegistryTargetCurrent = async (
   serviceId: AppConfig["serviceChannel"],
   gameId: AppConfig["activeGame"],
-  target: GameInstallPathRegistryTarget | undefined,
+  target: GameInstallPathConflictTarget | undefined,
 ): Promise<RegistryTargetValidation> => {
-  const targetResolution = resolveRegistryTarget(serviceId, gameId, target);
+  const targetResolution = resolveConflictRegistryTarget(
+    serviceId,
+    gameId,
+    target,
+  );
   if (!targetResolution.ok) return targetResolution;
 
   const registryResult = await readRegistryValueDetailed(
@@ -1402,6 +1871,297 @@ export const getGameInstallPathDiagnostics = async (
       registryDiagnostic,
     ),
   };
+};
+
+export const deriveGameInstallPathTargetSnapshots = (
+  diagnostics: GameInstallPathDiagnostics,
+): readonly GameInstallPathTargetSnapshot[] => {
+  return [
+    ...diagnostics.registry.candidates.map(
+      (candidate): GameInstallPathTargetSnapshot => ({
+        targetId: candidate.targetId,
+        currentPath: candidate.path,
+        registryState: candidate.state,
+      }),
+    ),
+    {
+      targetId: "config",
+      currentPath: diagnostics.config.path,
+    },
+  ];
+};
+
+export const collectGameInstallPathTargetSnapshots = async (
+  serviceId: AppConfig["serviceChannel"],
+  gameId: AppConfig["activeGame"],
+): Promise<readonly GameInstallPathTargetSnapshot[]> => {
+  const diagnostics = await getGameInstallPathDiagnostics(serviceId, gameId);
+  return deriveGameInstallPathTargetSnapshots(diagnostics);
+};
+
+const createGameInstallPathTargetFailure = (
+  targetId: GameInstallPathTargetId,
+  code: GameInstallPathTargetApplyFailureCode,
+  retryable: boolean,
+): GameInstallPathTargetApplyResult => ({
+  targetId,
+  status: "failed",
+  code,
+  retryable,
+});
+
+const createGameInstallPathRegistryTargetDeleteFailure = (
+  targetId: GameInstallPathRegistryTargetId,
+  code: GameInstallPathRegistryTargetDeleteFailureCode,
+  retryable: boolean,
+): GameInstallPathRegistryTargetDeleteResult => ({
+  targetId,
+  status: "failed",
+  code,
+  retryable,
+});
+
+const areSameSnapshotPaths = (
+  left: string | null,
+  right: string | null,
+): boolean => {
+  if (left === null || right === null) return left === right;
+  return areSameInstallPath(left, right);
+};
+
+const applyConfigInstallPathTarget = async (
+  serviceId: AppConfig["serviceChannel"],
+  gameId: AppConfig["activeGame"],
+  snapshot: Extract<GameInstallPathTargetSnapshot, { targetId: "config" }>,
+  installPath: string,
+): Promise<GameInstallPathTargetApplyResult> => {
+  const context = ContextProvider.get();
+  if (!context) {
+    return createGameInstallPathTargetFailure(
+      snapshot.targetId,
+      "context-unavailable",
+      true,
+    );
+  }
+
+  const config = context.getConfig() as AppConfig;
+  const persistedPaths = completeGameInstallPaths(config.gameInstallPaths);
+  const currentPaths = normalizeGameInstallPaths(persistedPaths);
+  const currentPath = currentPaths[serviceId][gameId] || null;
+  const expectedPath = snapshot.currentPath
+    ? normalizePath(snapshot.currentPath)
+    : null;
+
+  if (!areSameSnapshotPaths(currentPath, expectedPath)) {
+    return createGameInstallPathTargetFailure(
+      snapshot.targetId,
+      "target-changed",
+      true,
+    );
+  }
+
+  if (currentPath && areSameInstallPath(currentPath, installPath)) {
+    return {
+      targetId: snapshot.targetId,
+      status: "unchanged",
+      path: installPath,
+    };
+  }
+
+  const nextValue: GameInstallPaths = {
+    ...persistedPaths,
+    [serviceId]: {
+      ...persistedPaths[serviceId],
+      [gameId]: installPath,
+    },
+  };
+
+  try {
+    setConfigWithEvent(CONFIG_KEYS.GAME_INSTALL_PATHS, nextValue);
+  } catch (_error) {
+    return createGameInstallPathTargetFailure(
+      snapshot.targetId,
+      "mutation-failed",
+      true,
+    );
+  }
+
+  return {
+    targetId: snapshot.targetId,
+    status: "applied",
+    path: installPath,
+  };
+};
+
+export const applyGameInstallPathTarget = async (
+  serviceId: AppConfig["serviceChannel"],
+  gameId: AppConfig["activeGame"],
+  snapshot: GameInstallPathTargetSnapshot,
+  installPath: string,
+): Promise<GameInstallPathTargetApplyResult> => {
+  const targetResolution = resolveGameInstallPathTarget(
+    serviceId,
+    gameId,
+    snapshot.targetId,
+  );
+  if (!targetResolution.ok) {
+    return createGameInstallPathTargetFailure(
+      snapshot.targetId,
+      targetResolution.code,
+      targetResolution.retryable,
+    );
+  }
+
+  const normalizedInstallPath = normalizePath(installPath);
+  if (!normalizedInstallPath) {
+    return createGameInstallPathTargetFailure(
+      snapshot.targetId,
+      "install-path-empty",
+      false,
+    );
+  }
+
+  const verification = await verifyGameInstallPath(
+    serviceId,
+    normalizedInstallPath,
+  );
+  if (verification.status !== "valid") {
+    return createGameInstallPathTargetFailure(
+      snapshot.targetId,
+      verification.status === "missing"
+        ? "install-path-invalid"
+        : "install-path-check-failed",
+      verification.status === "unknown",
+    );
+  }
+
+  if (targetResolution.target.kind === "config") {
+    if (snapshot.targetId !== "config") {
+      return createGameInstallPathTargetFailure(
+        snapshot.targetId,
+        "invalid-snapshot",
+        false,
+      );
+    }
+    return applyConfigInstallPathTarget(
+      serviceId,
+      gameId,
+      snapshot,
+      normalizedInstallPath,
+    );
+  }
+
+  if (snapshot.targetId === "config" || !("registryState" in snapshot)) {
+    return createGameInstallPathTargetFailure(
+      snapshot.targetId,
+      "invalid-snapshot",
+      false,
+    );
+  }
+
+  if (snapshot.registryState === "read-failed") {
+    return createGameInstallPathTargetFailure(
+      snapshot.targetId,
+      "target-read-failed",
+      true,
+    );
+  }
+
+  const hasValidSnapshotShape =
+    snapshot.registryState === "found"
+      ? Boolean(snapshot.currentPath)
+      : snapshot.currentPath === null;
+  if (!hasValidSnapshotShape) {
+    return createGameInstallPathTargetFailure(
+      snapshot.targetId,
+      "invalid-snapshot",
+      false,
+    );
+  }
+
+  const mutationResult = await applyRegistryInstallPathTargetAtomically(
+    targetResolution.target.registryInfo,
+    snapshot,
+    normalizedInstallPath,
+  );
+  if (
+    mutationResult.status === "applied" ||
+    mutationResult.status === "unchanged"
+  ) {
+    return {
+      targetId: snapshot.targetId,
+      status: mutationResult.status,
+      path: normalizedInstallPath,
+    };
+  }
+
+  const failureCode: GameInstallPathTargetApplyFailureCode =
+    mutationResult.status === "changed"
+      ? "target-changed"
+      : mutationResult.status === "read-failed"
+        ? "target-read-failed"
+        : mutationResult.status;
+  return createGameInstallPathTargetFailure(
+    snapshot.targetId,
+    failureCode,
+    true,
+  );
+};
+
+export const deleteGameInstallPathRegistryTarget = async (
+  serviceId: AppConfig["serviceChannel"],
+  gameId: AppConfig["activeGame"],
+  request: GameInstallPathRegistryTargetDeleteRequest,
+): Promise<GameInstallPathRegistryTargetDeleteResult> => {
+  const targetResolution = resolveGameInstallPathTarget(
+    serviceId,
+    gameId,
+    request.targetId,
+  );
+  if (!targetResolution.ok || targetResolution.target.kind !== "registry") {
+    return createGameInstallPathRegistryTargetDeleteFailure(
+      request.targetId,
+      "target-not-allowed",
+      false,
+    );
+  }
+
+  const expectedPath = normalizePath(request.expectedPath);
+  if (!expectedPath) {
+    return createGameInstallPathRegistryTargetDeleteFailure(
+      request.targetId,
+      "expected-path-empty",
+      false,
+    );
+  }
+
+  const deletionResult = await deleteRegistryInstallPathTargetAtomically(
+    targetResolution.target.registryInfo,
+    expectedPath,
+  );
+  if (
+    deletionResult.status === "deleted" ||
+    deletionResult.status === "unchanged"
+  ) {
+    return {
+      targetId: request.targetId,
+      status: deletionResult.status,
+    };
+  }
+
+  const failureCode: GameInstallPathRegistryTargetDeleteFailureCode =
+    deletionResult.status === "changed"
+      ? "target-changed"
+      : deletionResult.status === "missing"
+        ? "target-missing"
+        : deletionResult.status === "read-failed"
+          ? "target-read-failed"
+          : deletionResult.status;
+  return createGameInstallPathRegistryTargetDeleteFailure(
+    request.targetId,
+    failureCode,
+    true,
+  );
 };
 
 export const setGameInstallPath = async (
@@ -1721,7 +2481,7 @@ export const resolveGameInstallPathConflict = async (
     };
   }
 
-  const targetResolution = resolveRegistryTarget(
+  const targetResolution = resolveConflictRegistryTarget(
     serviceId,
     gameId,
     registryTarget,

--- a/src/main/utils/registry.ts
+++ b/src/main/utils/registry.ts
@@ -10,6 +10,7 @@ import {
   ActiveGame,
   AppConfig,
   GameInstallPathConflictAction,
+  GameInstallPathConflictTarget,
   GameInstallPathConflictResolution,
   GameInstallPathConflictResolveResult,
   GameInstallPathConflictResolutions,
@@ -17,10 +18,17 @@ import {
   GameInstallPathClearSource,
   GameInstallPathConfigDiagnostic,
   GameInstallPathDiagnostics,
+  GameInstallPathHealth,
   GameInstallPaths,
+  GameInstallPathRegistryAggregateState,
+  GameInstallPathRegistryCandidateDiagnostic,
   GameInstallPathRegistryDiagnostic,
+  GameInstallPathRegistryTarget,
+  GameInstallPathRegisterRequest,
+  GameInstallPathRegisterResult,
   GameInstallPathSaveResult,
   GameInstallPathVerificationStatus,
+  GameInstallationStatus,
   ServiceChannel,
 } from "../../shared/types";
 import { ContextProvider } from "../context-provider";
@@ -35,7 +43,6 @@ type RegistryReadResult =
     }
   | { ok: false; error: string };
 
-export type GameInstallationStatus = "installed" | "uninstalled" | "unknown";
 type InstallPathVerificationStatus = Exclude<
   GameInstallPathVerificationStatus,
   "not-checked"
@@ -59,6 +66,51 @@ type ConfiguredInstallPathResult =
   | { state: "found"; path: string }
   | { state: "empty" | "context-unavailable"; path: null };
 
+type RegistryInstallPathInfo = {
+  path: string;
+  key: string;
+};
+
+type RegistryInstallPathInspection = {
+  activeCandidate: GameInstallPathRegistryCandidateDiagnostic | null;
+  aggregateState: GameInstallPathRegistryAggregateState;
+  candidates: GameInstallPathRegistryCandidateDiagnostic[];
+  displayedCandidate: GameInstallPathRegistryCandidateDiagnostic;
+};
+
+type RegistryTargetValidation =
+  | {
+      ok: true;
+      currentPath: string;
+      registryInfo: RegistryInstallPathInfo;
+    }
+  | { ok: false; error: string };
+
+type RegistryTargetResolution =
+  | {
+      ok: true;
+      expectedPath: string;
+      registryInfo: RegistryInstallPathInfo;
+    }
+  | { ok: false; error: string };
+
+type ConditionalRegistryMutationStatus =
+  "mutated" | "changed" | "missing" | "read-failed" | "mutation-failed";
+
+type ConditionalRegistryMutationResult =
+  | { status: "mutated" }
+  | {
+      status: Exclude<ConditionalRegistryMutationStatus, "mutated">;
+      error?: string;
+    };
+
+type AtomicRegistryRegistrationResult =
+  | { status: "registered" }
+  | {
+      status: "changed" | "read-failed" | "mutation-failed" | "readback-failed";
+      error?: string;
+    };
+
 const GAME_EXECUTABLE_NAMES = {
   "Kakao Games": "PathOfExile_KG.exe",
   GGG: "PathOfExile.exe",
@@ -72,28 +124,44 @@ const getGameExecutableName = (serviceId: AppConfig["serviceChannel"]) =>
  */
 export const GAME_INSTALL_REGISTRY_MAP = {
   "Kakao Games": {
-    POE1: {
-      path: "HKCU:\\Software\\DaumGames\\POE",
-      key: "InstallPath",
-    },
-    POE2: {
-      path: "HKCU:\\Software\\DaumGames\\POE2",
-      key: "InstallPath",
-    },
+    POE1: [
+      {
+        path: "HKCU:\\Software\\Kakaogames\\POE",
+        key: "InstallPath",
+      },
+      {
+        path: "HKCU:\\Software\\DaumGames\\POE",
+        key: "InstallPath",
+      },
+    ],
+    POE2: [
+      {
+        path: "HKCU:\\Software\\Kakaogames\\POE2",
+        key: "InstallPath",
+      },
+      {
+        path: "HKCU:\\Software\\DaumGames\\POE2",
+        key: "InstallPath",
+      },
+    ],
   },
   GGG: {
-    POE1: {
-      path: "HKCU:\\Software\\GrindingGearGames\\Path of Exile",
-      key: "InstallLocation",
-    },
-    POE2: {
-      path: "HKCU:\\Software\\GrindingGearGames\\Path of Exile 2",
-      key: "InstallLocation",
-    },
+    POE1: [
+      {
+        path: "HKCU:\\Software\\GrindingGearGames\\Path of Exile",
+        key: "InstallLocation",
+      },
+    ],
+    POE2: [
+      {
+        path: "HKCU:\\Software\\GrindingGearGames\\Path of Exile 2",
+        key: "InstallLocation",
+      },
+    ],
   },
 } as const satisfies Record<
   ServiceChannel,
-  Record<ActiveGame, { path: string; key: string }>
+  Record<ActiveGame, readonly RegistryInstallPathInfo[]>
 >;
 
 export const DAUM_STARTER_PROTOCOL_KEY =
@@ -643,63 +711,394 @@ const verifyGameInstallPath = async (
   }
 };
 
-const readRegistryInstallPath = async (
+const getRegistryInstallPathCandidates = (
   serviceId: AppConfig["serviceChannel"],
   gameId: AppConfig["activeGame"],
-): Promise<RegistryReadResult> => {
-  const registryInfo = GAME_INSTALL_REGISTRY_MAP[serviceId]?.[gameId];
-  if (!registryInfo) {
-    return {
-      ok: false,
-      error: `Unsupported game context: ${serviceId}/${gameId}`,
+): readonly RegistryInstallPathInfo[] =>
+  GAME_INSTALL_REGISTRY_MAP[serviceId][gameId];
+
+const getRegistryInstallPathCandidate = (
+  serviceId: AppConfig["serviceChannel"],
+  gameId: AppConfig["activeGame"],
+  registryPath: string,
+  registryValueName: string,
+): RegistryInstallPathInfo | null =>
+  getRegistryInstallPathCandidates(serviceId, gameId).find(
+    (candidate) =>
+      candidate.path.toLowerCase() === registryPath.toLowerCase() &&
+      candidate.key.toLowerCase() === registryValueName.toLowerCase(),
+  ) ?? null;
+
+const inspectRegistryInstallPaths = async (
+  serviceId: AppConfig["serviceChannel"],
+  gameId: AppConfig["activeGame"],
+): Promise<RegistryInstallPathInspection> => {
+  const candidates: GameInstallPathRegistryCandidateDiagnostic[] = [];
+
+  for (const registryInfo of getRegistryInstallPathCandidates(
+    serviceId,
+    gameId,
+  )) {
+    const registryResult = await readRegistryValueDetailed(
+      registryInfo.path,
+      registryInfo.key,
+    );
+
+    if (!registryResult.ok) {
+      candidates.push({
+        path: null,
+        state: "read-failed",
+        verification: "not-checked",
+        error: registryResult.error,
+        registryPath: registryInfo.path,
+        registryValueName: registryInfo.key,
+        isActive: false,
+      });
+      continue;
+    }
+
+    const installPath = registryResult.value
+      ? normalizePath(registryResult.value)
+      : null;
+    const candidate: GameInstallPathRegistryCandidateDiagnostic = {
+      path: installPath,
+      state: registryResult.state,
+      verification: "not-checked",
+      registryPath: registryInfo.path,
+      registryValueName: registryInfo.key,
+      isActive: false,
     };
+
+    if (installPath) {
+      const verification = await verifyGameInstallPath(serviceId, installPath);
+      candidate.verification = verification.status;
+      candidate.executablePath = verification.executablePath;
+      candidate.error = verification.error;
+    }
+
+    candidates.push(candidate);
   }
 
-  const registryResult = await readRegistryValueDetailed(
-    registryInfo.path,
-    registryInfo.key,
-  );
+  const activeCandidate =
+    candidates.find((candidate) => candidate.verification === "valid") ?? null;
+  if (activeCandidate) activeCandidate.isActive = true;
 
-  if (!registryResult.ok) return registryResult;
+  const displayedCandidate =
+    activeCandidate ??
+    candidates.find((candidate) => candidate.path !== null) ??
+    candidates.find((candidate) => candidate.state === "read-failed") ??
+    candidates[0];
+
+  let aggregateState: GameInstallPathRegistryAggregateState;
+  if (activeCandidate) {
+    aggregateState = "valid";
+  } else if (
+    candidates.some(
+      (candidate) =>
+        candidate.state === "read-failed" ||
+        candidate.verification === "unknown",
+    )
+  ) {
+    aggregateState = "unknown";
+  } else if (candidates.some((candidate) => candidate.path !== null)) {
+    aggregateState = "invalid";
+  } else {
+    aggregateState = "absent";
+  }
 
   return {
-    ok: true,
-    value: registryResult.value ? normalizePath(registryResult.value) : null,
-    state: registryResult.state,
+    activeCandidate,
+    aggregateState,
+    candidates,
+    displayedCandidate,
   };
 };
 
-const writeRegistryInstallPath = async (
-  serviceId: AppConfig["serviceChannel"],
-  gameId: AppConfig["activeGame"],
-  installPath: string,
-): Promise<boolean> => {
-  const registryInfo = GAME_INSTALL_REGISTRY_MAP[serviceId]?.[gameId];
-  if (!registryInfo) return false;
+const mutateRegistryInstallPathConditionally = async (
+  registryInfo: RegistryInstallPathInfo,
+  expectedPath: string,
+  mutation: { kind: "set"; installPath: string } | { kind: "delete" },
+): Promise<ConditionalRegistryMutationResult> => {
+  const finalPath = standardizeRegPath(registryInfo.path);
+  const safePath = escapePowerShellSingleQuotedString(finalPath);
+  const safeKey = escapePowerShellSingleQuotedString(registryInfo.key);
+  const safeExpectedPath = escapePowerShellSingleQuotedString(
+    normalizePath(expectedPath),
+  );
+  const mutationCommand =
+    mutation.kind === "set"
+      ? `Set-ItemProperty -LiteralPath $path -Name $name -Value '${escapePowerShellSingleQuotedString(normalizePath(mutation.installPath))}' -ErrorAction Stop`
+      : "Remove-ItemProperty -LiteralPath $path -Name $name -ErrorAction Stop";
 
-  return writeRegistryValue(registryInfo.path, registryInfo.key, installPath);
+  const psCommand = `
+    $path = '${safePath}'
+    $name = '${safeKey}'
+    $expectedPath = '${safeExpectedPath}'
+
+    function Normalize-InstallPath([string]$rawPath) {
+      if ([string]::IsNullOrWhiteSpace($rawPath)) {
+        return $null
+      }
+
+      $normalized = [System.IO.Path]::GetFullPath($rawPath.Trim())
+      while ($normalized.EndsWith('\\') -or $normalized.EndsWith('/')) {
+        $normalized = $normalized.Substring(0, $normalized.Length - 1)
+      }
+      return $normalized
+    }
+
+    try {
+      if (-not (Test-Path -LiteralPath $path)) {
+        Write-Output "__REG_CONDITIONAL_MISSING__"
+        return
+      }
+
+      $item = Get-Item -LiteralPath $path -ErrorAction Stop
+      if ($item.GetValueNames() -notcontains $name) {
+        Write-Output "__REG_CONDITIONAL_MISSING__"
+        return
+      }
+
+      $currentValue = $item.GetValue($name, $null)
+      if ($null -eq $currentValue -or [string]::IsNullOrWhiteSpace([string]$currentValue)) {
+        Write-Output "__REG_CONDITIONAL_MISSING__"
+        return
+      }
+
+      $currentNormalized = Normalize-InstallPath ([string]$currentValue)
+      $expectedNormalized = Normalize-InstallPath $expectedPath
+    } catch {
+      Write-Output "__REG_CONDITIONAL_READ_FAILED__"
+      Write-Output $_.Exception.Message
+      return
+    }
+
+    if ($currentNormalized -ine $expectedNormalized) {
+      Write-Output "__REG_CONDITIONAL_CHANGED__"
+      return
+    }
+
+    try {
+      ${mutationCommand}
+      Write-Output "__REG_CONDITIONAL_MUTATED__"
+    } catch {
+      Write-Output "__REG_CONDITIONAL_MUTATION_FAILED__"
+      Write-Output $_.Exception.Message
+    }
+  `.trim();
+
+  try {
+    const { stdout, stderr, code } = await runPowerShell(psCommand);
+    const lines = stdout
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean);
+    const marker = lines[0];
+    const detail = lines.slice(1).join("; ");
+
+    if (marker === "__REG_CONDITIONAL_MUTATED__") {
+      return code === 0
+        ? { status: "mutated" }
+        : {
+            status: "mutation-failed",
+            error: `PowerShell exited with code ${code} after reporting mutation.`,
+          };
+    }
+    if (marker === "__REG_CONDITIONAL_CHANGED__") {
+      return { status: "changed" };
+    }
+    if (marker === "__REG_CONDITIONAL_MISSING__") {
+      return { status: "missing" };
+    }
+    if (marker === "__REG_CONDITIONAL_READ_FAILED__") {
+      return { status: "read-failed", error: detail || stderr };
+    }
+    if (marker === "__REG_CONDITIONAL_MUTATION_FAILED__") {
+      return { status: "mutation-failed", error: detail || stderr };
+    }
+
+    return {
+      status: "read-failed",
+      error: `Unexpected conditional registry result (code=${code}, output=${stdout || stderr || "empty"}).`,
+    };
+  } catch (error) {
+    return { status: "read-failed", error: formatError(error) };
+  }
 };
 
-const deleteRegistryInstallPath = async (
-  serviceId: AppConfig["serviceChannel"],
-  gameId: AppConfig["activeGame"],
-): Promise<boolean> => {
-  const registryInfo = GAME_INSTALL_REGISTRY_MAP[serviceId]?.[gameId];
-  if (!registryInfo) return false;
+const formatConditionalRegistryMutationError = (
+  result: Exclude<ConditionalRegistryMutationResult, { status: "mutated" }>,
+) => {
+  switch (result.status) {
+    case "changed":
+      return "Registry target changed since diagnostics. Run diagnostics again.";
+    case "missing":
+      return "Registry target is missing. Run diagnostics again.";
+    case "read-failed":
+      return `Registry target could not be read.${result.error ? ` ${result.error}` : ""}`;
+    case "mutation-failed":
+      return `Registry target mutation failed.${result.error ? ` ${result.error}` : ""}`;
+  }
+};
 
-  return deleteRegistryValue(registryInfo.path, registryInfo.key);
+const registerCanonicalRegistryInstallPathAtomically = async (
+  candidates: readonly RegistryInstallPathInfo[],
+  installPath: string,
+): Promise<AtomicRegistryRegistrationResult> => {
+  const [canonical, legacy] = candidates;
+  if (!canonical || !legacy) {
+    return {
+      status: "read-failed",
+      error: "Canonical and legacy registry candidates are required.",
+    };
+  }
+
+  const canonicalPath = escapePowerShellSingleQuotedString(
+    standardizeRegPath(canonical.path),
+  );
+  const canonicalName = escapePowerShellSingleQuotedString(canonical.key);
+  const legacyPath = escapePowerShellSingleQuotedString(
+    standardizeRegPath(legacy.path),
+  );
+  const legacyName = escapePowerShellSingleQuotedString(legacy.key);
+  const expectedPath = escapePowerShellSingleQuotedString(
+    normalizePath(installPath),
+  );
+
+  const psCommand = `
+    $canonicalPath = '${canonicalPath}'
+    $canonicalName = '${canonicalName}'
+    $legacyPath = '${legacyPath}'
+    $legacyName = '${legacyName}'
+    $expectedPath = '${expectedPath}'
+
+    function Normalize-InstallPath([string]$rawPath) {
+      if ([string]::IsNullOrWhiteSpace($rawPath)) {
+        return $null
+      }
+
+      $normalized = [System.IO.Path]::GetFullPath($rawPath.Trim())
+      while ($normalized.EndsWith('\\') -or $normalized.EndsWith('/')) {
+        $normalized = $normalized.Substring(0, $normalized.Length - 1)
+      }
+      return $normalized
+    }
+
+    function Assert-RegistryValueAbsent([string]$candidatePath, [string]$candidateName) {
+      if (-not (Test-Path -LiteralPath $candidatePath -ErrorAction Stop)) {
+        return $true
+      }
+
+      $item = Get-Item -LiteralPath $candidatePath -ErrorAction Stop
+      if ($item.GetValueNames() -notcontains $candidateName) {
+        return $true
+      }
+
+      $currentValue = $item.GetValue($candidateName, $null)
+      return $null -eq $currentValue -or [string]::IsNullOrWhiteSpace([string]$currentValue)
+    }
+
+    try {
+      $canonicalAbsent = Assert-RegistryValueAbsent $canonicalPath $canonicalName
+      $legacyAbsent = Assert-RegistryValueAbsent $legacyPath $legacyName
+    } catch {
+      Write-Output "__REG_REGISTER_READ_FAILED__"
+      Write-Output $_.Exception.Message
+      return
+    }
+
+    if (-not $canonicalAbsent -or -not $legacyAbsent) {
+      Write-Output "__REG_REGISTER_CHANGED__"
+      return
+    }
+
+    try {
+      if (-not (Test-Path -LiteralPath $canonicalPath -ErrorAction Stop)) {
+        New-Item -Path $canonicalPath -Force -ErrorAction Stop | Out-Null
+      }
+      New-ItemProperty -LiteralPath $canonicalPath -Name $canonicalName -Value $expectedPath -PropertyType String -Force -ErrorAction Stop | Out-Null
+    } catch {
+      Write-Output "__REG_REGISTER_MUTATION_FAILED__"
+      Write-Output $_.Exception.Message
+      return
+    }
+
+    try {
+      $createdItem = Get-Item -LiteralPath $canonicalPath -ErrorAction Stop
+      $createdValue = $createdItem.GetValue($canonicalName, $null)
+      if ((Normalize-InstallPath ([string]$createdValue)) -ine (Normalize-InstallPath $expectedPath)) {
+        Write-Output "__REG_REGISTER_READBACK_FAILED__"
+        return
+      }
+    } catch {
+      Write-Output "__REG_REGISTER_READBACK_FAILED__"
+      Write-Output $_.Exception.Message
+      return
+    }
+
+    Write-Output "__REG_REGISTERED__"
+  `.trim();
+
+  try {
+    const { stdout, stderr, code } = await runPowerShell(psCommand);
+    const lines = stdout
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean);
+    const marker = lines[0];
+    const detail = lines.slice(1).join("; ");
+
+    if (marker === "__REG_REGISTERED__") {
+      return code === 0
+        ? { status: "registered" }
+        : {
+            status: "mutation-failed",
+            error: `PowerShell exited with code ${code} after reporting registration.`,
+          };
+    }
+    if (marker === "__REG_REGISTER_CHANGED__") {
+      return { status: "changed" };
+    }
+    if (marker === "__REG_REGISTER_READ_FAILED__") {
+      return { status: "read-failed", error: detail || stderr };
+    }
+    if (marker === "__REG_REGISTER_MUTATION_FAILED__") {
+      return { status: "mutation-failed", error: detail || stderr };
+    }
+    if (marker === "__REG_REGISTER_READBACK_FAILED__") {
+      return { status: "readback-failed", error: detail || stderr };
+    }
+
+    return {
+      status: "read-failed",
+      error: `Unexpected registry registration result (code=${code}, output=${stdout || stderr || "empty"}).`,
+    };
+  } catch (error) {
+    return { status: "read-failed", error: formatError(error) };
+  }
+};
+
+const formatRegistryRegistrationError = (
+  result: Exclude<AtomicRegistryRegistrationResult, { status: "registered" }>,
+) => {
+  switch (result.status) {
+    case "changed":
+      return "Registry candidates changed since diagnostics. Run diagnostics again.";
+    case "read-failed":
+      return `Registry candidates could not be read.${result.error ? ` ${result.error}` : ""}`;
+    case "mutation-failed":
+      return `Registry install path registration failed.${result.error ? ` ${result.error}` : ""}`;
+    case "readback-failed":
+      return `Registered registry install path could not be verified.${result.error ? ` ${result.error}` : ""}`;
+  }
 };
 
 const getRegistryInstallPathLabel = (
-  serviceId: AppConfig["serviceChannel"],
-  gameId: AppConfig["activeGame"],
-) => {
-  const registryInfo = GAME_INSTALL_REGISTRY_MAP[serviceId]?.[gameId];
-
-  return registryInfo
-    ? `${registryInfo.path} / ${registryInfo.key}`
-    : `${serviceId}/${gameId}`;
-};
+  candidate: Pick<
+    GameInstallPathRegistryCandidateDiagnostic,
+    "registryPath" | "registryValueName"
+  >,
+) => `${candidate.registryPath} / ${candidate.registryValueName}`;
 
 const formatDiagnostics = (diagnostics: string[]) => {
   return diagnostics.length > 0 ? diagnostics.join("; ") : "no details";
@@ -774,49 +1173,60 @@ const resolveGameInstallPath = async (
     diagnostics.push("config=empty");
   }
 
-  const registryResult = await readRegistryInstallPath(serviceId, gameId);
-  const registryLabel = getRegistryInstallPathLabel(serviceId, gameId);
-
-  if (!registryResult.ok) {
-    diagnostics.push(`registry=read-failed (${registryLabel})`);
-    return { path: null, error: registryResult.error, diagnostics };
-  }
-
-  if (!registryResult.value) {
-    diagnostics.push(`registry=${registryResult.state} (${registryLabel})`);
-    return { path: null, verifyError: configuredVerifyError, diagnostics };
-  }
-
-  const registryStatus = await verifyGameInstallPath(
+  const registryInspection = await inspectRegistryInstallPaths(
     serviceId,
-    registryResult.value,
+    gameId,
   );
 
-  if (registryStatus.status === "valid") {
-    if (configuredPath.state === "empty") {
-      await persistDiscoveredGameInstallPath(
-        serviceId,
-        gameId,
-        registryResult.value,
-      );
+  for (const candidate of registryInspection.candidates) {
+    const registryLabel = getRegistryInstallPathLabel(candidate);
+
+    if (candidate.state === "read-failed") {
+      diagnostics.push(`registry=read-failed (${registryLabel})`);
+      continue;
     }
 
-    return { path: registryResult.value, source: "registry", diagnostics };
+    if (!candidate.path) {
+      diagnostics.push(`registry=${candidate.state} (${registryLabel})`);
+      continue;
+    }
+
+    if (
+      candidate.verification === "missing" ||
+      candidate.verification === "unknown"
+    ) {
+      diagnostics.push(
+        `${formatPathCheckFailure(
+          serviceId,
+          "registry",
+          candidate.path,
+          candidate.verification,
+          candidate.error,
+        )} (${registryLabel})`,
+      );
+    }
   }
 
-  diagnostics.push(
-    formatPathCheckFailure(
-      serviceId,
-      "registry",
-      registryResult.value,
-      registryStatus.status,
-      registryStatus.error,
-    ),
-  );
+  if (registryInspection.activeCandidate?.path) {
+    const activePath = registryInspection.activeCandidate.path;
+    if (configuredPath.state === "empty") {
+      await persistDiscoveredGameInstallPath(serviceId, gameId, activePath);
+    }
+
+    return { path: activePath, source: "registry", diagnostics };
+  }
+
+  const registryReadError = registryInspection.candidates.find(
+    (candidate) => candidate.state === "read-failed",
+  )?.error;
+  const registryVerifyError = registryInspection.candidates.find(
+    (candidate) => candidate.verification === "unknown",
+  )?.error;
 
   return {
     path: null,
-    verifyError: registryStatus.error ?? configuredVerifyError,
+    error: registryReadError,
+    verifyError: registryVerifyError ?? configuredVerifyError,
     diagnostics,
   };
 };
@@ -826,6 +1236,82 @@ const areSameInstallPath = (left: string | null, right: string | null) => {
   return (
     normalizePath(left).toLowerCase() === normalizePath(right).toLowerCase()
   );
+};
+
+const resolveRegistryTarget = (
+  serviceId: AppConfig["serviceChannel"],
+  gameId: AppConfig["activeGame"],
+  target: GameInstallPathRegistryTarget | undefined,
+): RegistryTargetResolution => {
+  if (
+    !target ||
+    typeof target.registryPath !== "string" ||
+    typeof target.registryValueName !== "string" ||
+    typeof target.expectedPath !== "string"
+  ) {
+    return { ok: false, error: "Registry target is missing or malformed." };
+  }
+
+  const registryInfo = getRegistryInstallPathCandidate(
+    serviceId,
+    gameId,
+    target.registryPath,
+    target.registryValueName,
+  );
+  if (!registryInfo) {
+    return {
+      ok: false,
+      error: "Registry target is not allowed for this game context.",
+    };
+  }
+
+  const expectedPath = normalizePath(target.expectedPath);
+  if (!expectedPath) {
+    return { ok: false, error: "Expected registry install path is empty." };
+  }
+
+  return { ok: true, expectedPath, registryInfo };
+};
+
+const validateRegistryTargetCurrent = async (
+  serviceId: AppConfig["serviceChannel"],
+  gameId: AppConfig["activeGame"],
+  target: GameInstallPathRegistryTarget | undefined,
+): Promise<RegistryTargetValidation> => {
+  const targetResolution = resolveRegistryTarget(serviceId, gameId, target);
+  if (!targetResolution.ok) return targetResolution;
+
+  const registryResult = await readRegistryValueDetailed(
+    targetResolution.registryInfo.path,
+    targetResolution.registryInfo.key,
+  );
+  const { expectedPath, registryInfo } = targetResolution;
+  if (!registryResult.ok) {
+    return {
+      ok: false,
+      error: `Registry target could not be read: ${registryResult.error}`,
+    };
+  }
+
+  const currentPath = registryResult.value
+    ? normalizePath(registryResult.value)
+    : null;
+  if (!currentPath) {
+    return {
+      ok: false,
+      error: `Registry target changed (${registryResult.state}). Run diagnostics again.`,
+    };
+  }
+
+  if (!areSameInstallPath(currentPath, expectedPath)) {
+    return {
+      ok: false,
+      error:
+        "Registry target changed since diagnostics. Run diagnostics again.",
+    };
+  }
+
+  return { ok: true, currentPath, registryInfo };
 };
 
 const getRecommendedInstallPathSource = (
@@ -874,27 +1360,23 @@ export const getGameInstallPathDiagnostics = async (
     configDiagnostic.error = verification.error;
   }
 
-  const registryInfo = GAME_INSTALL_REGISTRY_MAP[serviceId][gameId];
-  const registryResult = await readRegistryInstallPath(serviceId, gameId);
+  const registryInspection = await inspectRegistryInstallPaths(
+    serviceId,
+    gameId,
+  );
+  const displayedRegistryCandidate = registryInspection.displayedCandidate;
   const registryDiagnostic: GameInstallPathRegistryDiagnostic = {
     source: "registry",
-    path: registryResult.ok ? registryResult.value : null,
-    state: registryResult.ok ? registryResult.state : "read-failed",
-    verification: "not-checked",
-    error: registryResult.ok ? undefined : registryResult.error,
-    registryPath: registryInfo.path,
-    registryValueName: registryInfo.key,
+    path: displayedRegistryCandidate.path,
+    state: displayedRegistryCandidate.state,
+    verification: displayedRegistryCandidate.verification,
+    executablePath: displayedRegistryCandidate.executablePath,
+    error: displayedRegistryCandidate.error,
+    registryPath: displayedRegistryCandidate.registryPath,
+    registryValueName: displayedRegistryCandidate.registryValueName,
+    aggregateState: registryInspection.aggregateState,
+    candidates: registryInspection.candidates,
   };
-
-  if (registryResult.ok && registryResult.value) {
-    const verification = await verifyGameInstallPath(
-      serviceId,
-      registryResult.value,
-    );
-    registryDiagnostic.verification = verification.status;
-    registryDiagnostic.executablePath = verification.executablePath;
-    registryDiagnostic.error = verification.error;
-  }
 
   const hasPathConflict =
     Boolean(configDiagnostic.path && registryDiagnostic.path) &&
@@ -976,10 +1458,105 @@ export const setGameInstallPath = async (
   };
 };
 
+export const registerGameInstallPath = async (
+  serviceId: AppConfig["serviceChannel"],
+  gameId: AppConfig["activeGame"],
+  request: GameInstallPathRegisterRequest,
+): Promise<GameInstallPathRegisterResult> => {
+  if (serviceId !== "Kakao Games") {
+    return {
+      ok: false,
+      verification: "not-checked",
+      error:
+        "Registry install path registration is only supported for Kakao Games.",
+      diagnostics: await getGameInstallPathDiagnostics(serviceId, gameId),
+    };
+  }
+
+  const configuredPath = getConfiguredGameInstallPath(serviceId, gameId);
+  const configPath = configuredPath.path;
+  if (!configPath) {
+    return {
+      ok: false,
+      verification: "not-checked",
+      error: "Launcher config path is empty.",
+      diagnostics: await getGameInstallPathDiagnostics(serviceId, gameId),
+    };
+  }
+
+  const verification = await verifyGameInstallPath(serviceId, configPath);
+  if (verification.status !== "valid") {
+    return {
+      ok: false,
+      path: configPath,
+      verification: verification.status,
+      error:
+        verification.error ||
+        `런처 설정 경로에서 ${getGameExecutableName(serviceId)}를 찾을 수 없습니다.`,
+      diagnostics: await getGameInstallPathDiagnostics(serviceId, gameId),
+    };
+  }
+
+  if (
+    !request ||
+    typeof request.expectedConfigPath !== "string" ||
+    !areSameInstallPath(configPath, request.expectedConfigPath)
+  ) {
+    return {
+      ok: false,
+      path: configPath,
+      verification: verification.status,
+      error:
+        "Launcher config path changed since confirmation. Run diagnostics again.",
+      diagnostics: await getGameInstallPathDiagnostics(serviceId, gameId),
+    };
+  }
+
+  const candidates = getRegistryInstallPathCandidates(serviceId, gameId);
+  const canonical = candidates[0];
+  if (!canonical || !canonical.path.includes("\\Kakaogames\\")) {
+    return {
+      ok: false,
+      path: configPath,
+      verification: verification.status,
+      error: "Canonical Kakaogames registry candidate is unavailable.",
+      diagnostics: await getGameInstallPathDiagnostics(serviceId, gameId),
+    };
+  }
+
+  const registrationResult =
+    await registerCanonicalRegistryInstallPathAtomically(
+      candidates,
+      configPath,
+    );
+  if (registrationResult.status !== "registered") {
+    return {
+      ok: false,
+      path: configPath,
+      verification: verification.status,
+      error: formatRegistryRegistrationError(registrationResult),
+      diagnostics: await getGameInstallPathDiagnostics(serviceId, gameId),
+    };
+  }
+
+  logger.log(
+    `[Registry] Registered canonical install path for ${gameId} (${serviceId}); legacy registry candidate remains unchanged.`,
+  );
+
+  return {
+    ok: true,
+    path: configPath,
+    registryPath: canonical.path,
+    registryValueName: canonical.key,
+    diagnostics: await getGameInstallPathDiagnostics(serviceId, gameId),
+  };
+};
+
 export const clearGameInstallPath = async (
   serviceId: AppConfig["serviceChannel"],
   gameId: AppConfig["activeGame"],
   source: GameInstallPathClearSource,
+  registryTarget?: GameInstallPathRegistryTarget,
 ): Promise<GameInstallPathClearResult> => {
   if (source === "config") {
     const context = ContextProvider.get();
@@ -1011,12 +1588,30 @@ export const clearGameInstallPath = async (
     };
   }
 
-  const deleted = await deleteRegistryInstallPath(serviceId, gameId);
-  if (!deleted) {
+  const targetResolution = resolveRegistryTarget(
+    serviceId,
+    gameId,
+    registryTarget,
+  );
+  if (!targetResolution.ok) {
     return {
       ok: false,
       source,
-      error: "Failed to delete registry install path.",
+      error: targetResolution.error,
+      diagnostics: await getGameInstallPathDiagnostics(serviceId, gameId),
+    };
+  }
+
+  const mutationResult = await mutateRegistryInstallPathConditionally(
+    targetResolution.registryInfo,
+    targetResolution.expectedPath,
+    { kind: "delete" },
+  );
+  if (mutationResult.status !== "mutated") {
+    return {
+      ok: false,
+      source,
+      error: formatConditionalRegistryMutationError(mutationResult),
       diagnostics: await getGameInstallPathDiagnostics(serviceId, gameId),
     };
   }
@@ -1032,10 +1627,10 @@ export const resolveGameInstallPathConflict = async (
   serviceId: AppConfig["serviceChannel"],
   gameId: AppConfig["activeGame"],
   action: GameInstallPathConflictAction,
+  registryTarget: GameInstallPathConflictTarget,
 ): Promise<GameInstallPathConflictResolveResult> => {
   const diagnostics = await getGameInstallPathDiagnostics(serviceId, gameId);
   const configPath = diagnostics.config.path;
-  const registryPath = diagnostics.registry.path;
 
   if (!configPath) {
     return {
@@ -1061,15 +1656,35 @@ export const resolveGameInstallPathConflict = async (
     };
   }
 
+  if (
+    typeof registryTarget?.expectedConfigPath !== "string" ||
+    !areSameInstallPath(configPath, registryTarget.expectedConfigPath)
+  ) {
+    return {
+      ok: false,
+      action,
+      path: configPath,
+      verification: verification.status,
+      error:
+        "Launcher config path changed since confirmation. Run diagnostics again.",
+      diagnostics,
+    };
+  }
+
   if (action === "launcher-config-only") {
-    if (!registryPath) {
+    const targetValidation = await validateRegistryTargetCurrent(
+      serviceId,
+      gameId,
+      registryTarget,
+    );
+    if (!targetValidation.ok) {
       return {
         ok: false,
         action,
         path: configPath,
         verification: verification.status,
-        error: "Registry path is empty.",
-        diagnostics,
+        error: targetValidation.error,
+        diagnostics: await getGameInstallPathDiagnostics(serviceId, gameId),
       };
     }
 
@@ -1078,7 +1693,7 @@ export const resolveGameInstallPathConflict = async (
       gameId,
       {
         configPath,
-        registryPath,
+        registryPath: targetValidation.currentPath,
         resolvedAt: Date.now(),
       },
     );
@@ -1106,15 +1721,35 @@ export const resolveGameInstallPathConflict = async (
     };
   }
 
-  const written = await writeRegistryInstallPath(serviceId, gameId, configPath);
-  if (!written) {
+  const targetResolution = resolveRegistryTarget(
+    serviceId,
+    gameId,
+    registryTarget,
+  );
+  if (!targetResolution.ok) {
     return {
       ok: false,
       action,
       path: configPath,
       verification: verification.status,
-      error: "Failed to update registry install path.",
-      diagnostics,
+      error: targetResolution.error,
+      diagnostics: await getGameInstallPathDiagnostics(serviceId, gameId),
+    };
+  }
+
+  const mutationResult = await mutateRegistryInstallPathConditionally(
+    targetResolution.registryInfo,
+    targetResolution.expectedPath,
+    { kind: "set", installPath: configPath },
+  );
+  if (mutationResult.status !== "mutated") {
+    return {
+      ok: false,
+      action,
+      path: configPath,
+      verification: verification.status,
+      error: formatConditionalRegistryMutationError(mutationResult),
+      diagnostics: await getGameInstallPathDiagnostics(serviceId, gameId),
     };
   }
 
@@ -1226,6 +1861,125 @@ export const getGameInstallationStatus = async (
 
   logInstallPathResolutionFailure(serviceId, gameId, resolution);
   return "uninstalled";
+};
+
+/**
+ * Produces the install availability and Kakao registry advisory from one path
+ * inspection. A valid configured path remains authoritative for launching, but
+ * Kakao registry candidates are still inspected so recovery guidance can be
+ * carried with the same status reconciliation result.
+ */
+export const getGameInstallPathHealth = async (
+  serviceId: AppConfig["serviceChannel"],
+  gameId: AppConfig["activeGame"],
+  checkedAt = Date.now(),
+): Promise<GameInstallPathHealth> => {
+  const diagnostics: string[] = [];
+  const configuredPath = getConfiguredGameInstallPath(serviceId, gameId);
+  let configuredVerification: InstallPathVerificationStatus | null = null;
+  let configuredVerifyError: string | undefined;
+
+  if (configuredPath.path) {
+    const verification = await verifyGameInstallPath(
+      serviceId,
+      configuredPath.path,
+    );
+    configuredVerification = verification.status;
+    configuredVerifyError = verification.error;
+
+    if (verification.status !== "valid") {
+      diagnostics.push(
+        formatPathCheckFailure(
+          serviceId,
+          "config",
+          configuredPath.path,
+          verification.status,
+          verification.error,
+        ),
+      );
+    }
+  } else {
+    diagnostics.push(`config=${configuredPath.state}`);
+  }
+
+  if (configuredVerification === "valid" && serviceId === "GGG") {
+    return { installationStatus: "installed", checkedAt };
+  }
+
+  const registryInspection = await inspectRegistryInstallPaths(
+    serviceId,
+    gameId,
+  );
+
+  if (configuredVerification === "valid") {
+    return {
+      installationStatus: "installed",
+      checkedAt,
+      ...(registryInspection.aggregateState === "valid"
+        ? {}
+        : {
+            registryAdvisory: {
+              state: registryInspection.aggregateState,
+            },
+          }),
+    };
+  }
+
+  if (registryInspection.activeCandidate?.path) {
+    if (configuredPath.state === "empty") {
+      await persistDiscoveredGameInstallPath(
+        serviceId,
+        gameId,
+        registryInspection.activeCandidate.path,
+      );
+    }
+
+    return { installationStatus: "installed", checkedAt };
+  }
+
+  for (const candidate of registryInspection.candidates) {
+    const registryLabel = getRegistryInstallPathLabel(candidate);
+    if (candidate.state === "read-failed") {
+      diagnostics.push(`registry=read-failed (${registryLabel})`);
+    } else if (!candidate.path) {
+      diagnostics.push(`registry=${candidate.state} (${registryLabel})`);
+    } else if (
+      candidate.verification === "missing" ||
+      candidate.verification === "unknown"
+    ) {
+      diagnostics.push(
+        `${formatPathCheckFailure(
+          serviceId,
+          "registry",
+          candidate.path,
+          candidate.verification,
+          candidate.error,
+        )} (${registryLabel})`,
+      );
+    }
+  }
+
+  const hasUnknownResult =
+    configuredVerification === "unknown" ||
+    Boolean(configuredVerifyError) ||
+    registryInspection.aggregateState === "unknown";
+  const resolution: InstallPathResolution = {
+    path: null,
+    error: registryInspection.candidates.find(
+      (candidate) => candidate.state === "read-failed",
+    )?.error,
+    verifyError:
+      registryInspection.candidates.find(
+        (candidate) => candidate.verification === "unknown",
+      )?.error ?? configuredVerifyError,
+    diagnostics,
+  };
+  logInstallPathResolutionFailure(serviceId, gameId, resolution);
+
+  return {
+    installationStatus: hasUnknownResult ? "unknown" : "uninstalled",
+    checkedAt,
+  };
 };
 
 export const isGameInstalled = async (

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -22,7 +22,11 @@ import {
   KakaoGameStarterMigrationRequest,
   GameInstallPathConflictTarget,
   GameInstallPathDiagnostics,
-  GameInstallPathRegistryTarget,
+  GameInstallPathRegistryTargetDeleteRequest,
+  GameInstallPathSelectionBatchResult,
+  GameInstallPathSelectionDescriptor,
+  GameInstallPathSelectionResult,
+  GameInstallPathTargetId,
   OperationalNotification,
   RenewedPatchReservation,
   RenewedPatchReservationInput,
@@ -65,7 +69,13 @@ import {
   getGameStartButtonLabel,
   shouldOpenGamePathDiagnostic,
 } from "./utils/game-start-label";
-import { updateGamePathModalForContext } from "./utils/game-path-modal-state";
+import {
+  applyGamePathSelectionBatchForContext,
+  createGamePathModalOperationTracker,
+  type GamePathModalOperation,
+  type GamePathSelectionPresentationResult,
+  updateGamePathModalForContext,
+} from "./utils/game-path-modal-state";
 import { createGamePathRegistryWarning } from "./utils/game-path-registry-warning";
 import { logger } from "./utils/logger";
 import { applyThemeColors, DEFAULT_THEME_COLORS } from "./utils/theme";
@@ -84,6 +94,7 @@ type KakaoMaintenanceModalInfo = KakaoMaintenanceInfo & {
 type GamePathModalMode = "conflict" | "missing" | "diagnostic";
 
 type GamePathModalState = {
+  generation: number;
   mode: GamePathModalMode;
   gameId: AppConfig["activeGame"];
   serviceId: AppConfig["serviceChannel"];
@@ -92,34 +103,27 @@ type GamePathModalState = {
   errorMessage?: string;
   highlightManual?: boolean;
   showRegistrySyncConfirm?: boolean;
-  showRegistryClearConfirm?: boolean;
   showRegistryRegisterConfirm?: boolean;
+  selection?: GameInstallPathSelectionDescriptor;
+  selectionApplyResult?: GamePathSelectionPresentationResult;
+  registryDeleteTarget?: GameInstallPathRegistryTargetDeleteRequest;
   manualSaveToastId?: number;
   registrySaveToastId?: number;
 };
 
 type GamePathSource = "config" | "registry";
 
-const getRegistryMutationTarget = (
-  diagnostics: GameInstallPathDiagnostics,
-): GameInstallPathRegistryTarget | null => {
-  if (!diagnostics.registry.path) return null;
-
-  return {
-    registryPath: diagnostics.registry.registryPath,
-    registryValueName: diagnostics.registry.registryValueName,
-    expectedPath: diagnostics.registry.path,
-  };
-};
-
 const getRegistryConflictTarget = (
   diagnostics: GameInstallPathDiagnostics,
 ): GameInstallPathConflictTarget | null => {
-  const registryTarget = getRegistryMutationTarget(diagnostics);
-  if (!registryTarget || !diagnostics.config.path) return null;
+  const registryTarget = diagnostics.registry.candidates.find(
+    (candidate) => candidate.isActive && candidate.path,
+  );
+  if (!registryTarget?.path || !diagnostics.config.path) return null;
 
   return {
-    ...registryTarget,
+    targetId: registryTarget.targetId,
+    expectedPath: registryTarget.path,
     expectedConfigPath: diagnostics.config.path,
   };
 };
@@ -193,6 +197,34 @@ const getGamePathSaveErrorMessage = (
   }
 
   return fallback || "게임 경로를 저장하지 못했습니다.";
+};
+
+const getGamePathSelectionErrorMessage = (
+  result: Exclude<GameInstallPathSelectionResult, { ok: true }>,
+) => {
+  if (result.status === "canceled") return undefined;
+  if (result.status === "unavailable") {
+    return "경로 선택 세션을 만들 수 없습니다. 잠시 후 다시 시도해 주세요.";
+  }
+  return getGamePathSaveErrorMessage(result.verification);
+};
+
+const getGamePathBatchErrorMessage = (
+  result: GameInstallPathSelectionBatchResult,
+) => {
+  if (result.results.length > 0) return undefined;
+  if (!("failureCode" in result)) return undefined;
+  if (result.failureCode === "selection-busy") {
+    return "선택한 경로를 이미 적용 중입니다.";
+  }
+  if (
+    result.failureCode === "selection-not-found" ||
+    result.failureCode === "selection-expired" ||
+    result.failureCode === "selection-invalidated"
+  ) {
+    return "경로 선택이 만료되었습니다. 폴더를 다시 선택해 주세요.";
+  }
+  return "선택한 저장 위치에 경로를 적용하지 못했습니다.";
 };
 
 const NEWS_OPEN_MODE_OPTIONS: Array<{
@@ -283,6 +315,10 @@ function App() {
   );
   const [gamePathModalState, setGamePathModalState] =
     useState<GamePathModalState | null>(null);
+  const gamePathModalGenerationRef = useRef(0);
+  const gamePathModalOperationTrackerRef = useRef(
+    createGamePathModalOperationTracker(),
+  );
   const shownGamePathConflictKeysRef = useRef<Set<string>>(new Set());
 
   const [bgImage, setBgImage] = useState(bgPoe);
@@ -366,7 +402,10 @@ function App() {
         }
 
         shownGamePathConflictKeysRef.current.add(contextKey);
+        const generation = ++gamePathModalGenerationRef.current;
+        gamePathModalOperationTrackerRef.current.activateGeneration(generation);
         setGamePathModalState({
+          generation,
           mode: "conflict",
           serviceId,
           gameId,
@@ -1202,6 +1241,21 @@ function App() {
     [],
   );
 
+  const beginGamePathModalOperation = useCallback(
+    (
+      operation: GamePathModalOperation,
+      state: GamePathModalState,
+      selectionId?: string,
+    ) =>
+      gamePathModalOperationTrackerRef.current.begin(operation, {
+        generation: state.generation,
+        serviceId: state.serviceId,
+        gameId: state.gameId,
+        ...(selectionId ? { selectionId } : {}),
+      }),
+    [],
+  );
+
   const openGamePathModal = useCallback(
     async (
       mode: GamePathModalMode,
@@ -1214,7 +1268,9 @@ function App() {
         return;
       }
 
-      setGamePathModalState({
+      const generation = ++gamePathModalGenerationRef.current;
+      const initialState: GamePathModalState = {
+        generation,
         mode,
         serviceId,
         gameId,
@@ -1222,9 +1278,15 @@ function App() {
         busy: true,
         highlightManual: options?.highlightManual ?? false,
         showRegistrySyncConfirm: false,
-        showRegistryClearConfirm: false,
         showRegistryRegisterConfirm: false,
-      });
+      };
+      gamePathModalOperationTrackerRef.current.activateGeneration(generation);
+      const request = gamePathModalOperationTrackerRef.current.begin(
+        "diagnostics",
+        initialState,
+      );
+      if (!request) return;
+      setGamePathModalState(initialState);
 
       try {
         const diagnostics =
@@ -1233,33 +1295,36 @@ function App() {
             gameId,
           );
 
-        setGamePathModalState((current) => {
-          if (
-            !current ||
-            current.mode !== mode ||
-            current.serviceId !== serviceId ||
-            current.gameId !== gameId
-          ) {
-            return current;
-          }
-
-          return {
-            ...current,
-            diagnostics,
-            busy: false,
-            errorMessage: undefined,
-          };
-        });
+        if (!gamePathModalOperationTrackerRef.current.finish(request)) return;
+        setGamePathModalState((current) =>
+          updateGamePathModalForContext(
+            current,
+            serviceId,
+            gameId,
+            (matched) => ({
+              ...matched,
+              diagnostics,
+              busy: false,
+              errorMessage: undefined,
+            }),
+            request,
+          ),
+        );
       } catch (error) {
-        setGamePathModalState((current) => {
-          if (!current) return current;
-
-          return {
-            ...current,
-            busy: false,
-            errorMessage: `게임 경로를 확인하지 못했습니다. ${formatUnknownError(error)}`,
-          };
-        });
+        if (!gamePathModalOperationTrackerRef.current.finish(request)) return;
+        setGamePathModalState((current) =>
+          updateGamePathModalForContext(
+            current,
+            serviceId,
+            gameId,
+            (matched) => ({
+              ...matched,
+              busy: false,
+              errorMessage: `게임 경로를 확인하지 못했습니다. ${formatUnknownError(error)}`,
+            }),
+            request,
+          ),
+        );
       }
     },
     [],
@@ -1293,10 +1358,19 @@ function App() {
         return;
       }
 
+      const generation = ++gamePathModalGenerationRef.current;
+      gamePathModalOperationTrackerRef.current.activateGeneration(generation);
+      const request = gamePathModalOperationTrackerRef.current.begin(
+        "diagnostics",
+        { generation, serviceId, gameId },
+      );
+      if (!request) return;
+
       setGamePathModalState((current) =>
         current
           ? {
               ...current,
+              generation,
               mode: "diagnostic",
               serviceId,
               gameId,
@@ -1305,8 +1379,10 @@ function App() {
               errorMessage: undefined,
               highlightManual: false,
               showRegistrySyncConfirm: false,
-              showRegistryClearConfirm: false,
               showRegistryRegisterConfirm: false,
+              selection: undefined,
+              selectionApplyResult: undefined,
+              registryDeleteTarget: undefined,
             }
           : current,
       );
@@ -1318,43 +1394,38 @@ function App() {
             gameId,
           );
 
-        setGamePathModalState((current) => {
-          if (
-            !current ||
-            current.serviceId !== serviceId ||
-            current.gameId !== gameId
-          ) {
-            return current;
-          }
-
-          return {
-            ...current,
-            diagnostics,
-            busy: false,
-          };
-        });
+        if (!gamePathModalOperationTrackerRef.current.finish(request)) return;
+        setGamePathModalState((current) =>
+          updateGamePathModalForContext(
+            current,
+            serviceId,
+            gameId,
+            (matched) => ({ ...matched, diagnostics, busy: false }),
+            request,
+          ),
+        );
       } catch (error) {
-        setGamePathModalState((current) => {
-          if (
-            !current ||
-            current.serviceId !== serviceId ||
-            current.gameId !== gameId
-          ) {
-            return current;
-          }
-
-          return {
-            ...current,
-            busy: false,
-            errorMessage: `게임 경로를 확인하지 못했습니다. ${formatUnknownError(error)}`,
-          };
-        });
+        if (!gamePathModalOperationTrackerRef.current.finish(request)) return;
+        setGamePathModalState((current) =>
+          updateGamePathModalForContext(
+            current,
+            serviceId,
+            gameId,
+            (matched) => ({
+              ...matched,
+              busy: false,
+              errorMessage: `게임 경로를 확인하지 못했습니다. ${formatUnknownError(error)}`,
+            }),
+            request,
+          ),
+        );
       }
     },
     [gamePathModalState],
   );
 
   const handleGamePathModalClose = useCallback(() => {
+    gamePathModalOperationTrackerRef.current.invalidate();
     setGamePathModalState(null);
   }, []);
 
@@ -1386,8 +1457,8 @@ function App() {
             ? {
                 ...current,
                 showRegistrySyncConfirm: true,
-                showRegistryClearConfirm: false,
                 showRegistryRegisterConfirm: false,
+                registryDeleteTarget: undefined,
                 errorMessage: undefined,
               }
             : current,
@@ -1407,6 +1478,7 @@ function App() {
         );
 
         if (result.ok) {
+          gamePathModalOperationTrackerRef.current.invalidate();
           setGamePathModalState(null);
           void syncGameState(gameId, serviceId);
           return;
@@ -1444,75 +1516,175 @@ function App() {
     if (!window.electronAPI || !gamePathModalState) return;
 
     const { serviceId, gameId } = gamePathModalState;
+    const request = beginGamePathModalOperation("picker", gamePathModalState);
+    if (!request) return;
     setGamePathModalState((current) =>
-      current ? { ...current, busy: true, errorMessage: undefined } : current,
+      updateGamePathModalForContext(
+        current,
+        serviceId,
+        gameId,
+        (matched) => ({
+          ...matched,
+          busy: true,
+          errorMessage: undefined,
+          selection: undefined,
+          selectionApplyResult: undefined,
+          registryDeleteTarget: undefined,
+        }),
+        request,
+      ),
     );
 
     try {
-      const result = await window.electronAPI.pickGameInstallPath(
+      const result = await window.electronAPI.pickGameInstallPathTargets(
         serviceId,
         gameId,
       );
+      if (!gamePathModalOperationTrackerRef.current.finish(request)) return;
 
       if (result.ok) {
         setGamePathModalState((current) =>
-          current
-            ? {
-                ...current,
-                mode: "diagnostic",
-                diagnostics: result.diagnostics,
-                busy: false,
-                errorMessage: undefined,
-                highlightManual: false,
-                showRegistrySyncConfirm: false,
-                showRegistryClearConfirm: false,
-                showRegistryRegisterConfirm: false,
-                manualSaveToastId: Date.now(),
-              }
-            : current,
+          updateGamePathModalForContext(
+            current,
+            serviceId,
+            gameId,
+            (matched) => ({
+              ...matched,
+              mode: "diagnostic",
+              busy: false,
+              errorMessage: undefined,
+              highlightManual: false,
+              showRegistrySyncConfirm: false,
+              showRegistryRegisterConfirm: false,
+              selection: result.selection,
+              selectionApplyResult: undefined,
+            }),
+            request,
+          ),
         );
-
-        void syncGameState(gameId, serviceId);
         return;
       }
 
       setGamePathModalState((current) =>
-        current
-          ? {
-              ...current,
-              diagnostics: result.diagnostics || current.diagnostics,
-              busy: false,
-              errorMessage: result.canceled
-                ? undefined
-                : getGamePathSaveErrorMessage(
-                    result.verification,
-                    result.error,
-                  ),
-            }
-          : current,
+        updateGamePathModalForContext(
+          current,
+          serviceId,
+          gameId,
+          (matched) => ({
+            ...matched,
+            busy: false,
+            errorMessage: getGamePathSelectionErrorMessage(result),
+          }),
+          request,
+        ),
       );
     } catch (error) {
+      if (!gamePathModalOperationTrackerRef.current.finish(request)) return;
       setGamePathModalState((current) =>
-        current
-          ? {
-              ...current,
-              busy: false,
-              errorMessage: `수동 경로를 저장하지 못했습니다. ${formatUnknownError(error)}`,
-            }
-          : current,
+        updateGamePathModalForContext(
+          current,
+          serviceId,
+          gameId,
+          (matched) => ({
+            ...matched,
+            busy: false,
+            errorMessage: `수동 경로를 선택하지 못했습니다. ${formatUnknownError(error)}`,
+          }),
+          request,
+        ),
       );
     }
-  }, [gamePathModalState, syncGameState]);
+  }, [beginGamePathModalOperation, gamePathModalState]);
+
+  const handleApplyGamePathTargets = useCallback(
+    async (targetIds: readonly GameInstallPathTargetId[]) => {
+      if (!window.electronAPI || !gamePathModalState?.selection) return;
+
+      const { serviceId, gameId, selection } = gamePathModalState;
+      const request = beginGamePathModalOperation(
+        "apply",
+        gamePathModalState,
+        selection.selectionId,
+      );
+      if (!request) return;
+      setGamePathModalState((current) =>
+        updateGamePathModalForContext(
+          current,
+          serviceId,
+          gameId,
+          (matched) => ({
+            ...matched,
+            busy: true,
+            errorMessage: undefined,
+          }),
+          request,
+        ),
+      );
+
+      try {
+        const result = await window.electronAPI.applyGameInstallPathTargets(
+          selection.selectionId,
+          targetIds,
+        );
+        if (!gamePathModalOperationTrackerRef.current.finish(request)) return;
+        setGamePathModalState((current) => {
+          const updated = applyGamePathSelectionBatchForContext(
+            current,
+            serviceId,
+            gameId,
+            result,
+            request,
+          );
+          return updateGamePathModalForContext(
+            updated,
+            serviceId,
+            gameId,
+            (matched) => ({
+              ...matched,
+              errorMessage: getGamePathBatchErrorMessage(result),
+              manualSaveToastId: result.ok
+                ? Date.now()
+                : matched.manualSaveToastId,
+            }),
+            request,
+          );
+        });
+        if (result.ok) void syncGameState(gameId, serviceId);
+      } catch (error) {
+        if (!gamePathModalOperationTrackerRef.current.finish(request)) return;
+        setGamePathModalState((current) =>
+          updateGamePathModalForContext(
+            current,
+            serviceId,
+            gameId,
+            (matched) => ({
+              ...matched,
+              busy: false,
+              errorMessage: `게임 경로를 적용하지 못했습니다. ${formatUnknownError(error)}`,
+            }),
+            request,
+          ),
+        );
+      }
+    },
+    [beginGamePathModalOperation, gamePathModalState, syncGameState],
+  );
+
+  const handleGamePathSelectionClose = useCallback(() => {
+    setGamePathModalState((current) =>
+      current
+        ? {
+            ...current,
+            selection: undefined,
+            selectionApplyResult: undefined,
+          }
+        : current,
+    );
+  }, []);
 
   const handleGamePathConflictConfirmClose = useCallback(() => {
     setGamePathModalState((current) =>
       current ? { ...current, showRegistrySyncConfirm: false } : current,
-    );
-  }, []);
-
-  const handleGamePathRegistryClearConfirmClose = useCallback(() => {
-    setGamePathModalState((current) =>
-      current ? { ...current, showRegistryClearConfirm: false } : current,
     );
   }, []);
 
@@ -1523,7 +1695,7 @@ function App() {
             ...current,
             showRegistryRegisterConfirm: true,
             showRegistrySyncConfirm: false,
-            showRegistryClearConfirm: false,
+            registryDeleteTarget: undefined,
             errorMessage: undefined,
           }
         : current,
@@ -1558,13 +1730,22 @@ function App() {
       return;
     }
 
+    const request = beginGamePathModalOperation("register", gamePathModalState);
+    if (!request) return;
+
     setGamePathModalState((current) =>
-      updateGamePathModalForContext(current, serviceId, gameId, (matched) => ({
-        ...matched,
-        busy: true,
-        showRegistryRegisterConfirm: false,
-        errorMessage: undefined,
-      })),
+      updateGamePathModalForContext(
+        current,
+        serviceId,
+        gameId,
+        (matched) => ({
+          ...matched,
+          busy: true,
+          showRegistryRegisterConfirm: false,
+          errorMessage: undefined,
+        }),
+        request,
+      ),
     );
 
     try {
@@ -1573,6 +1754,7 @@ function App() {
         gameId,
         { expectedConfigPath },
       );
+      if (!gamePathModalOperationTrackerRef.current.finish(request)) return;
 
       if (result.ok) {
         setGamePathModalState((current) =>
@@ -1589,6 +1771,7 @@ function App() {
               showRegistryRegisterConfirm: false,
               registrySaveToastId: Date.now(),
             }),
+            request,
           ),
         );
         void syncGameState(gameId, serviceId);
@@ -1607,9 +1790,11 @@ function App() {
             errorMessage:
               result.error || getGamePathSaveErrorMessage(result.verification),
           }),
+          request,
         ),
       );
     } catch (error) {
+      if (!gamePathModalOperationTrackerRef.current.finish(request)) return;
       setGamePathModalState((current) =>
         updateGamePathModalForContext(
           current,
@@ -1620,115 +1805,186 @@ function App() {
             busy: false,
             errorMessage: `레지스트리 게임 경로를 등록하지 못했습니다. ${formatUnknownError(error)}`,
           }),
+          request,
         ),
       );
     }
-  }, [gamePathModalState, syncGameState]);
+  }, [beginGamePathModalOperation, gamePathModalState, syncGameState]);
 
-  const handleClearGamePath = useCallback(
-    async (source: GamePathSource, confirmed = false) => {
-      if (!window.electronAPI || !gamePathModalState) return;
+  const handleClearGamePath = useCallback(async () => {
+    if (!window.electronAPI || !gamePathModalState) return;
 
-      if (source === "registry" && !confirmed) {
+    const { serviceId, gameId } = gamePathModalState;
+    const request = beginGamePathModalOperation(
+      "config-clear",
+      gamePathModalState,
+    );
+    if (!request) return;
+    setGamePathModalState((current) =>
+      updateGamePathModalForContext(
+        current,
+        serviceId,
+        gameId,
+        (matched) => ({
+          ...matched,
+          busy: true,
+          errorMessage: undefined,
+          showRegistryRegisterConfirm: false,
+        }),
+        request,
+      ),
+    );
+
+    try {
+      const result = await window.electronAPI.clearGameInstallPath(
+        serviceId,
+        gameId,
+      );
+      if (!gamePathModalOperationTrackerRef.current.finish(request)) return;
+
+      if (result.ok) {
         setGamePathModalState((current) =>
-          current
-            ? {
-                ...current,
-                showRegistryClearConfirm: true,
-                showRegistrySyncConfirm: false,
-                showRegistryRegisterConfirm: false,
-                errorMessage: undefined,
-              }
-            : current,
+          updateGamePathModalForContext(
+            current,
+            serviceId,
+            gameId,
+            (matched) => ({
+              ...matched,
+              mode: "diagnostic",
+              diagnostics: result.diagnostics,
+              busy: false,
+              errorMessage: undefined,
+              showRegistrySyncConfirm: false,
+              showRegistryRegisterConfirm: false,
+            }),
+            request,
+          ),
         );
+        void syncGameState(gameId, serviceId);
         return;
       }
 
-      const registryTarget =
-        source === "registry" && gamePathModalState.diagnostics
-          ? getRegistryMutationTarget(gamePathModalState.diagnostics)
-          : undefined;
-      if (source === "registry" && !registryTarget) {
-        setGamePathModalState((current) =>
-          current
-            ? {
-                ...current,
-                errorMessage:
-                  "삭제할 레지스트리 대상을 확인할 수 없습니다. 다시 진단해 주세요.",
-              }
-            : current,
-        );
-        return;
-      }
+      setGamePathModalState((current) =>
+        updateGamePathModalForContext(
+          current,
+          serviceId,
+          gameId,
+          (matched) => ({
+            ...matched,
+            diagnostics: result.diagnostics || matched.diagnostics,
+            busy: false,
+            errorMessage:
+              result.error || "저장된 게임 경로를 삭제하지 못했습니다.",
+          }),
+          request,
+        ),
+      );
+    } catch (error) {
+      if (!gamePathModalOperationTrackerRef.current.finish(request)) return;
+      setGamePathModalState((current) =>
+        updateGamePathModalForContext(
+          current,
+          serviceId,
+          gameId,
+          (matched) => ({
+            ...matched,
+            busy: false,
+            errorMessage: `게임 경로를 삭제하지 못했습니다. ${formatUnknownError(error)}`,
+          }),
+          request,
+        ),
+      );
+    }
+  }, [beginGamePathModalOperation, gamePathModalState, syncGameState]);
 
-      const { serviceId, gameId } = gamePathModalState;
+  const handleGamePathRegistryDeleteRequest = useCallback(
+    (request: GameInstallPathRegistryTargetDeleteRequest) => {
       setGamePathModalState((current) =>
         current
           ? {
               ...current,
-              busy: true,
-              errorMessage: undefined,
-              showRegistryClearConfirm: false,
+              registryDeleteTarget: request,
+              showRegistrySyncConfirm: false,
               showRegistryRegisterConfirm: false,
+              errorMessage: undefined,
             }
           : current,
       );
+    },
+    [],
+  );
 
-      try {
-        const result = await window.electronAPI.clearGameInstallPath(
+  const handleGamePathRegistryDeleteConfirmClose = useCallback(() => {
+    setGamePathModalState((current) =>
+      current ? { ...current, registryDeleteTarget: undefined } : current,
+    );
+  }, []);
+
+  const handleDeleteGamePathRegistryTarget = useCallback(async () => {
+    if (!window.electronAPI || !gamePathModalState?.registryDeleteTarget) {
+      return;
+    }
+
+    const { serviceId, gameId, registryDeleteTarget } = gamePathModalState;
+    const request = beginGamePathModalOperation("delete", gamePathModalState);
+    if (!request) return;
+    setGamePathModalState((current) =>
+      updateGamePathModalForContext(
+        current,
+        serviceId,
+        gameId,
+        (matched) => ({
+          ...matched,
+          busy: true,
+          errorMessage: undefined,
+        }),
+        request,
+      ),
+    );
+
+    try {
+      const result =
+        await window.electronAPI.deleteGameInstallPathRegistryTarget(
           serviceId,
           gameId,
-          source,
-          registryTarget || undefined,
+          registryDeleteTarget,
         );
-
-        if (result.ok) {
-          setGamePathModalState((current) =>
-            current
-              ? {
-                  ...current,
-                  mode: "diagnostic",
-                  diagnostics: result.diagnostics,
-                  busy: false,
-                  errorMessage: undefined,
-                  showRegistrySyncConfirm: false,
-                  showRegistryClearConfirm: false,
-                  showRegistryRegisterConfirm: false,
-                }
-              : current,
-          );
-          void syncGameState(gameId, serviceId);
-          return;
-        }
-
-        setGamePathModalState((current) =>
-          current
-            ? {
-                ...current,
-                diagnostics: result.diagnostics || current.diagnostics,
-                busy: false,
-                errorMessage:
-                  result.error ||
-                  (source === "registry"
-                    ? "레지스트리 설치 경로를 삭제하지 못했습니다."
-                    : "저장된 게임 경로를 삭제하지 못했습니다."),
-              }
-            : current,
-        );
-      } catch (error) {
-        setGamePathModalState((current) =>
-          current
-            ? {
-                ...current,
-                busy: false,
-                errorMessage: `게임 경로를 삭제하지 못했습니다. ${formatUnknownError(error)}`,
-              }
-            : current,
-        );
-      }
-    },
-    [gamePathModalState, syncGameState],
-  );
+      if (!gamePathModalOperationTrackerRef.current.finish(request)) return;
+      setGamePathModalState((current) =>
+        updateGamePathModalForContext(
+          current,
+          serviceId,
+          gameId,
+          (matched) => ({
+            ...matched,
+            diagnostics: result.diagnostics,
+            busy: false,
+            registryDeleteTarget: undefined,
+            errorMessage: result.ok
+              ? undefined
+              : "레지스트리 경로값을 삭제하지 못했습니다. 최신 상태를 확인해 주세요.",
+          }),
+          request,
+        ),
+      );
+      if (result.ok) void syncGameState(gameId, serviceId);
+    } catch (error) {
+      if (!gamePathModalOperationTrackerRef.current.finish(request)) return;
+      setGamePathModalState((current) =>
+        updateGamePathModalForContext(
+          current,
+          serviceId,
+          gameId,
+          (matched) => ({
+            ...matched,
+            busy: false,
+            errorMessage: `레지스트리 경로값을 삭제하지 못했습니다. ${formatUnknownError(error)}`,
+          }),
+          request,
+        ),
+      );
+    }
+  }, [beginGamePathModalOperation, gamePathModalState, syncGameState]);
 
   const handleResolveGamePathConflict = useCallback(
     async (action: "launcher-config-only" | "sync-registry") => {
@@ -1751,17 +2007,27 @@ function App() {
         return;
       }
 
+      const request = beginGamePathModalOperation(
+        "conflict",
+        gamePathModalState,
+      );
+      if (!request) return;
+
       setGamePathModalState((current) =>
-        current
-          ? {
-              ...current,
-              busy: true,
-              errorMessage: undefined,
-              showRegistrySyncConfirm: false,
-              showRegistryClearConfirm: false,
-              showRegistryRegisterConfirm: false,
-            }
-          : current,
+        updateGamePathModalForContext(
+          current,
+          serviceId,
+          gameId,
+          (matched) => ({
+            ...matched,
+            busy: true,
+            errorMessage: undefined,
+            showRegistrySyncConfirm: false,
+            showRegistryRegisterConfirm: false,
+            registryDeleteTarget: undefined,
+          }),
+          request,
+        ),
       );
 
       try {
@@ -1771,52 +2037,64 @@ function App() {
           action,
           registryTarget,
         );
+        if (!gamePathModalOperationTrackerRef.current.finish(request)) return;
 
         if (result.ok) {
+          gamePathModalOperationTrackerRef.current.invalidate();
           setGamePathModalState(null);
           void syncGameState(gameId, serviceId);
           return;
         }
 
         setGamePathModalState((current) =>
-          current
-            ? {
-                ...current,
-                diagnostics: result.diagnostics || current.diagnostics,
-                busy: false,
-                errorMessage:
-                  result.verification === "valid" &&
-                  result.action === "sync-registry"
-                    ? "레지스트리 설치 경로를 업데이트하지 못했습니다."
-                    : result.verification === "valid" &&
-                        result.action === "launcher-config-only"
-                      ? "경로 충돌 확인 상태를 저장하지 못했습니다."
-                      : getGamePathSaveErrorMessage(
-                          result.verification,
-                          result.error,
-                        ),
-              }
-            : current,
+          updateGamePathModalForContext(
+            current,
+            serviceId,
+            gameId,
+            (matched) => ({
+              ...matched,
+              diagnostics: result.diagnostics || matched.diagnostics,
+              busy: false,
+              errorMessage:
+                result.verification === "valid" &&
+                result.action === "sync-registry"
+                  ? "레지스트리 설치 경로를 업데이트하지 못했습니다."
+                  : result.verification === "valid" &&
+                      result.action === "launcher-config-only"
+                    ? "경로 충돌 확인 상태를 저장하지 못했습니다."
+                    : getGamePathSaveErrorMessage(
+                        result.verification,
+                        result.error,
+                      ),
+            }),
+            request,
+          ),
         );
       } catch (error) {
+        if (!gamePathModalOperationTrackerRef.current.finish(request)) return;
         setGamePathModalState((current) =>
-          current
-            ? {
-                ...current,
-                busy: false,
-                errorMessage: `게임 경로 충돌을 처리하지 못했습니다. ${formatUnknownError(error)}`,
-              }
-            : current,
+          updateGamePathModalForContext(
+            current,
+            serviceId,
+            gameId,
+            (matched) => ({
+              ...matched,
+              busy: false,
+              errorMessage: `게임 경로 충돌을 처리하지 못했습니다. ${formatUnknownError(error)}`,
+            }),
+            request,
+          ),
         );
       }
     },
-    [gamePathModalState, syncGameState],
+    [beginGamePathModalOperation, gamePathModalState, syncGameState],
   );
 
   const handleGamePathInstall = useCallback(() => {
     if (!gamePathModalState) return;
 
     openDownloadPage(gamePathModalState.serviceId, gamePathModalState.gameId);
+    gamePathModalOperationTrackerRef.current.invalidate();
     setGamePathModalState(null);
   }, [gamePathModalState, openDownloadPage]);
 
@@ -2140,21 +2418,29 @@ function App() {
         showRegistrySyncConfirm={
           gamePathModalState?.showRegistrySyncConfirm ?? false
         }
-        showRegistryClearConfirm={
-          gamePathModalState?.showRegistryClearConfirm ?? false
-        }
         showRegistryRegisterConfirm={
           gamePathModalState?.showRegistryRegisterConfirm ?? false
         }
+        selection={gamePathModalState?.selection}
+        selectionApplyResult={gamePathModalState?.selectionApplyResult}
+        registryDeleteTarget={gamePathModalState?.registryDeleteTarget}
         manualSaveToastId={gamePathModalState?.manualSaveToastId}
         registrySaveToastId={gamePathModalState?.registrySaveToastId}
         onClose={handleGamePathModalClose}
         onContextChange={handleGamePathContextChange}
         onUsePath={handleUseGamePath}
-        onClearPath={(source) => void handleClearGamePath(source)}
+        onClearPath={() => void handleClearGamePath()}
         onManualSelect={handleManualGamePathSelect}
+        onApplyTargets={(targetIds) =>
+          void handleApplyGamePathTargets(targetIds)
+        }
+        onCloseSelection={handleGamePathSelectionClose}
+        onRegistryDeleteRequest={handleGamePathRegistryDeleteRequest}
+        onRegistryDeleteConfirmClose={handleGamePathRegistryDeleteConfirmClose}
+        onConfirmDeleteRegistryTarget={() =>
+          void handleDeleteGamePathRegistryTarget()
+        }
         onRegistrySyncConfirmClose={handleGamePathConflictConfirmClose}
-        onRegistryClearConfirmClose={handleGamePathRegistryClearConfirmClose}
         onRegistryRegisterRequest={handleGamePathRegistryRegisterRequest}
         onRegistryRegisterConfirmClose={
           handleGamePathRegistryRegisterConfirmClose
@@ -2164,9 +2450,6 @@ function App() {
         }
         onSyncRegistry={() =>
           void handleResolveGamePathConflict("sync-registry")
-        }
-        onConfirmClearRegistry={() =>
-          void handleClearGamePath("registry", true)
         }
         onConfirmRegisterRegistry={() => void handleRegisterGamePath()}
         onInstall={

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -20,7 +20,10 @@ import {
   ThemeDefinition,
   KakaoMaintenanceInfo,
   KakaoGameStarterMigrationRequest,
+  GameInstallPathConflictTarget,
   GameInstallPathDiagnostics,
+  GameInstallPathRegistryTarget,
+  OperationalNotification,
   RenewedPatchReservation,
   RenewedPatchReservationInput,
 } from "../shared/types";
@@ -58,7 +61,12 @@ import TitleBar from "./components/TitleBar";
 import UpdateModal from "./components/UpdateModal";
 import { useGameState } from "./contexts/GameStateContext";
 import { VersionService, RemoteVersions } from "./services/VersionService";
-import { getGameStartButtonLabel } from "./utils/game-start-label";
+import {
+  getGameStartButtonLabel,
+  shouldOpenGamePathDiagnostic,
+} from "./utils/game-start-label";
+import { updateGamePathModalForContext } from "./utils/game-path-modal-state";
+import { createGamePathRegistryWarning } from "./utils/game-path-registry-warning";
 import { logger } from "./utils/logger";
 import { applyThemeColors, DEFAULT_THEME_COLORS } from "./utils/theme";
 
@@ -85,10 +93,36 @@ type GamePathModalState = {
   highlightManual?: boolean;
   showRegistrySyncConfirm?: boolean;
   showRegistryClearConfirm?: boolean;
+  showRegistryRegisterConfirm?: boolean;
   manualSaveToastId?: number;
+  registrySaveToastId?: number;
 };
 
 type GamePathSource = "config" | "registry";
+
+const getRegistryMutationTarget = (
+  diagnostics: GameInstallPathDiagnostics,
+): GameInstallPathRegistryTarget | null => {
+  if (!diagnostics.registry.path) return null;
+
+  return {
+    registryPath: diagnostics.registry.registryPath,
+    registryValueName: diagnostics.registry.registryValueName,
+    expectedPath: diagnostics.registry.path,
+  };
+};
+
+const getRegistryConflictTarget = (
+  diagnostics: GameInstallPathDiagnostics,
+): GameInstallPathConflictTarget | null => {
+  const registryTarget = getRegistryMutationTarget(diagnostics);
+  if (!registryTarget || !diagnostics.config.path) return null;
+
+  return {
+    ...registryTarget,
+    expectedConfigPath: diagnostics.config.path,
+  };
+};
 
 // Status Message Mapping (Configuration)
 const STATUS_MESSAGES: Record<RunStatus, StatusMessageConfig> = {
@@ -274,6 +308,19 @@ function App() {
   const activeGameStatus = useMemo(() => {
     return getActiveGameState(config.activeGame, config.serviceChannel);
   }, [config.activeGame, config.serviceChannel, getActiveGameState]);
+  const operationalNotifications = useMemo(() => {
+    if (!isConfigLoaded) return [];
+    const warning = createGamePathRegistryWarning(activeGameStatus, {
+      serviceId: config.serviceChannel,
+      gameId: config.activeGame,
+    });
+    return warning ? [warning] : [];
+  }, [
+    activeGameStatus,
+    config.activeGame,
+    config.serviceChannel,
+    isConfigLoaded,
+  ]);
   const isFontMigrationBlockedByRunningGame = useMemo(() => {
     return (
       getActiveGameState(config.activeGame, "Kakao Games").status ===
@@ -1176,6 +1223,7 @@ function App() {
         highlightManual: options?.highlightManual ?? false,
         showRegistrySyncConfirm: false,
         showRegistryClearConfirm: false,
+        showRegistryRegisterConfirm: false,
       });
 
       try {
@@ -1217,6 +1265,18 @@ function App() {
     [],
   );
 
+  const handleOperationalNotificationClick = useCallback(
+    (notification: OperationalNotification) => {
+      if (notification.action !== "open-game-path-diagnostic") return;
+      void openGamePathModal(
+        "diagnostic",
+        notification.serviceId,
+        notification.gameId,
+      );
+    },
+    [openGamePathModal],
+  );
+
   const handleGamePathContextChange = useCallback(
     async (
       serviceId: AppConfig["serviceChannel"],
@@ -1246,6 +1306,7 @@ function App() {
               highlightManual: false,
               showRegistrySyncConfirm: false,
               showRegistryClearConfirm: false,
+              showRegistryRegisterConfirm: false,
             }
           : current,
       );
@@ -1326,6 +1387,7 @@ function App() {
                 ...current,
                 showRegistrySyncConfirm: true,
                 showRegistryClearConfirm: false,
+                showRegistryRegisterConfirm: false,
                 errorMessage: undefined,
               }
             : current,
@@ -1404,6 +1466,7 @@ function App() {
                 highlightManual: false,
                 showRegistrySyncConfirm: false,
                 showRegistryClearConfirm: false,
+                showRegistryRegisterConfirm: false,
                 manualSaveToastId: Date.now(),
               }
             : current,
@@ -1453,6 +1516,115 @@ function App() {
     );
   }, []);
 
+  const handleGamePathRegistryRegisterRequest = useCallback(() => {
+    setGamePathModalState((current) =>
+      current
+        ? {
+            ...current,
+            showRegistryRegisterConfirm: true,
+            showRegistrySyncConfirm: false,
+            showRegistryClearConfirm: false,
+            errorMessage: undefined,
+          }
+        : current,
+    );
+  }, []);
+
+  const handleGamePathRegistryRegisterConfirmClose = useCallback(() => {
+    setGamePathModalState((current) =>
+      current ? { ...current, showRegistryRegisterConfirm: false } : current,
+    );
+  }, []);
+
+  const handleRegisterGamePath = useCallback(async () => {
+    if (!window.electronAPI || !gamePathModalState?.diagnostics) return;
+
+    const { serviceId, gameId, diagnostics } = gamePathModalState;
+    const expectedConfigPath = diagnostics.config.path;
+    if (!expectedConfigPath) {
+      setGamePathModalState((current) =>
+        updateGamePathModalForContext(
+          current,
+          serviceId,
+          gameId,
+          (matched) => ({
+            ...matched,
+            showRegistryRegisterConfirm: false,
+            errorMessage:
+              "등록할 런처 설정 경로가 없습니다. 다시 진단해 주세요.",
+          }),
+        ),
+      );
+      return;
+    }
+
+    setGamePathModalState((current) =>
+      updateGamePathModalForContext(current, serviceId, gameId, (matched) => ({
+        ...matched,
+        busy: true,
+        showRegistryRegisterConfirm: false,
+        errorMessage: undefined,
+      })),
+    );
+
+    try {
+      const result = await window.electronAPI.registerGameInstallPath(
+        serviceId,
+        gameId,
+        { expectedConfigPath },
+      );
+
+      if (result.ok) {
+        setGamePathModalState((current) =>
+          updateGamePathModalForContext(
+            current,
+            serviceId,
+            gameId,
+            (matched) => ({
+              ...matched,
+              mode: "diagnostic",
+              diagnostics: result.diagnostics,
+              busy: false,
+              errorMessage: undefined,
+              showRegistryRegisterConfirm: false,
+              registrySaveToastId: Date.now(),
+            }),
+          ),
+        );
+        void syncGameState(gameId, serviceId);
+        return;
+      }
+
+      setGamePathModalState((current) =>
+        updateGamePathModalForContext(
+          current,
+          serviceId,
+          gameId,
+          (matched) => ({
+            ...matched,
+            diagnostics: result.diagnostics || matched.diagnostics,
+            busy: false,
+            errorMessage:
+              result.error || getGamePathSaveErrorMessage(result.verification),
+          }),
+        ),
+      );
+    } catch (error) {
+      setGamePathModalState((current) =>
+        updateGamePathModalForContext(
+          current,
+          serviceId,
+          gameId,
+          (matched) => ({
+            ...matched,
+            busy: false,
+            errorMessage: `레지스트리 게임 경로를 등록하지 못했습니다. ${formatUnknownError(error)}`,
+          }),
+        ),
+      );
+    }
+  }, [gamePathModalState, syncGameState]);
+
   const handleClearGamePath = useCallback(
     async (source: GamePathSource, confirmed = false) => {
       if (!window.electronAPI || !gamePathModalState) return;
@@ -1464,7 +1636,25 @@ function App() {
                 ...current,
                 showRegistryClearConfirm: true,
                 showRegistrySyncConfirm: false,
+                showRegistryRegisterConfirm: false,
                 errorMessage: undefined,
+              }
+            : current,
+        );
+        return;
+      }
+
+      const registryTarget =
+        source === "registry" && gamePathModalState.diagnostics
+          ? getRegistryMutationTarget(gamePathModalState.diagnostics)
+          : undefined;
+      if (source === "registry" && !registryTarget) {
+        setGamePathModalState((current) =>
+          current
+            ? {
+                ...current,
+                errorMessage:
+                  "삭제할 레지스트리 대상을 확인할 수 없습니다. 다시 진단해 주세요.",
               }
             : current,
         );
@@ -1479,6 +1669,7 @@ function App() {
               busy: true,
               errorMessage: undefined,
               showRegistryClearConfirm: false,
+              showRegistryRegisterConfirm: false,
             }
           : current,
       );
@@ -1488,6 +1679,7 @@ function App() {
           serviceId,
           gameId,
           source,
+          registryTarget || undefined,
         );
 
         if (result.ok) {
@@ -1501,6 +1693,7 @@ function App() {
                   errorMessage: undefined,
                   showRegistrySyncConfirm: false,
                   showRegistryClearConfirm: false,
+                  showRegistryRegisterConfirm: false,
                 }
               : current,
           );
@@ -1541,7 +1734,23 @@ function App() {
     async (action: "launcher-config-only" | "sync-registry") => {
       if (!window.electronAPI || !gamePathModalState) return;
 
-      const { serviceId, gameId } = gamePathModalState;
+      const { serviceId, gameId, diagnostics } = gamePathModalState;
+      const registryTarget = diagnostics
+        ? getRegistryConflictTarget(diagnostics)
+        : null;
+      if (!registryTarget) {
+        setGamePathModalState((current) =>
+          current
+            ? {
+                ...current,
+                errorMessage:
+                  "동기화할 레지스트리 대상을 확인할 수 없습니다. 다시 진단해 주세요.",
+              }
+            : current,
+        );
+        return;
+      }
+
       setGamePathModalState((current) =>
         current
           ? {
@@ -1550,6 +1759,7 @@ function App() {
               errorMessage: undefined,
               showRegistrySyncConfirm: false,
               showRegistryClearConfirm: false,
+              showRegistryRegisterConfirm: false,
             }
           : current,
       );
@@ -1559,6 +1769,7 @@ function App() {
           serviceId,
           gameId,
           action,
+          registryTarget,
         );
 
         if (result.ok) {
@@ -1637,16 +1848,7 @@ function App() {
       return;
     }
 
-    if (activeGameStatus.status === "uninstalled") {
-      void openGamePathModal(
-        "missing",
-        config.serviceChannel,
-        config.activeGame,
-      );
-      return;
-    }
-
-    if (activeGameStatus.status === "install_check_blocked") {
+    if (shouldOpenGamePathDiagnostic(activeGameStatus.status)) {
       void openGamePathModal(
         "missing",
         config.serviceChannel,
@@ -1941,7 +2143,11 @@ function App() {
         showRegistryClearConfirm={
           gamePathModalState?.showRegistryClearConfirm ?? false
         }
+        showRegistryRegisterConfirm={
+          gamePathModalState?.showRegistryRegisterConfirm ?? false
+        }
         manualSaveToastId={gamePathModalState?.manualSaveToastId}
+        registrySaveToastId={gamePathModalState?.registrySaveToastId}
         onClose={handleGamePathModalClose}
         onContextChange={handleGamePathContextChange}
         onUsePath={handleUseGamePath}
@@ -1949,6 +2155,10 @@ function App() {
         onManualSelect={handleManualGamePathSelect}
         onRegistrySyncConfirmClose={handleGamePathConflictConfirmClose}
         onRegistryClearConfirmClose={handleGamePathRegistryClearConfirmClose}
+        onRegistryRegisterRequest={handleGamePathRegistryRegisterRequest}
+        onRegistryRegisterConfirmClose={
+          handleGamePathRegistryRegisterConfirmClose
+        }
         onKeepLauncherConfig={() =>
           void handleResolveGamePathConflict("launcher-config-only")
         }
@@ -1958,6 +2168,7 @@ function App() {
         onConfirmClearRegistry={() =>
           void handleClearGamePath("registry", true)
         }
+        onConfirmRegisterRegistry={() => void handleRegisterGamePath()}
         onInstall={
           gamePathModalState?.mode === "missing"
             ? handleGamePathInstall
@@ -2087,6 +2298,8 @@ function App() {
           onUpdateClick={() => setIsUpdateModalOpen(true)}
           devMode={config.dev_mode}
           debugConsole={config.debug_console}
+          operationalNotifications={operationalNotifications}
+          onOperationalNotificationClick={handleOperationalNotificationClick}
         />
 
         {/* 2. Main Content Frame */}

--- a/src/renderer/components/TitleBar.tsx
+++ b/src/renderer/components/TitleBar.tsx
@@ -3,12 +3,18 @@ import React from "react";
 import WindowControls from "./WindowControls";
 import icon from "../assets/icon.ico"; // Assuming copied icon.ico works, or fallback
 
+import type { OperationalNotification } from "../../shared/types";
+
 interface TitleBarProps {
   title?: string;
   showUpdateIcon?: boolean;
   onUpdateClick?: () => void;
   devMode?: boolean;
   debugConsole?: boolean;
+  operationalNotifications?: readonly OperationalNotification[];
+  onOperationalNotificationClick?: (
+    notification: OperationalNotification,
+  ) => void;
 }
 
 const TitleBar: React.FC<TitleBarProps> = ({
@@ -17,6 +23,8 @@ const TitleBar: React.FC<TitleBarProps> = ({
   onUpdateClick,
   devMode = false,
   debugConsole = false,
+  operationalNotifications = [],
+  onOperationalNotificationClick,
 }) => {
   return (
     <div className="title-bar">
@@ -69,7 +77,12 @@ const TitleBar: React.FC<TitleBarProps> = ({
             UPDATE
           </button>
         )}
-        <WindowControls devMode={devMode} debugConsole={debugConsole} />
+        <WindowControls
+          devMode={devMode}
+          debugConsole={debugConsole}
+          operationalNotifications={operationalNotifications}
+          onOperationalNotificationClick={onOperationalNotificationClick}
+        />
       </div>
     </div>
   );

--- a/src/renderer/components/WindowControls.test.tsx
+++ b/src/renderer/components/WindowControls.test.tsx
@@ -1,0 +1,126 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import WindowControls from "./WindowControls";
+
+import type {
+  DebugLogPayload,
+  ElectronAPI,
+  OperationalNotification,
+} from "../../shared/types";
+
+const warning: OperationalNotification = {
+  id: "game-path-registry:Kakao Games:POE2",
+  contextKey: "Kakao Games:POE2",
+  level: "warn",
+  tone: "amber",
+  title: "POE2 게임 경로 확인 필요",
+  message: "게임은 설치되어 있지만 레지스트리 경로가 없습니다.",
+  serviceId: "Kakao Games",
+  gameId: "POE2",
+  action: "open-game-path-diagnostic",
+};
+
+describe("WindowControls notifications", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let emitException: ((log: DebugLogPayload) => void) | undefined;
+
+  beforeEach(() => {
+    (
+      globalThis as typeof globalThis & {
+        IS_REACT_ACT_ENVIRONMENT: boolean;
+      }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+    window.localStorage.clear();
+    emitException = undefined;
+    window.electronAPI = {
+      getDebugHistory: vi.fn().mockResolvedValue([]),
+      onExceptionLog: vi.fn((callback) => {
+        emitException = callback;
+        return vi.fn();
+      }),
+      minimizeWindow: vi.fn(),
+      closeWindow: vi.fn(),
+      setConfig: vi.fn(),
+    } as unknown as ElectronAPI;
+    container = document.createElement("div");
+    document.body.append(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+  });
+
+  it("deduplicates an operational warning and sends its exact context without opening the exception report", async () => {
+    const onClick = vi.fn();
+    const reportListener = vi.fn();
+    window.addEventListener("SHOW_REPORT_MODAL", reportListener);
+
+    await act(async () => {
+      root.render(
+        <WindowControls
+          devMode={false}
+          debugConsole={false}
+          operationalNotifications={[warning, warning]}
+          onOperationalNotificationClick={onClick}
+        />,
+      );
+    });
+    await act(async () => Promise.resolve());
+
+    const notificationToggle = container.querySelector<HTMLButtonElement>(
+      'button[title="알림 1건 확인"]',
+    );
+    await act(async () => notificationToggle?.click());
+    expect(container.textContent).toContain("알림");
+    expect(
+      container.querySelectorAll(`[data-notification-id="${warning.id}"]`),
+    ).toHaveLength(1);
+
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>(
+          `[data-notification-id="${warning.id}"]`,
+        )
+        ?.click();
+    });
+
+    expect(onClick).toHaveBeenCalledWith(
+      expect.objectContaining({
+        serviceId: "Kakao Games",
+        gameId: "POE2",
+        action: "open-game-path-diagnostic",
+      }),
+    );
+    expect(reportListener).not.toHaveBeenCalled();
+    window.removeEventListener("SHOW_REPORT_MODAL", reportListener);
+  });
+
+  it("keeps existing exception notifications alongside the operational warning", async () => {
+    await act(async () => {
+      root.render(
+        <WindowControls
+          devMode={false}
+          debugConsole={false}
+          operationalNotifications={[warning]}
+        />,
+      );
+    });
+    await act(async () => {
+      emitException?.({
+        type: "renderer_exception",
+        content: "Unhandled exception\n at App",
+        isError: true,
+        timestamp: 1,
+      });
+    });
+
+    expect(
+      container.querySelector('button[title="알림 2건 확인"]'),
+    ).not.toBeNull();
+  });
+});

--- a/src/renderer/components/WindowControls.tsx
+++ b/src/renderer/components/WindowControls.tsx
@@ -8,11 +8,16 @@ import {
   getDebugLogPreview,
   getExceptionDebugLogs,
 } from "../../shared/debug-log-policy";
-import { DebugLogPayload } from "../../shared/types";
+import { DebugLogPayload, OperationalNotification } from "../../shared/types";
+import { dedupeOperationalNotifications } from "../utils/game-path-registry-warning";
 
 interface WindowControlsProps {
   devMode: boolean;
   debugConsole: boolean;
+  operationalNotifications?: readonly OperationalNotification[];
+  onOperationalNotificationClick?: (
+    notification: OperationalNotification,
+  ) => void;
 }
 
 const DISMISSED_NOTIFICATION_STORAGE_KEY =
@@ -23,6 +28,8 @@ const MAX_VISIBLE_NOTIFICATION_ITEMS = 4;
 const WindowControls: React.FC<WindowControlsProps> = ({
   devMode,
   debugConsole,
+  operationalNotifications = [],
+  onOperationalNotificationClick,
 }) => {
   const [exceptionLogs, setExceptionLogs] = useState<DebugLogPayload[]>([]);
   const [isNotificationOpen, setIsNotificationOpen] = useState(false);
@@ -88,7 +95,12 @@ const WindowControls: React.FC<WindowControlsProps> = ({
         .reverse(),
     [dismissedNotificationIds, exceptionLogs],
   );
-  const notificationCount = notificationLogs.length;
+  const operationalNotificationItems = useMemo(
+    () => dedupeOperationalNotifications(operationalNotifications),
+    [operationalNotifications],
+  );
+  const notificationCount =
+    notificationLogs.length + operationalNotificationItems.length;
   const shouldScrollNotifications =
     notificationCount >= MAX_VISIBLE_NOTIFICATION_ITEMS;
 
@@ -117,6 +129,13 @@ const WindowControls: React.FC<WindowControlsProps> = ({
       },
     });
     window.dispatchEvent(event);
+    setIsNotificationOpen(false);
+  };
+
+  const handleOpenOperationalNotification = (
+    notification: OperationalNotification,
+  ) => {
+    onOperationalNotificationClick?.(notification);
     setIsNotificationOpen(false);
   };
 
@@ -216,7 +235,7 @@ const WindowControls: React.FC<WindowControlsProps> = ({
             textShadow: "0 0 8px rgba(255, 183, 77, 0.55)",
             position: "relative",
           }}
-          title={`오류 로그 ${notificationCount}건 확인 및 제보`}
+          title={`알림 ${notificationCount}건 확인`}
           onMouseEnter={(e) => {
             e.currentTarget.style.background = "rgba(255,183,77,0.12)";
             e.currentTarget.style.color = "#fff";
@@ -286,7 +305,7 @@ const WindowControls: React.FC<WindowControlsProps> = ({
               fontWeight: 700,
             }}
           >
-            <span>오류 알림</span>
+            <span>알림</span>
             <span style={{ color: "#ffb74d", fontSize: "12px" }}>
               {notificationCount}건
             </span>
@@ -299,6 +318,73 @@ const WindowControls: React.FC<WindowControlsProps> = ({
               padding: "6px",
             }}
           >
+            {operationalNotificationItems.map((notification) => (
+              <button
+                key={notification.id}
+                type="button"
+                data-notification-id={notification.id}
+                onClick={() => handleOpenOperationalNotification(notification)}
+                style={{
+                  width: "100%",
+                  minHeight: "76px",
+                  display: "grid",
+                  gridTemplateColumns: "28px 1fr",
+                  gap: "8px",
+                  padding: "10px 8px",
+                  border: "none",
+                  borderBottom: "1px solid rgba(255, 255, 255, 0.05)",
+                  borderRadius: "6px",
+                  background: "transparent",
+                  color: "#ddd",
+                  cursor: "pointer",
+                  textAlign: "left",
+                  transition: "background 0.15s ease",
+                }}
+                onMouseEnter={(event) => {
+                  event.currentTarget.style.background =
+                    "rgba(255, 183, 77, 0.1)";
+                }}
+                onMouseLeave={(event) => {
+                  event.currentTarget.style.background = "transparent";
+                }}
+              >
+                <span
+                  className="material-symbols-outlined"
+                  style={{
+                    color: "#ffb74d",
+                    fontSize: "18px",
+                    lineHeight: "20px",
+                    marginTop: "1px",
+                  }}
+                >
+                  warning
+                </span>
+                <span style={{ minWidth: 0 }}>
+                  <span
+                    style={{
+                      display: "block",
+                      color: "#f0d8a8",
+                      fontSize: "12px",
+                      fontWeight: 700,
+                      lineHeight: "1.35",
+                      marginBottom: "4px",
+                    }}
+                  >
+                    {notification.title}
+                  </span>
+                  <span
+                    style={{
+                      display: "block",
+                      color: "#aaa",
+                      fontSize: "11px",
+                      lineHeight: "1.45",
+                    }}
+                  >
+                    {notification.message}
+                  </span>
+                </span>
+              </button>
+            ))}
             {notificationLogs.map((log) => (
               <div
                 key={getDebugLogNotificationId(log)}

--- a/src/renderer/components/modals/GamePathDiagnosticModal.css
+++ b/src/renderer/components/modals/GamePathDiagnosticModal.css
@@ -361,6 +361,73 @@ img.game-path-channel-logo[alt="Grinding Gear Games"] {
   overflow-wrap: anywhere;
 }
 
+.game-path-registry-candidates {
+  display: grid;
+  gap: 7px;
+  margin: 0 0 10px;
+}
+
+.game-path-registry-candidate {
+  padding: 8px 9px;
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  border-radius: 5px;
+  background: rgba(0, 0, 0, 0.18);
+}
+
+.game-path-registry-candidate.is-active {
+  border-color: rgba(64, 192, 87, 0.42);
+  background: rgba(64, 192, 87, 0.055);
+}
+
+.game-path-registry-candidate.is-unknown {
+  border-color: rgba(255, 171, 0, 0.32);
+}
+
+.game-path-registry-candidate-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.game-path-registry-candidate-head strong {
+  color: #ddd;
+  font-size: 11px;
+}
+
+.game-path-registry-candidate-head span {
+  color: #999;
+  font-size: 10px;
+  font-weight: 700;
+}
+
+.game-path-registry-candidate-head span.is-valid {
+  color: #40c057;
+}
+
+.game-path-registry-candidate-head span.is-invalid {
+  color: #fa7070;
+}
+
+.game-path-registry-candidate-head span.is-empty,
+.game-path-registry-candidate-head span.is-unknown {
+  color: #ffb83d;
+}
+
+.game-path-registry-candidate-path {
+  margin-top: 5px;
+  color: #bbb;
+  font-family: Consolas, "Courier New", monospace;
+  font-size: 10px;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+}
+
+.game-path-registry-candidate-path.is-empty {
+  color: #777;
+  font-family: var(--launcher-font-family);
+}
+
 .game-path-option-actions {
   display: flex;
   gap: 8px;
@@ -389,6 +456,32 @@ img.game-path-channel-logo[alt="Grinding Gear Games"] {
   border: 1px solid rgba(223, 207, 153, 0.14);
   border-radius: 8px;
   background: rgba(223, 207, 153, 0.045);
+}
+
+.game-path-registry-register-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-top: 16px;
+  padding: 12px 14px;
+  border: 1px solid rgba(255, 171, 0, 0.3);
+  border-radius: 8px;
+  background: rgba(255, 171, 0, 0.055);
+}
+
+.game-path-registry-register-row strong {
+  display: block;
+  color: #ffd27a;
+  font-size: 13px;
+}
+
+.game-path-registry-register-row span {
+  display: block;
+  margin-top: 3px;
+  color: #aaa;
+  font-size: 12px;
+  line-height: 1.45;
 }
 
 .game-path-manual-row.is-highlighted {
@@ -667,7 +760,8 @@ img.game-path-channel-logo[alt="Grinding Gear Games"] {
   }
 
   .game-path-modal-header,
-  .game-path-manual-row {
+  .game-path-manual-row,
+  .game-path-registry-register-row {
     align-items: flex-start;
     flex-direction: column;
   }

--- a/src/renderer/components/modals/GamePathDiagnosticModal.css
+++ b/src/renderer/components/modals/GamePathDiagnosticModal.css
@@ -12,7 +12,10 @@
 
 .game-path-modal {
   position: relative;
-  width: min(960px, calc(100vw - 80px));
+  display: flex;
+  flex-direction: column;
+  width: min(960px, calc((100vw - 80px) / var(--app-scale, 1)));
+  max-height: calc((100vh - 48px) / var(--app-scale, 1));
   overflow: hidden;
   border: 1px solid rgba(223, 207, 153, 0.22);
   border-radius: 8px;
@@ -23,7 +26,17 @@
   animation: gamePathContentIn 0.18s ease-out;
 }
 
+.game-path-modal-background {
+  display: contents;
+}
+
+.game-path-modal-background[inert] > * {
+  pointer-events: none;
+  user-select: none;
+}
+
 .game-path-modal-header {
+  flex: 0 0 auto;
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -182,6 +195,9 @@ img.game-path-channel-logo[alt="Grinding Gear Games"] {
 }
 
 .game-path-modal-body {
+  min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
   padding: 20px 22px 22px;
   background: #151515;
 }
@@ -390,9 +406,52 @@ img.game-path-channel-logo[alt="Grinding Gear Games"] {
   gap: 8px;
 }
 
+.game-path-registry-candidate-head > div {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  min-width: 0;
+  flex: 1 1 auto;
+}
+
+.game-path-candidate-delete {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 40px;
+  width: 40px;
+  height: 40px;
+  padding: 0;
+  border: 1px solid rgba(250, 82, 82, 0.36);
+  border-radius: 4px;
+  background: rgba(185, 63, 63, 0.16);
+  color: #ff9b9b;
+  cursor: pointer;
+}
+
+.game-path-candidate-delete .material-symbols-outlined {
+  font-size: 17px;
+}
+
+.game-path-candidate-delete:hover:not(:disabled) {
+  border-color: rgba(250, 82, 82, 0.62);
+  background: rgba(185, 63, 63, 0.3);
+}
+
+.game-path-candidate-delete:disabled {
+  cursor: not-allowed;
+  opacity: 0.3;
+}
+
 .game-path-registry-candidate-head strong {
   color: #ddd;
   font-size: 11px;
+}
+
+.game-path-registry-candidate-head strong:focus-visible {
+  outline: 2px solid rgba(223, 207, 153, 0.62);
+  outline-offset: 3px;
 }
 
 .game-path-registry-candidate-head span {
@@ -524,6 +583,7 @@ img.game-path-channel-logo[alt="Grinding Gear Games"] {
 }
 
 .game-path-modal-footer {
+  flex: 0 0 auto;
   display: flex;
   justify-content: flex-end;
   gap: 10px;
@@ -613,16 +673,14 @@ img.game-path-channel-logo[alt="Grinding Gear Games"] {
   border: 1px solid rgba(255, 171, 0, 0.44);
   border-radius: 8px;
   background:
-    linear-gradient(rgba(255, 171, 0, 0.055), rgba(255, 171, 0, 0.02)),
-    #181818;
+    linear-gradient(rgba(255, 171, 0, 0.055), rgba(255, 171, 0, 0.02)), #181818;
   box-shadow: 0 24px 58px rgba(0, 0, 0, 0.72);
 }
 
 .game-path-confirm-dialog.is-danger {
   border-color: rgba(250, 82, 82, 0.52);
   background:
-    linear-gradient(rgba(250, 82, 82, 0.06), rgba(250, 82, 82, 0.02)),
-    #181818;
+    linear-gradient(rgba(250, 82, 82, 0.06), rgba(250, 82, 82, 0.02)), #181818;
 }
 
 .game-path-confirm-icon {
@@ -700,6 +758,256 @@ img.game-path-channel-logo[alt="Grinding Gear Games"] {
   margin-top: 4px;
 }
 
+.game-path-target-overlay {
+  z-index: 30;
+  padding: 18px;
+}
+
+.game-path-target-dialog {
+  display: flex;
+  flex-direction: column;
+  width: min(660px, 100%);
+  max-height: 100%;
+  overflow: hidden;
+  border: 1px solid rgba(223, 207, 153, 0.4);
+  border-radius: 8px;
+  background: #181818;
+  box-shadow: 0 24px 58px rgba(0, 0, 0, 0.76);
+}
+
+.game-path-target-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  flex: 0 0 auto;
+  padding: 18px 20px 14px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  background: linear-gradient(105deg, rgba(223, 207, 153, 0.08), transparent);
+}
+
+.game-path-target-kicker {
+  display: block;
+  margin-bottom: 5px;
+  color: #8f8465;
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.game-path-target-header h3 {
+  margin: 0;
+  color: #f1dca4;
+  font-size: 17px;
+  line-height: 1.35;
+}
+
+.game-path-target-header > .material-symbols-outlined {
+  color: var(--theme-accent, #dfcf99);
+  font-size: 28px;
+}
+
+.game-path-target-context {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 0.7fr);
+  gap: 8px;
+  flex: 0 0 auto;
+  padding: 14px 20px 10px;
+}
+
+.game-path-target-context > div {
+  min-width: 0;
+  padding: 9px 10px;
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  border-radius: 5px;
+  background: rgba(0, 0, 0, 0.2);
+}
+
+.game-path-target-context span {
+  display: block;
+  margin-bottom: 4px;
+  color: #818181;
+  font-size: 10px;
+  font-weight: 700;
+}
+
+.game-path-target-context strong {
+  display: block;
+  color: #ddd;
+  font-size: 12px;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+}
+
+.game-path-target-context .game-path-target-selected-path {
+  grid-column: 1 / -1;
+}
+
+.game-path-target-selected-path strong {
+  font-family: Consolas, "Courier New", monospace;
+}
+
+.game-path-target-list,
+.game-path-target-results {
+  min-height: 0;
+  margin: 0;
+  padding: 10px 20px 16px;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  border: 0;
+}
+
+.game-path-target-list legend {
+  margin-bottom: 7px;
+  padding: 0;
+  color: #aaa;
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.game-path-target-option {
+  display: grid;
+  grid-template-columns: 20px minmax(0, 1fr);
+  gap: 10px;
+  align-items: center;
+  min-height: 52px;
+  margin-top: 7px;
+  padding: 9px 11px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.025);
+  cursor: pointer;
+}
+
+.game-path-target-option:has(input:checked) {
+  border-color: rgba(223, 207, 153, 0.42);
+  background: rgba(223, 207, 153, 0.07);
+}
+
+.game-path-target-option:focus-within {
+  outline: 2px solid rgba(223, 207, 153, 0.62);
+  outline-offset: 2px;
+}
+
+.game-path-target-option.is-disabled {
+  cursor: not-allowed;
+  opacity: 0.48;
+}
+
+.game-path-target-option input {
+  width: 18px;
+  height: 18px;
+  margin: 0;
+  accent-color: var(--theme-accent, #dfcf99);
+}
+
+.game-path-target-checkmark {
+  display: none;
+}
+
+.game-path-target-option-copy {
+  min-width: 0;
+}
+
+.game-path-target-option-copy strong,
+.game-path-target-option-copy span {
+  display: block;
+}
+
+.game-path-target-option-copy strong {
+  color: #dedede;
+  font-size: 12px;
+}
+
+.game-path-target-option-copy span {
+  margin-top: 4px;
+  color: #888;
+  font-family: Consolas, "Courier New", monospace;
+  font-size: 10px;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+}
+
+.game-path-target-count {
+  display: block;
+  margin-top: 9px;
+  color: #9d9274;
+  font-size: 11px;
+  text-align: right;
+}
+
+.game-path-target-results > strong {
+  display: block;
+  margin-bottom: 9px;
+  color: #ddd;
+  font-size: 12px;
+}
+
+.game-path-target-results ul {
+  display: grid;
+  gap: 7px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.game-path-target-results li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  min-height: 40px;
+  padding: 8px 10px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 5px;
+  color: #bbb;
+  font-size: 11px;
+}
+
+.game-path-target-results li.is-applied strong,
+.game-path-target-results li.is-unchanged strong {
+  color: #62cf75;
+}
+
+.game-path-target-results li.is-failed strong {
+  color: #ff8787;
+}
+
+.game-path-nested-error {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  margin: 0 20px 12px;
+  padding: 9px 10px;
+  border: 1px solid rgba(250, 82, 82, 0.34);
+  border-radius: 5px;
+  background: rgba(250, 82, 82, 0.09);
+  color: #ff9b9b;
+  font-size: 11px;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+}
+
+.game-path-confirm-paths > .game-path-nested-error {
+  margin: 0;
+}
+
+.game-path-nested-error .material-symbols-outlined {
+  flex: 0 0 auto;
+  font-size: 18px;
+}
+
+.game-path-target-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  flex: 0 0 auto;
+  padding: 14px 20px 18px;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  background: #121212;
+}
+
 .game-path-modal .shared-toast.visible {
   animation: gamePathToastLifecycle 2.5s ease forwards;
 }
@@ -756,7 +1064,7 @@ img.game-path-channel-logo[alt="Grinding Gear Games"] {
 
 @media (max-width: 680px) {
   .game-path-modal {
-    width: min(640px, 92vw);
+    width: min(640px, calc(92vw / var(--app-scale, 1)));
   }
 
   .game-path-modal-header,
@@ -790,5 +1098,31 @@ img.game-path-channel-logo[alt="Grinding Gear Games"] {
   .game-path-confirm-actions {
     justify-content: stretch;
     flex-direction: column;
+  }
+
+  .game-path-target-context {
+    grid-template-columns: 1fr;
+  }
+
+  .game-path-target-context .game-path-target-selected-path {
+    grid-column: auto;
+  }
+
+  .game-path-target-actions {
+    flex-direction: column;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .game-path-modal-overlay,
+  .game-path-modal,
+  .game-path-manual-row.is-highlighted,
+  .game-path-modal .shared-toast.visible {
+    animation: none;
+  }
+
+  .game-path-action,
+  .game-path-context-trigger .material-symbols-outlined {
+    transition: none;
   }
 }

--- a/src/renderer/components/modals/GamePathDiagnosticModal.test.tsx
+++ b/src/renderer/components/modals/GamePathDiagnosticModal.test.tsx
@@ -1,3 +1,6 @@
+import fs from "node:fs";
+import path from "node:path";
+
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -8,15 +11,21 @@ import { getRegistryRegistrationEligibility } from "../../utils/game-path-regist
 import type {
   GameInstallPathDiagnostics,
   GameInstallPathRegistryCandidateDiagnostic,
+  GameInstallPathRegistryTargetDeleteRequest,
+  GameInstallPathSelectionBatchResult,
+  GameInstallPathSelectionDescriptor,
 } from "../../../shared/types";
 
 const configPath = String.raw`C:\Games\Path of Exile 2`;
 const primaryRegistryPath = String.raw`HKCU:\Software\Kakaogames\POE2`;
 const legacyRegistryPath = String.raw`HKCU:\Software\DaumGames\POE2`;
 
+const selectedPath = String.raw`F:\\Games\\Path of Exile 2`;
+
 const createCandidate = (
   overrides: Partial<GameInstallPathRegistryCandidateDiagnostic>,
 ): GameInstallPathRegistryCandidateDiagnostic => ({
+  targetId: "registry-primary",
   path: null,
   state: "value-missing",
   verification: "not-checked",
@@ -64,11 +73,49 @@ const absentDiagnostics = () =>
       createCandidate({ state: "key-missing" }),
       createCandidate({
         state: "value-empty",
+        targetId: "registry-compatibility",
         registryPath: legacyRegistryPath,
       }),
     ],
     "absent",
   );
+
+const createSelection = (
+  overrides: Partial<GameInstallPathSelectionDescriptor> = {},
+): GameInstallPathSelectionDescriptor => ({
+  selectionId: "selection-1",
+  serviceId: "Kakao Games",
+  gameId: "POE2",
+  path: selectedPath,
+  targets: [
+    {
+      targetId: "registry-primary",
+      currentPath: null,
+      selectedByDefault: true,
+      completed: false,
+      disabled: false,
+      registryPath: primaryRegistryPath,
+      registryValueName: "InstallPath",
+    },
+    {
+      targetId: "registry-compatibility",
+      currentPath: null,
+      selectedByDefault: false,
+      completed: false,
+      disabled: false,
+      registryPath: legacyRegistryPath,
+      registryValueName: "InstallPath",
+    },
+    {
+      targetId: "config",
+      currentPath: configPath,
+      selectedByDefault: true,
+      completed: false,
+      disabled: false,
+    },
+  ],
+  ...overrides,
+});
 
 describe("GamePathDiagnosticModal registry diagnostics", () => {
   let container: HTMLDivElement;
@@ -108,12 +155,10 @@ describe("GamePathDiagnosticModal registry diagnostics", () => {
       onClearPath: vi.fn(),
       onManualSelect: vi.fn(),
       onRegistrySyncConfirmClose: vi.fn(),
-      onRegistryClearConfirmClose: vi.fn(),
       onRegistryRegisterRequest: vi.fn(),
       onRegistryRegisterConfirmClose: vi.fn(),
       onKeepLauncherConfig: vi.fn(),
       onSyncRegistry: vi.fn(),
-      onConfirmClearRegistry: vi.fn(),
       onConfirmRegisterRegistry: vi.fn(),
       ...overrides,
     };
@@ -130,6 +175,7 @@ describe("GamePathDiagnosticModal registry diagnostics", () => {
           path: legacyPath,
           state: "found",
           verification: "valid",
+          targetId: "registry-compatibility",
           registryPath: legacyRegistryPath,
           isActive: true,
         }),
@@ -187,6 +233,7 @@ describe("GamePathDiagnosticModal registry diagnostics", () => {
         createCandidate({ state: "read-failed", error: "access denied" }),
         createCandidate({
           state: "value-missing",
+          targetId: "registry-compatibility",
           registryPath: legacyRegistryPath,
         }),
       ],
@@ -214,6 +261,7 @@ describe("GamePathDiagnosticModal registry diagnostics", () => {
           verification: "missing",
         }),
         createCandidate({
+          targetId: "registry-compatibility",
           state: "value-missing",
           registryPath: legacyRegistryPath,
         }),
@@ -262,6 +310,7 @@ describe("GamePathDiagnosticModal registry diagnostics", () => {
         }),
         createCandidate({
           state: "value-missing",
+          targetId: "registry-compatibility",
           registryPath: legacyRegistryPath,
         }),
       ],
@@ -275,5 +324,499 @@ describe("GamePathDiagnosticModal registry diagnostics", () => {
       "레지스트리 게임 경로가 등록되었습니다.",
     );
     expect(container.textContent).not.toContain("레지스트리에 경로 등록");
+  });
+
+  it("opens an accessible target dialog with Main-owned defaults and disables zero selection", async () => {
+    const onApplyTargets = vi.fn();
+    await renderModal(absentDiagnostics(), {
+      selection: createSelection(),
+      onApplyTargets,
+    });
+
+    const outerDialog = container.querySelector(
+      '[role="dialog"][aria-labelledby="game-path-diagnostic-title"]',
+    );
+    const targetDialog = container.querySelector<HTMLElement>(
+      '[role="dialog"][aria-labelledby="game-path-target-selection-title"]',
+    );
+    expect(outerDialog?.getAttribute("aria-modal")).toBeNull();
+    expect(targetDialog?.getAttribute("aria-modal")).toBe("true");
+    const background = container.querySelector<HTMLElement>(
+      ".game-path-modal-background",
+    );
+    expect(background?.hasAttribute("inert")).toBe(true);
+    expect(background?.getAttribute("aria-hidden")).toBe("true");
+    expect(background?.contains(targetDialog ?? null)).toBe(false);
+    expect(targetDialog?.textContent).toContain("Kakao Games");
+    expect(targetDialog?.textContent).toContain("POE2");
+    expect(targetDialog?.textContent).toContain(selectedPath);
+
+    const primary = targetDialog?.querySelector<HTMLInputElement>(
+      'input[value="registry-primary"]',
+    );
+    const compatibility = targetDialog?.querySelector<HTMLInputElement>(
+      'input[value="registry-compatibility"]',
+    );
+    const config = targetDialog?.querySelector<HTMLInputElement>(
+      'input[value="config"]',
+    );
+    expect(primary?.checked).toBe(true);
+    expect(compatibility?.checked).toBe(false);
+    expect(config?.checked).toBe(true);
+
+    const selectButton = [
+      ...(targetDialog?.querySelectorAll("button") ?? []),
+    ].find((button) => button.textContent?.trim() === "선택 (2개)");
+    expect(selectButton?.disabled).toBe(false);
+
+    await act(async () => {
+      primary?.click();
+      config?.click();
+    });
+    expect(selectButton?.textContent?.trim()).toBe("선택 (0개)");
+    expect(selectButton?.disabled).toBe(true);
+    await act(async () => selectButton?.click());
+    expect(onApplyTargets).not.toHaveBeenCalled();
+  });
+
+  it("does not invent a compatibility target for GGG", async () => {
+    await renderModal(absentDiagnostics(), {
+      serviceId: "GGG",
+      selection: createSelection({
+        serviceId: "GGG",
+        targets: [
+          {
+            targetId: "registry-primary",
+            currentPath: null,
+            selectedByDefault: true,
+            completed: false,
+            disabled: false,
+          },
+          {
+            targetId: "config",
+            currentPath: configPath,
+            selectedByDefault: true,
+            completed: false,
+            disabled: false,
+          },
+        ],
+      }),
+    });
+
+    const targetDialog = container.querySelector(
+      '[aria-labelledby="game-path-target-selection-title"]',
+    );
+    expect(
+      targetDialog?.querySelector('input[value="registry-compatibility"]'),
+    ).toBeNull();
+  });
+
+  it("submits only candidate targetId and expectedPath and disables an empty candidate", async () => {
+    const primaryPath = String.raw`D:\\Games\\Primary`;
+    const diagnostics = createDiagnostics(
+      [
+        createCandidate({
+          path: primaryPath,
+          state: "found",
+          verification: "valid",
+          isActive: true,
+        }),
+        createCandidate({
+          targetId: "registry-compatibility",
+          registryPath: legacyRegistryPath,
+        }),
+      ],
+      "valid",
+    );
+    const onRegistryDeleteRequest = vi.fn();
+    const onRegistryDeleteConfirmClose = vi.fn();
+    const props = await renderModal(diagnostics, {
+      onRegistryDeleteRequest,
+      onRegistryDeleteConfirmClose,
+    });
+
+    const primaryDelete = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Kakaogames (기본) 레지스트리 값 삭제"]',
+    );
+    const compatibilityDelete = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="DaumGames (호환) 레지스트리 값 삭제"]',
+    );
+    expect(primaryDelete?.disabled).toBe(false);
+    expect(compatibilityDelete?.disabled).toBe(true);
+    await act(async () => primaryDelete?.click());
+    expect(onRegistryDeleteRequest).toHaveBeenCalledWith({
+      targetId: "registry-primary",
+      expectedPath: primaryPath,
+    });
+
+    const deleteTarget: GameInstallPathRegistryTargetDeleteRequest = {
+      targetId: "registry-primary",
+      expectedPath: primaryPath,
+    };
+    primaryDelete?.focus();
+    await act(async () =>
+      root.render(
+        <GamePathDiagnosticModal
+          {...props}
+          registryDeleteTarget={deleteTarget}
+        />,
+      ),
+    );
+    const confirmDialog = container.querySelector(
+      '[role="dialog"][aria-labelledby="game-path-registry-delete-title"]',
+    );
+    expect(confirmDialog?.textContent).toContain("Kakaogames (기본)");
+    expect(confirmDialog?.textContent).toContain(primaryPath);
+    expect(document.activeElement?.textContent).toContain("취소");
+    await act(async () =>
+      confirmDialog?.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+      ),
+    );
+    expect(onRegistryDeleteConfirmClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows coherent fresh diagnostics and retries only exact failed target IDs", async () => {
+    const freshConfigPath = String.raw`F:\\Games\\Fresh Config`;
+    const freshPrimaryPath = String.raw`F:\\Games\\Fresh Primary`;
+    const freshDiagnostics = createDiagnostics(
+      [
+        createCandidate({
+          path: freshPrimaryPath,
+          state: "found",
+          verification: "valid",
+          isActive: true,
+        }),
+        createCandidate({
+          targetId: "registry-compatibility",
+          registryPath: legacyRegistryPath,
+        }),
+      ],
+      "valid",
+    );
+    freshDiagnostics.config.path = freshConfigPath;
+    const selection = createSelection({
+      targets: createSelection().targets.map((target) => ({
+        ...target,
+        completed:
+          target.targetId === "registry-primary" ||
+          target.targetId === "config",
+        disabled:
+          target.targetId === "registry-primary" ||
+          target.targetId === "config",
+        ...(target.targetId === "registry-primary" ||
+        target.targetId === "config"
+          ? { disabledReason: "target-completed" as const }
+          : {}),
+      })),
+    });
+    const applyResult: GameInstallPathSelectionBatchResult = {
+      ok: true,
+      overall: "partial",
+      results: [
+        {
+          targetId: "registry-primary",
+          status: "applied",
+          path: selectedPath,
+        },
+        {
+          targetId: "registry-compatibility",
+          status: "failed",
+          code: "target-changed",
+          retryable: true,
+        },
+        { targetId: "config", status: "unchanged", path: selectedPath },
+      ],
+      retryableTargetIds: ["registry-compatibility"],
+      diagnostics: freshDiagnostics,
+      selection,
+    };
+    const onApplyTargets = vi.fn();
+    await renderModal(freshDiagnostics, {
+      selection,
+      selectionApplyResult: applyResult,
+      onApplyTargets,
+    });
+
+    expect(container.textContent).toContain(freshPrimaryPath);
+    expect(container.textContent).toContain(freshConfigPath);
+    const liveRegion = container.querySelector('[aria-live="polite"]');
+    expect(liveRegion?.textContent).toContain(
+      "일부 대상에 적용하지 못했습니다.",
+    );
+    expect(liveRegion?.textContent).toContain("적용 완료");
+    expect(liveRegion?.textContent).toContain("변경 없음");
+    expect(liveRegion?.textContent).toContain("적용 실패");
+
+    const retryButton = [...container.querySelectorAll("button")].find(
+      (button) => button.textContent?.includes("실패 항목 다시 시도"),
+    );
+    await act(async () => retryButton?.click());
+    expect(onApplyTargets).toHaveBeenCalledWith(["registry-compatibility"]);
+  });
+
+  it("moves focus from the unmounted apply control to retry and then close on result transitions", async () => {
+    const selection = createSelection();
+    const onCloseSelection = vi.fn();
+    const props = await renderModal(absentDiagnostics(), {
+      selection,
+      onCloseSelection,
+    });
+    const applyButton = [...container.querySelectorAll("button")].find(
+      (button) => button.textContent?.trim() === "선택 (2개)",
+    );
+    applyButton?.focus();
+    expect(document.activeElement).toBe(applyButton);
+
+    const partialResult: GameInstallPathSelectionBatchResult = {
+      ok: true,
+      overall: "partial",
+      results: [
+        {
+          targetId: "registry-primary",
+          status: "applied",
+          path: selectedPath,
+        },
+        {
+          targetId: "config",
+          status: "failed",
+          code: "target-changed",
+          retryable: true,
+        },
+      ],
+      retryableTargetIds: ["config"],
+      diagnostics: absentDiagnostics(),
+      selection,
+    };
+    await act(async () =>
+      root.render(
+        <GamePathDiagnosticModal
+          {...props}
+          selection={selection}
+          selectionApplyResult={partialResult}
+        />,
+      ),
+    );
+    const retryButton = [...container.querySelectorAll("button")].find(
+      (button) => button.textContent?.includes("실패 항목 다시 시도"),
+    );
+    expect(document.activeElement).toBe(retryButton);
+
+    const successResult: GameInstallPathSelectionBatchResult = {
+      ok: true,
+      overall: "success",
+      results: [
+        {
+          targetId: "config",
+          status: "applied",
+          path: selectedPath,
+        },
+      ],
+      retryableTargetIds: [],
+      diagnostics: absentDiagnostics(),
+      selection,
+    };
+    await act(async () =>
+      root.render(
+        <GamePathDiagnosticModal
+          {...props}
+          selection={selection}
+          selectionApplyResult={successResult}
+        />,
+      ),
+    );
+    const targetDialog = container.querySelector<HTMLElement>(
+      '[aria-labelledby="game-path-target-selection-title"]',
+    );
+    const closeButton = [
+      ...(targetDialog?.querySelectorAll("button") ?? []),
+    ].find((button) => button.textContent?.trim() === "닫기");
+    expect(document.activeElement).toBe(closeButton);
+
+    await act(async () =>
+      targetDialog?.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+      ),
+    );
+    expect(onCloseSelection).toHaveBeenCalledTimes(1);
+  });
+
+  it("announces apply exceptions inside the active target dialog", async () => {
+    await renderModal(absentDiagnostics(), {
+      selection: createSelection(),
+      errorMessage: "게임 경로를 적용하지 못했습니다. IPC failure",
+    });
+
+    const targetDialog = container.querySelector(
+      '[aria-labelledby="game-path-target-selection-title"]',
+    );
+    const alert = targetDialog?.querySelector('[role="alert"]');
+    expect(alert?.textContent).toContain("IPC failure");
+    expect(
+      container.querySelector(".game-path-modal-background [role=alert]"),
+    ).toBeNull();
+  });
+
+  it("announces delete exceptions inside the active confirmation dialog", async () => {
+    const primaryPath = String.raw`D:\\Games\\Primary`;
+    const diagnostics = createDiagnostics(
+      [
+        createCandidate({
+          path: primaryPath,
+          state: "found",
+          verification: "valid",
+          isActive: true,
+        }),
+      ],
+      "valid",
+    );
+    await renderModal(diagnostics, {
+      registryDeleteTarget: {
+        targetId: "registry-primary",
+        expectedPath: primaryPath,
+      },
+      errorMessage: "레지스트리 경로값을 삭제하지 못했습니다. IPC failure",
+    });
+
+    const deleteDialog = container.querySelector(
+      '[aria-labelledby="game-path-registry-delete-title"]',
+    );
+    expect(
+      deleteDialog?.querySelector('[role="alert"]')?.textContent,
+    ).toContain("IPC failure");
+    expect(
+      container.querySelector(".game-path-modal-background [role=alert]"),
+    ).toBeNull();
+  });
+
+  it("restores focus to the candidate heading when deletion disables the opener", async () => {
+    const primaryPath = String.raw`D:\\Games\\Primary`;
+    const diagnostics = createDiagnostics(
+      [
+        createCandidate({
+          path: primaryPath,
+          state: "found",
+          verification: "valid",
+          isActive: true,
+        }),
+      ],
+      "valid",
+    );
+    const props = await renderModal(diagnostics);
+    const deleteButton = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Kakaogames (기본) 레지스트리 값 삭제"]',
+    );
+    deleteButton?.focus();
+    await act(async () =>
+      root.render(
+        <GamePathDiagnosticModal
+          {...props}
+          registryDeleteTarget={{
+            targetId: "registry-primary",
+            expectedPath: primaryPath,
+          }}
+        />,
+      ),
+    );
+
+    const deletedDiagnostics = absentDiagnostics();
+    await act(async () => {
+      root.render(
+        <GamePathDiagnosticModal
+          {...props}
+          diagnostics={deletedDiagnostics}
+          registryDeleteTarget={null}
+        />,
+      );
+      await Promise.resolve();
+    });
+
+    const fallbackHeading = container.querySelector<HTMLElement>(
+      '[data-registry-candidate-heading="registry-primary"]',
+    );
+    expect(document.activeElement).toBe(fallbackHeading);
+    expect(deleteButton?.disabled).toBe(true);
+  });
+
+  it("marks decorative glyphs hidden from assistive technology", async () => {
+    await renderModal(absentDiagnostics(), { selection: createSelection() });
+
+    const glyphs = [
+      ...container.querySelectorAll<HTMLElement>(".material-symbols-outlined"),
+    ];
+    expect(glyphs.length).toBeGreaterThan(0);
+    expect(
+      glyphs.every((glyph) => glyph.getAttribute("aria-hidden") === "true"),
+    ).toBe(true);
+  });
+
+  it("contains nested scrolling and keeps the candidate delete hit target reasonable", () => {
+    const css = fs.readFileSync(
+      path.join(
+        process.cwd(),
+        "src/renderer/components/modals/GamePathDiagnosticModal.css",
+      ),
+      "utf8",
+    );
+
+    expect(css).toMatch(
+      /\.game-path-modal-body\s*\{[^}]*overscroll-behavior:\s*contain/s,
+    );
+    expect(css).toMatch(
+      /\.game-path-target-list,\s*\.game-path-target-results\s*\{[^}]*overscroll-behavior:\s*contain/s,
+    );
+    expect(css).toMatch(
+      /\.game-path-candidate-delete\s*\{[^}]*(?:min-)?width:\s*(?:40|4[1-9]|[5-9]\d)px[^}]*(?:min-)?height:\s*(?:40|4[1-9]|[5-9]\d)px/s,
+    );
+  });
+
+  it("focuses and traps the target dialog, closes with Escape, and restores the opener", async () => {
+    const onCloseSelection = vi.fn();
+    const props = await renderModal(absentDiagnostics(), { onCloseSelection });
+    const opener = [...container.querySelectorAll("button")].find((button) =>
+      button.textContent?.includes("폴더 선택"),
+    );
+    opener?.focus();
+
+    await act(async () =>
+      root.render(
+        <GamePathDiagnosticModal {...props} selection={createSelection()} />,
+      ),
+    );
+    const targetDialog = container.querySelector<HTMLElement>(
+      '[aria-labelledby="game-path-target-selection-title"]',
+    );
+    const firstCheckbox = targetDialog?.querySelector<HTMLInputElement>(
+      'input[value="registry-primary"]',
+    );
+    expect(document.activeElement).toBe(firstCheckbox);
+
+    firstCheckbox?.focus();
+    await act(async () =>
+      targetDialog?.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "Tab",
+          shiftKey: true,
+          bubbles: true,
+        }),
+      ),
+    );
+    const focusable = [
+      ...(targetDialog?.querySelectorAll<HTMLElement>("*") ?? []),
+    ].filter((element) =>
+      element.matches("button:not(:disabled), input:not(:disabled)"),
+    );
+    expect(document.activeElement).toBe(focusable[focusable.length - 1]);
+
+    await act(async () =>
+      targetDialog?.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+      ),
+    );
+    expect(onCloseSelection).toHaveBeenCalledTimes(1);
+    await act(async () =>
+      root.render(<GamePathDiagnosticModal {...props} selection={null} />),
+    );
+    expect(document.activeElement).toBe(opener);
   });
 });

--- a/src/renderer/components/modals/GamePathDiagnosticModal.test.tsx
+++ b/src/renderer/components/modals/GamePathDiagnosticModal.test.tsx
@@ -1,0 +1,279 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import GamePathDiagnosticModal from "./GamePathDiagnosticModal";
+import { getRegistryRegistrationEligibility } from "../../utils/game-path-registry-registration";
+
+import type {
+  GameInstallPathDiagnostics,
+  GameInstallPathRegistryCandidateDiagnostic,
+} from "../../../shared/types";
+
+const configPath = String.raw`C:\Games\Path of Exile 2`;
+const primaryRegistryPath = String.raw`HKCU:\Software\Kakaogames\POE2`;
+const legacyRegistryPath = String.raw`HKCU:\Software\DaumGames\POE2`;
+
+const createCandidate = (
+  overrides: Partial<GameInstallPathRegistryCandidateDiagnostic>,
+): GameInstallPathRegistryCandidateDiagnostic => ({
+  path: null,
+  state: "value-missing",
+  verification: "not-checked",
+  registryPath: primaryRegistryPath,
+  registryValueName: "InstallPath",
+  isActive: false,
+  ...overrides,
+});
+
+const createDiagnostics = (
+  candidates: GameInstallPathRegistryCandidateDiagnostic[],
+  aggregateState: GameInstallPathDiagnostics["registry"]["aggregateState"],
+): GameInstallPathDiagnostics => {
+  const displayed =
+    candidates.find((candidate) => candidate.isActive) ?? candidates[0];
+  return {
+    serviceId: "Kakao Games",
+    gameId: "POE2",
+    executableName: "PathOfExile_KG.exe",
+    config: {
+      source: "config",
+      path: configPath,
+      state: "found",
+      verification: "valid",
+    },
+    registry: {
+      source: "registry",
+      path: displayed.path,
+      state: displayed.state,
+      verification: displayed.verification,
+      registryPath: displayed.registryPath,
+      registryValueName: displayed.registryValueName,
+      aggregateState,
+      candidates,
+    },
+    hasPathConflict: false,
+    isPathConflictAcknowledged: false,
+    recommendedSource: aggregateState === "valid" ? "registry" : "config",
+  };
+};
+
+const absentDiagnostics = () =>
+  createDiagnostics(
+    [
+      createCandidate({ state: "key-missing" }),
+      createCandidate({
+        state: "value-empty",
+        registryPath: legacyRegistryPath,
+      }),
+    ],
+    "absent",
+  );
+
+describe("GamePathDiagnosticModal registry diagnostics", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    (
+      globalThis as typeof globalThis & {
+        IS_REACT_ACT_ENVIRONMENT: boolean;
+      }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.append(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+  });
+
+  const renderModal = async (
+    diagnostics: GameInstallPathDiagnostics,
+    overrides: Partial<
+      React.ComponentProps<typeof GamePathDiagnosticModal>
+    > = {},
+  ) => {
+    const props: React.ComponentProps<typeof GamePathDiagnosticModal> = {
+      isOpen: true,
+      mode: "diagnostic",
+      serviceId: "Kakao Games",
+      gameId: "POE2",
+      diagnostics,
+      onClose: vi.fn(),
+      onContextChange: vi.fn(),
+      onUsePath: vi.fn(),
+      onClearPath: vi.fn(),
+      onManualSelect: vi.fn(),
+      onRegistrySyncConfirmClose: vi.fn(),
+      onRegistryClearConfirmClose: vi.fn(),
+      onRegistryRegisterRequest: vi.fn(),
+      onRegistryRegisterConfirmClose: vi.fn(),
+      onKeepLauncherConfig: vi.fn(),
+      onSyncRegistry: vi.fn(),
+      onConfirmClearRegistry: vi.fn(),
+      onConfirmRegisterRegistry: vi.fn(),
+      ...overrides,
+    };
+    await act(async () => root.render(<GamePathDiagnosticModal {...props} />));
+    return props;
+  };
+
+  it("shows registry key and value name separately with primary and fallback status", async () => {
+    const legacyPath = String.raw`D:\Games\Path of Exile 2`;
+    const diagnostics = createDiagnostics(
+      [
+        createCandidate({ state: "key-missing" }),
+        createCandidate({
+          path: legacyPath,
+          state: "found",
+          verification: "valid",
+          registryPath: legacyRegistryPath,
+          isActive: true,
+        }),
+      ],
+      "valid",
+    );
+
+    await renderModal(diagnostics);
+
+    const summaryMetadata = [
+      ...container.querySelectorAll(
+        ".game-path-option-head .game-path-option-meta > div",
+      ),
+    ].map((line) => line.textContent);
+    expect(summaryMetadata).toEqual([
+      String.raw`키: HKCU:\Software\DaumGames\POE2`,
+      "값 이름: InstallPath",
+    ]);
+    expect(container.textContent).toContain("Kakaogames (기본)");
+    expect(container.textContent).toContain("DaumGames (호환)");
+    expect(container.textContent).toContain("호환 경로 사용 중 (fallback)");
+    expect(container.textContent).not.toContain(" / InstallPath");
+  });
+
+  it("allows registration only when both candidates are confirmed absent", async () => {
+    const diagnostics = absentDiagnostics();
+    const onRequest = vi.fn();
+    const props = await renderModal(diagnostics, {
+      onRegistryRegisterRequest: onRequest,
+    });
+
+    expect(getRegistryRegistrationEligibility(diagnostics)).toBe("eligible");
+    const registerButton = [...container.querySelectorAll("button")].find(
+      (button) => button.textContent?.includes("레지스트리에 경로 등록"),
+    );
+    expect(registerButton?.disabled).toBe(false);
+    await act(async () => registerButton?.click());
+    expect(onRequest).toHaveBeenCalledTimes(1);
+
+    await renderModal(diagnostics, {
+      ...props,
+      showRegistryRegisterConfirm: true,
+    });
+    expect(container.textContent).toContain(primaryRegistryPath);
+    expect(container.textContent).toContain("값 이름InstallPath");
+    expect(container.textContent).toContain(`등록 경로${configPath}`);
+    expect(container.textContent).toContain(
+      "DaumGames (호환) 키와 값은 변경하지 않습니다.",
+    );
+  });
+
+  it("disables registration and explains an unknown registry read", async () => {
+    const diagnostics = createDiagnostics(
+      [
+        createCandidate({ state: "read-failed", error: "access denied" }),
+        createCandidate({
+          state: "value-missing",
+          registryPath: legacyRegistryPath,
+        }),
+      ],
+      "unknown",
+    );
+
+    await renderModal(diagnostics);
+
+    expect(getRegistryRegistrationEligibility(diagnostics)).toBe("unknown");
+    const registerButton = [...container.querySelectorAll("button")].find(
+      (button) => button.textContent?.includes("레지스트리에 경로 등록"),
+    );
+    expect(registerButton?.disabled).toBe(true);
+    expect(container.textContent).toContain(
+      "레지스트리 상태를 확인할 수 없어 안전하게 등록할 수 없습니다.",
+    );
+  });
+
+  it("blocks registration when a candidate contains a nonempty invalid path", async () => {
+    const diagnostics = createDiagnostics(
+      [
+        createCandidate({
+          path: String.raw`C:\Broken\Path of Exile 2`,
+          state: "found",
+          verification: "missing",
+        }),
+        createCandidate({
+          state: "value-missing",
+          registryPath: legacyRegistryPath,
+        }),
+      ],
+      "invalid",
+    );
+
+    await renderModal(diagnostics);
+
+    expect(getRegistryRegistrationEligibility(diagnostics)).toBe("blocked");
+    const registerButton = [...container.querySelectorAll("button")].find(
+      (button) => button.textContent?.includes("레지스트리에 경로 등록"),
+    );
+    expect(registerButton?.disabled).toBe(true);
+    expect(container.textContent).toContain(
+      "기존 레지스트리 경로값이 있어 새 경로를 등록할 수 없습니다.",
+    );
+  });
+
+  it("does not close from the backdrop while a path action is busy", async () => {
+    const onClose = vi.fn();
+    await renderModal(absentDiagnostics(), { busy: true, onClose });
+
+    await act(async () => {
+      container
+        .querySelector<HTMLDivElement>(".game-path-modal-overlay")
+        ?.click();
+    });
+
+    expect(onClose).not.toHaveBeenCalled();
+    expect(
+      container
+        .querySelector(".game-path-modal-overlay")
+        ?.getAttribute("aria-busy"),
+    ).toBe("true");
+  });
+
+  it("renders fresh canonical diagnostics after a successful registration result", async () => {
+    const registeredDiagnostics = createDiagnostics(
+      [
+        createCandidate({
+          path: configPath,
+          state: "found",
+          verification: "valid",
+          isActive: true,
+        }),
+        createCandidate({
+          state: "value-missing",
+          registryPath: legacyRegistryPath,
+        }),
+      ],
+      "valid",
+    );
+
+    await renderModal(registeredDiagnostics, { registrySaveToastId: 1 });
+
+    expect(container.textContent).toContain("기본 경로 사용 중");
+    expect(container.textContent).toContain(
+      "레지스트리 게임 경로가 등록되었습니다.",
+    );
+    expect(container.textContent).not.toContain("레지스트리에 경로 등록");
+  });
+});

--- a/src/renderer/components/modals/GamePathDiagnosticModal.tsx
+++ b/src/renderer/components/modals/GamePathDiagnosticModal.tsx
@@ -7,17 +7,19 @@ import {
   type ActiveGame,
   type GameInstallPathConfigDiagnostic,
   type GameInstallPathDiagnostics,
+  type GameInstallPathRegistryCandidateDiagnostic,
   type GameInstallPathRegistryDiagnostic,
   type ServiceChannel,
 } from "../../../shared/types";
+import { getRegistryRegistrationEligibility } from "../../utils/game-path-registry-registration";
 import { SERVICE_CHANNEL_ASSETS } from "../../utils/service-channel-assets";
 import { Toast } from "../ui/Toast";
 
 type GamePathSource = "config" | "registry";
 type GamePathModalMode = "conflict" | "missing" | "diagnostic";
 type PathDiagnostic =
-  | GameInstallPathConfigDiagnostic
-  | GameInstallPathRegistryDiagnostic;
+  GameInstallPathConfigDiagnostic | GameInstallPathRegistryDiagnostic;
+type PathStatusDiagnostic = Pick<PathDiagnostic, "state" | "verification">;
 
 interface GamePathDiagnosticModalProps {
   isOpen: boolean;
@@ -30,7 +32,9 @@ interface GamePathDiagnosticModalProps {
   highlightManual?: boolean;
   showRegistrySyncConfirm?: boolean;
   showRegistryClearConfirm?: boolean;
+  showRegistryRegisterConfirm?: boolean;
   manualSaveToastId?: number;
+  registrySaveToastId?: number;
   onClose: () => void;
   onContextChange: (serviceId: ServiceChannel, gameId: ActiveGame) => void;
   onUsePath: (source: GamePathSource) => void;
@@ -38,13 +42,16 @@ interface GamePathDiagnosticModalProps {
   onManualSelect: () => void;
   onRegistrySyncConfirmClose: () => void;
   onRegistryClearConfirmClose: () => void;
+  onRegistryRegisterRequest: () => void;
+  onRegistryRegisterConfirmClose: () => void;
   onKeepLauncherConfig: () => void;
   onSyncRegistry: () => void;
   onConfirmClearRegistry: () => void;
+  onConfirmRegisterRegistry: () => void;
   onInstall?: () => void;
 }
 
-const getStatusIcon = (diagnostic: PathDiagnostic) => {
+const getStatusIcon = (diagnostic: PathStatusDiagnostic) => {
   if (diagnostic.verification === "valid") return "check_circle";
   if (diagnostic.verification === "missing") return "cancel";
   if (
@@ -57,7 +64,7 @@ const getStatusIcon = (diagnostic: PathDiagnostic) => {
   return "help";
 };
 
-const getStatusClass = (diagnostic: PathDiagnostic) => {
+const getStatusClass = (diagnostic: PathStatusDiagnostic) => {
   if (diagnostic.verification === "valid") return "is-valid";
   if (diagnostic.verification === "missing") return "is-invalid";
   if (
@@ -70,7 +77,7 @@ const getStatusClass = (diagnostic: PathDiagnostic) => {
   return "is-empty";
 };
 
-const getStatusText = (diagnostic: PathDiagnostic) => {
+const getStatusText = (diagnostic: PathStatusDiagnostic) => {
   if (diagnostic.verification === "valid") return "확인됨";
   if (diagnostic.verification === "missing") return "실행 파일 없음";
   if (diagnostic.verification === "unknown") return "확인 불가";
@@ -109,6 +116,62 @@ const GAME_LABELS: Record<ActiveGame, string> = {
   POE1: "POE1",
   POE2: "POE2",
 };
+
+const getRegistryCandidateLabel = (
+  serviceId: ServiceChannel,
+  index: number,
+) => {
+  if (serviceId !== "Kakao Games") return `후보 ${index + 1}`;
+  return index === 0 ? "Kakaogames (기본)" : "DaumGames (호환)";
+};
+
+const getRegistryCandidateStatusText = (
+  candidate: GameInstallPathRegistryCandidateDiagnostic,
+  index: number,
+) => {
+  if (candidate.isActive) {
+    return index === 0 ? "기본 경로 사용 중" : "호환 경로 사용 중 (fallback)";
+  }
+  if (candidate.verification === "valid") return "사용 가능";
+  return getStatusText(candidate);
+};
+
+const RegistryCandidateList: React.FC<{
+  serviceId: ServiceChannel;
+  candidates: GameInstallPathRegistryCandidateDiagnostic[];
+}> = ({ serviceId, candidates }) => (
+  <div className="game-path-registry-candidates">
+    {candidates.map((candidate, index) => {
+      const statusClass = getStatusClass(candidate);
+      return (
+        <div
+          key={`${candidate.registryPath}:${candidate.registryValueName}`}
+          className={`game-path-registry-candidate ${statusClass} ${
+            candidate.isActive ? "is-active" : ""
+          }`}
+        >
+          <div className="game-path-registry-candidate-head">
+            <strong>{getRegistryCandidateLabel(serviceId, index)}</strong>
+            <span className={statusClass}>
+              {getRegistryCandidateStatusText(candidate, index)}
+            </span>
+          </div>
+          <div className="game-path-option-meta">
+            <div>키: {candidate.registryPath}</div>
+            <div>값 이름: {candidate.registryValueName}</div>
+          </div>
+          <div
+            className={`game-path-registry-candidate-path ${
+              candidate.path ? "" : "is-empty"
+            }`}
+          >
+            {candidate.path || "등록된 경로 없음"}
+          </div>
+        </div>
+      );
+    })}
+  </div>
+);
 
 const GamePathServiceSelect: React.FC<{
   value: ServiceChannel;
@@ -249,6 +312,7 @@ const PathOptionCard: React.FC<{
   title: string;
   source: GamePathSource;
   diagnostic: PathDiagnostic;
+  serviceId?: ServiceChannel;
   recommended: boolean;
   busy: boolean;
   onUsePath: (source: GamePathSource) => void;
@@ -258,6 +322,7 @@ const PathOptionCard: React.FC<{
   title,
   source,
   diagnostic,
+  serviceId,
   recommended,
   busy,
   onUsePath,
@@ -275,10 +340,6 @@ const PathOptionCard: React.FC<{
   );
   const statusClass = getStatusClass(diagnostic);
   const actionDisabled = (!canUsePath && !canReselectConfigPath) || busy;
-  const registryDetail =
-    diagnostic.source === "registry"
-      ? `${diagnostic.registryPath} / ${diagnostic.registryValueName}`
-      : null;
 
   return (
     <section
@@ -289,8 +350,11 @@ const PathOptionCard: React.FC<{
       <div className="game-path-option-head">
         <div>
           <div className="game-path-option-title">{title}</div>
-          {registryDetail && (
-            <div className="game-path-option-meta">{registryDetail}</div>
+          {diagnostic.source === "registry" && (
+            <div className="game-path-option-meta">
+              <div>키: {diagnostic.registryPath}</div>
+              <div>값 이름: {diagnostic.registryValueName}</div>
+            </div>
           )}
         </div>
         <div className={`game-path-state ${statusClass}`}>
@@ -310,6 +374,13 @@ const PathOptionCard: React.FC<{
 
       {diagnostic.error && (
         <div className="game-path-option-error">{diagnostic.error}</div>
+      )}
+
+      {diagnostic.source === "registry" && serviceId && (
+        <RegistryCandidateList
+          serviceId={serviceId}
+          candidates={diagnostic.candidates}
+        />
       )}
 
       <div className="game-path-option-actions">
@@ -362,7 +433,9 @@ const GamePathDiagnosticModal: React.FC<GamePathDiagnosticModalProps> = ({
   highlightManual = false,
   showRegistrySyncConfirm = false,
   showRegistryClearConfirm = false,
+  showRegistryRegisterConfirm = false,
   manualSaveToastId,
+  registrySaveToastId,
   onClose,
   onContextChange,
   onUsePath,
@@ -370,9 +443,12 @@ const GamePathDiagnosticModal: React.FC<GamePathDiagnosticModalProps> = ({
   onManualSelect,
   onRegistrySyncConfirmClose,
   onRegistryClearConfirmClose,
+  onRegistryRegisterRequest,
+  onRegistryRegisterConfirmClose,
   onKeepLauncherConfig,
   onSyncRegistry,
   onConfirmClearRegistry,
+  onConfirmRegisterRegistry,
   onInstall,
 }) => {
   const manualRowRef = React.useRef<HTMLDivElement>(null);
@@ -396,11 +472,19 @@ const GamePathDiagnosticModal: React.FC<GamePathDiagnosticModalProps> = ({
       : mode === "conflict"
         ? "설정 경로와 레지스트리 경로가 다릅니다."
         : "서비스와 게임별 설치 경로를 확인합니다.";
+  const registrationEligibility = diagnostics
+    ? getRegistryRegistrationEligibility(diagnostics)
+    : "not-applicable";
+  const canonicalCandidate = diagnostics?.registry.candidates[0];
 
   if (!isOpen) return null;
 
   return (
-    <div className="game-path-modal-overlay" onClick={onClose}>
+    <div
+      className="game-path-modal-overlay"
+      aria-busy={busy}
+      onClick={busy ? undefined : onClose}
+    >
       <div
         className="game-path-modal"
         onClick={(event) => event.stopPropagation()}
@@ -439,6 +523,7 @@ const GamePathDiagnosticModal: React.FC<GamePathDiagnosticModalProps> = ({
                   title="레지스트리"
                   source="registry"
                   diagnostic={diagnostics.registry}
+                  serviceId={serviceId}
                   recommended={diagnostics.recommendedSource === "registry"}
                   busy={busy}
                   onUsePath={onUsePath}
@@ -456,6 +541,32 @@ const GamePathDiagnosticModal: React.FC<GamePathDiagnosticModalProps> = ({
                   onManualSelect={onManualSelect}
                 />
               </div>
+
+              {(registrationEligibility === "eligible" ||
+                registrationEligibility === "unknown" ||
+                registrationEligibility === "blocked") && (
+                <div className="game-path-registry-register-row">
+                  <div>
+                    <strong>카카오게임즈 레지스트리 복구</strong>
+                    <span>
+                      {registrationEligibility === "eligible"
+                        ? "런처 내 설정 경로를 Kakaogames 기본 키에 등록할 수 있습니다."
+                        : registrationEligibility === "unknown"
+                          ? "레지스트리 상태를 확인할 수 없어 안전하게 등록할 수 없습니다. 다시 진단해 주세요."
+                          : "기존 레지스트리 경로값이 있어 새 경로를 등록할 수 없습니다."}
+                    </span>
+                  </div>
+                  <button
+                    type="button"
+                    className="game-path-action secondary"
+                    disabled={busy || registrationEligibility !== "eligible"}
+                    onClick={onRegistryRegisterRequest}
+                  >
+                    <span className="material-symbols-outlined">add_link</span>
+                    레지스트리에 경로 등록
+                  </button>
+                </div>
+              )}
 
               <div
                 ref={manualRowRef}
@@ -578,6 +689,64 @@ const GamePathDiagnosticModal: React.FC<GamePathDiagnosticModalProps> = ({
             </div>
           )}
 
+        {showRegistryRegisterConfirm &&
+          registrationEligibility === "eligible" &&
+          diagnostics?.config.path &&
+          canonicalCandidate && (
+            <div className="game-path-confirm-overlay">
+              <div
+                className="game-path-confirm-dialog"
+                onClick={(event) => event.stopPropagation()}
+              >
+                <div className="game-path-confirm-icon">
+                  <span className="material-symbols-outlined">add_link</span>
+                </div>
+                <div className="game-path-confirm-content">
+                  <h3>레지스트리에 게임 경로를 등록할까요?</h3>
+                  <p>
+                    런처 내 설정 경로를 카카오게임즈 기본 레지스트리 값으로
+                    등록합니다. 확인하는 동안 기존 값이 생기거나 상태를 읽을 수
+                    없으면 변경하지 않습니다.
+                  </p>
+                  <p>DaumGames (호환) 키와 값은 변경하지 않습니다.</p>
+                  <div className="game-path-confirm-paths">
+                    <div>
+                      <span>키</span>
+                      <strong>{canonicalCandidate.registryPath}</strong>
+                    </div>
+                    <div>
+                      <span>값 이름</span>
+                      <strong>{canonicalCandidate.registryValueName}</strong>
+                    </div>
+                    <div>
+                      <span>등록 경로</span>
+                      <strong>{diagnostics.config.path}</strong>
+                    </div>
+                  </div>
+                </div>
+                <div className="game-path-confirm-actions">
+                  <button
+                    type="button"
+                    className="game-path-action ghost"
+                    disabled={busy}
+                    onClick={onRegistryRegisterConfirmClose}
+                  >
+                    취소
+                  </button>
+                  <button
+                    type="button"
+                    className="game-path-action primary"
+                    disabled={busy}
+                    onClick={onConfirmRegisterRegistry}
+                  >
+                    <span className="material-symbols-outlined">add_link</span>
+                    경로 등록
+                  </button>
+                </div>
+              </div>
+            </div>
+          )}
+
         {showRegistryClearConfirm && diagnostics?.registry.path && (
           <div className="game-path-confirm-overlay">
             <div
@@ -632,6 +801,14 @@ const GamePathDiagnosticModal: React.FC<GamePathDiagnosticModalProps> = ({
           <Toast
             key={manualSaveToastId}
             message="게임 경로가 저장되었습니다."
+            visible
+            variant="success"
+          />
+        )}
+        {registrySaveToastId && (
+          <Toast
+            key={registrySaveToastId}
+            message="레지스트리 게임 경로가 등록되었습니다."
             visible
             variant="success"
           />

--- a/src/renderer/components/modals/GamePathDiagnosticModal.tsx
+++ b/src/renderer/components/modals/GamePathDiagnosticModal.tsx
@@ -9,11 +9,18 @@ import {
   type GameInstallPathDiagnostics,
   type GameInstallPathRegistryCandidateDiagnostic,
   type GameInstallPathRegistryDiagnostic,
+  type GameInstallPathRegistryTargetDeleteRequest,
+  type GameInstallPathSelectionDescriptor,
+  type GameInstallPathSelectionTargetDescriptor,
+  type GameInstallPathTargetApplyResult,
+  type GameInstallPathTargetId,
   type ServiceChannel,
 } from "../../../shared/types";
 import { getRegistryRegistrationEligibility } from "../../utils/game-path-registry-registration";
 import { SERVICE_CHANNEL_ASSETS } from "../../utils/service-channel-assets";
 import { Toast } from "../ui/Toast";
+
+import type { GamePathSelectionPresentationResult } from "../../utils/game-path-modal-state";
 
 type GamePathSource = "config" | "registry";
 type GamePathModalMode = "conflict" | "missing" | "diagnostic";
@@ -31,22 +38,29 @@ interface GamePathDiagnosticModalProps {
   errorMessage?: string;
   highlightManual?: boolean;
   showRegistrySyncConfirm?: boolean;
-  showRegistryClearConfirm?: boolean;
   showRegistryRegisterConfirm?: boolean;
+  selection?: GameInstallPathSelectionDescriptor | null;
+  selectionApplyResult?: GamePathSelectionPresentationResult | null;
+  registryDeleteTarget?: GameInstallPathRegistryTargetDeleteRequest | null;
   manualSaveToastId?: number;
   registrySaveToastId?: number;
   onClose: () => void;
   onContextChange: (serviceId: ServiceChannel, gameId: ActiveGame) => void;
   onUsePath: (source: GamePathSource) => void;
-  onClearPath: (source: GamePathSource) => void;
+  onClearPath: () => void;
   onManualSelect: () => void;
+  onApplyTargets?: (targetIds: readonly GameInstallPathTargetId[]) => void;
+  onCloseSelection?: () => void;
+  onRegistryDeleteRequest?: (
+    request: GameInstallPathRegistryTargetDeleteRequest,
+  ) => void;
+  onRegistryDeleteConfirmClose?: () => void;
+  onConfirmDeleteRegistryTarget?: () => void;
   onRegistrySyncConfirmClose: () => void;
-  onRegistryClearConfirmClose: () => void;
   onRegistryRegisterRequest: () => void;
   onRegistryRegisterConfirmClose: () => void;
   onKeepLauncherConfig: () => void;
   onSyncRegistry: () => void;
-  onConfirmClearRegistry: () => void;
   onConfirmRegisterRegistry: () => void;
   onInstall?: () => void;
 }
@@ -139,10 +153,15 @@ const getRegistryCandidateStatusText = (
 const RegistryCandidateList: React.FC<{
   serviceId: ServiceChannel;
   candidates: GameInstallPathRegistryCandidateDiagnostic[];
-}> = ({ serviceId, candidates }) => (
+  busy: boolean;
+  onDeleteRequest: (
+    request: GameInstallPathRegistryTargetDeleteRequest,
+  ) => void;
+}> = ({ serviceId, candidates, busy, onDeleteRequest }) => (
   <div className="game-path-registry-candidates">
     {candidates.map((candidate, index) => {
       const statusClass = getStatusClass(candidate);
+      const candidateLabel = getRegistryCandidateLabel(serviceId, index);
       return (
         <div
           key={`${candidate.registryPath}:${candidate.registryValueName}`}
@@ -151,10 +170,35 @@ const RegistryCandidateList: React.FC<{
           }`}
         >
           <div className="game-path-registry-candidate-head">
-            <strong>{getRegistryCandidateLabel(serviceId, index)}</strong>
-            <span className={statusClass}>
-              {getRegistryCandidateStatusText(candidate, index)}
-            </span>
+            <div>
+              <strong
+                tabIndex={-1}
+                data-registry-candidate-heading={candidate.targetId}
+              >
+                {candidateLabel}
+              </strong>
+              <span className={statusClass}>
+                {getRegistryCandidateStatusText(candidate, index)}
+              </span>
+            </div>
+            <button
+              type="button"
+              className="game-path-candidate-delete"
+              aria-label={`${candidateLabel} 레지스트리 값 삭제`}
+              title="이 후보의 레지스트리 값 삭제"
+              disabled={busy || !candidate.path}
+              onClick={() => {
+                if (!candidate.path) return;
+                onDeleteRequest({
+                  targetId: candidate.targetId,
+                  expectedPath: candidate.path,
+                });
+              }}
+            >
+              <span className="material-symbols-outlined" aria-hidden="true">
+                delete
+              </span>
+            </button>
           </div>
           <div className="game-path-option-meta">
             <div>키: {candidate.registryPath}</div>
@@ -172,6 +216,333 @@ const RegistryCandidateList: React.FC<{
     })}
   </div>
 );
+
+const TARGET_LABELS: Record<GameInstallPathTargetId, string> = {
+  "registry-primary": "기본 레지스트리",
+  "registry-compatibility": "호환 레지스트리",
+  config: "런처 내 설정",
+};
+
+const getTargetResultText = (result: GameInstallPathTargetApplyResult) => {
+  if (result.status === "applied") return "적용 완료";
+  if (result.status === "unchanged") return "변경 없음";
+  return "적용 실패";
+};
+
+const getTargetResultSummary = (
+  result: GamePathSelectionPresentationResult,
+) => {
+  if (result.overall === "success") return "선택한 대상에 적용했습니다.";
+  if (result.overall === "partial") {
+    return "일부 대상에 적용하지 못했습니다.";
+  }
+  return "선택한 대상에 적용하지 못했습니다.";
+};
+
+const getTargetDisabledText = (
+  target: GameInstallPathSelectionTargetDescriptor,
+) => {
+  if (target.completed) return "적용 완료";
+  if (target.disabledReason === "target-read-failed")
+    return "현재 상태 확인 불가";
+  return target.disabled ? "선택 불가" : undefined;
+};
+
+const DIALOG_FOCUSABLE_SELECTOR = [
+  "button:not(:disabled)",
+  "input:not(:disabled)",
+  "[href]",
+  '[tabindex]:not([tabindex="-1"])',
+].join(",");
+const NOOP = () => undefined;
+
+const useNestedDialogFocus = (
+  open: boolean,
+  busy: boolean,
+  onClose: () => void,
+  getRestoreFallback?: () => HTMLElement | null,
+) => {
+  const dialogRef = React.useRef<HTMLDivElement>(null);
+  const openerRef = React.useRef<HTMLElement | null>(null);
+
+  React.useLayoutEffect(() => {
+    if (!open) return;
+
+    openerRef.current =
+      document.activeElement instanceof HTMLElement
+        ? document.activeElement
+        : null;
+    const restoreFallback = getRestoreFallback;
+    const initialTarget = dialogRef.current?.querySelector<HTMLElement>(
+      "[data-dialog-initial-focus]",
+    );
+    initialTarget?.focus();
+
+    return () => {
+      const opener = openerRef.current;
+      window.queueMicrotask(() => {
+        const openerDisabled =
+          opener instanceof HTMLButtonElement ||
+          opener instanceof HTMLInputElement
+            ? opener.disabled
+            : false;
+        const target =
+          opener?.isConnected && !openerDisabled && !opener.closest("[inert]")
+            ? opener
+            : restoreFallback?.();
+        target?.focus();
+      });
+      openerRef.current = null;
+    };
+  }, [getRestoreFallback, open]);
+
+  const handleKeyDown = React.useCallback(
+    (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        if (!busy) {
+          event.preventDefault();
+          onClose();
+        }
+        return;
+      }
+      if (event.key !== "Tab") return;
+
+      const focusable = [
+        ...(dialogRef.current?.querySelectorAll<HTMLElement>("*") ?? []),
+      ].filter((element) => element.matches(DIALOG_FOCUSABLE_SELECTOR));
+      if (focusable.length === 0) {
+        event.preventDefault();
+        return;
+      }
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    },
+    [busy, onClose],
+  );
+
+  React.useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+
+    dialog.addEventListener("keydown", handleKeyDown);
+    return () => dialog.removeEventListener("keydown", handleKeyDown);
+  }, [handleKeyDown]);
+
+  return dialogRef;
+};
+
+const TargetSelectionDialog: React.FC<{
+  selection: GameInstallPathSelectionDescriptor;
+  result?: GamePathSelectionPresentationResult | null;
+  errorMessage?: string;
+  busy: boolean;
+  onApply: (targetIds: readonly GameInstallPathTargetId[]) => void;
+  onClose: () => void;
+}> = ({ selection, result, errorMessage, busy, onApply, onClose }) => {
+  const [selectedTargetIds, setSelectedTargetIds] = React.useState<
+    Set<GameInstallPathTargetId>
+  >(
+    () =>
+      new Set(
+        selection.targets
+          .filter((target) => target.selectedByDefault && !target.disabled)
+          .map((target) => target.targetId),
+      ),
+  );
+  const dialogRef = useNestedDialogFocus(true, busy, onClose);
+  const firstEnabledTargetId = selection.targets.find(
+    (target) => !target.disabled,
+  )?.targetId;
+  const selectedCount = selectedTargetIds.size;
+
+  React.useLayoutEffect(() => {
+    if (!result) return;
+
+    const resultFocusTarget = dialogRef.current?.querySelector<HTMLElement>(
+      "[data-dialog-result-focus]",
+    );
+    resultFocusTarget?.focus();
+  }, [dialogRef, result]);
+
+  const handleApply = () => {
+    if (selectedCount === 0 || busy) return;
+    onApply(
+      selection.targets
+        .map((target) => target.targetId)
+        .filter((targetId) => selectedTargetIds.has(targetId)),
+    );
+  };
+
+  return (
+    <div
+      className="game-path-confirm-overlay game-path-target-overlay"
+      onClick={busy ? undefined : onClose}
+    >
+      <div
+        ref={dialogRef}
+        className="game-path-target-dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="game-path-target-selection-title"
+        aria-busy={busy}
+        onClick={(event) => event.stopPropagation()}
+      >
+        <header className="game-path-target-header">
+          <div>
+            <span className="game-path-target-kicker">적용 대상</span>
+            <h3 id="game-path-target-selection-title">
+              선택한 경로를 어디에 적용할까요?
+            </h3>
+          </div>
+          <span className="material-symbols-outlined" aria-hidden="true">
+            folder_managed
+          </span>
+        </header>
+
+        <div className="game-path-target-context" aria-label="선택 정보">
+          <div>
+            <span>서비스</span>
+            <strong>{selection.serviceId}</strong>
+          </div>
+          <div>
+            <span>게임</span>
+            <strong>{selection.gameId}</strong>
+          </div>
+          <div className="game-path-target-selected-path">
+            <span>선택한 경로</span>
+            <strong>{selection.path}</strong>
+          </div>
+        </div>
+
+        {result ? (
+          <div className="game-path-target-results" aria-live="polite">
+            <strong>{getTargetResultSummary(result)}</strong>
+            <ul>
+              {result.results.map((targetResult) => (
+                <li
+                  key={targetResult.targetId}
+                  className={`is-${targetResult.status}`}
+                >
+                  <span>{TARGET_LABELS[targetResult.targetId]}</span>
+                  <strong>{getTargetResultText(targetResult)}</strong>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ) : (
+          <fieldset className="game-path-target-list">
+            <legend>적용할 저장 위치</legend>
+            {selection.targets.map((target) => {
+              const disabledText = getTargetDisabledText(target);
+              const targetDescriptionId = `game-path-target-${target.targetId}-description`;
+              return (
+                <label
+                  key={target.targetId}
+                  className={`game-path-target-option ${
+                    target.disabled ? "is-disabled" : ""
+                  }`}
+                >
+                  <input
+                    type="checkbox"
+                    value={target.targetId}
+                    checked={selectedTargetIds.has(target.targetId)}
+                    disabled={busy || target.disabled}
+                    aria-describedby={targetDescriptionId}
+                    data-dialog-initial-focus={
+                      target.targetId === firstEnabledTargetId
+                        ? "true"
+                        : undefined
+                    }
+                    onChange={(event) => {
+                      const checked = event.currentTarget.checked;
+                      setSelectedTargetIds((current) => {
+                        const next = new Set(current);
+                        if (checked) next.add(target.targetId);
+                        else next.delete(target.targetId);
+                        return next;
+                      });
+                    }}
+                  />
+                  <span
+                    className="game-path-target-checkmark"
+                    aria-hidden="true"
+                  />
+                  <span className="game-path-target-option-copy">
+                    <strong>{TARGET_LABELS[target.targetId]}</strong>
+                    <span id={targetDescriptionId}>
+                      {disabledText || target.currentPath || "등록된 경로 없음"}
+                    </span>
+                  </span>
+                </label>
+              );
+            })}
+            <span className="game-path-target-count" aria-live="polite">
+              {selectedCount}개 대상 선택됨
+            </span>
+          </fieldset>
+        )}
+
+        {errorMessage && (
+          <div className="game-path-nested-error" role="alert">
+            <span className="material-symbols-outlined" aria-hidden="true">
+              error
+            </span>
+            {errorMessage}
+          </div>
+        )}
+
+        <footer className="game-path-target-actions">
+          <button
+            type="button"
+            className="game-path-action ghost"
+            disabled={busy}
+            data-dialog-initial-focus={
+              firstEnabledTargetId ? undefined : "true"
+            }
+            data-dialog-result-focus={
+              result && result.retryableTargetIds.length === 0
+                ? "true"
+                : undefined
+            }
+            onClick={onClose}
+          >
+            {result ? "닫기" : "취소"}
+          </button>
+          {result ? (
+            result.retryableTargetIds.length > 0 && (
+              <button
+                type="button"
+                className="game-path-action primary"
+                disabled={busy}
+                data-dialog-result-focus="true"
+                onClick={() => onApply(result.retryableTargetIds)}
+              >
+                실패 항목 다시 시도 ({result.retryableTargetIds.length}개)
+              </button>
+            )
+          ) : (
+            <button
+              type="button"
+              className="game-path-action primary"
+              disabled={busy || selectedCount === 0}
+              onClick={handleApply}
+            >
+              선택 ({selectedCount}개)
+            </button>
+          )}
+        </footer>
+      </div>
+    </div>
+  );
+};
 
 const GamePathServiceSelect: React.FC<{
   value: ServiceChannel;
@@ -213,7 +584,9 @@ const GamePathServiceSelect: React.FC<{
           alt={activeInfo.alt}
           className="game-path-channel-logo"
         />
-        <span className="material-symbols-outlined">expand_more</span>
+        <span className="material-symbols-outlined" aria-hidden="true">
+          expand_more
+        </span>
       </button>
 
       {isOpen && (
@@ -282,7 +655,9 @@ const GamePathGameSelect: React.FC<{
         onClick={() => setIsOpen((current) => !current)}
       >
         <span className="game-path-game-label">{GAME_LABELS[value]}</span>
-        <span className="material-symbols-outlined">expand_more</span>
+        <span className="material-symbols-outlined" aria-hidden="true">
+          expand_more
+        </span>
       </button>
 
       {isOpen && (
@@ -316,8 +691,11 @@ const PathOptionCard: React.FC<{
   recommended: boolean;
   busy: boolean;
   onUsePath: (source: GamePathSource) => void;
-  onClearPath: (source: GamePathSource) => void;
+  onClearPath: () => void;
   onManualSelect: () => void;
+  onRegistryDeleteRequest: (
+    request: GameInstallPathRegistryTargetDeleteRequest,
+  ) => void;
 }> = ({
   title,
   source,
@@ -328,6 +706,7 @@ const PathOptionCard: React.FC<{
   onUsePath,
   onClearPath,
   onManualSelect,
+  onRegistryDeleteRequest,
 }) => {
   const canUsePath = Boolean(
     diagnostic.path && diagnostic.verification === "valid",
@@ -358,7 +737,7 @@ const PathOptionCard: React.FC<{
           )}
         </div>
         <div className={`game-path-state ${statusClass}`}>
-          <span className="material-symbols-outlined">
+          <span className="material-symbols-outlined" aria-hidden="true">
             {getStatusIcon(diagnostic)}
           </span>
           {getStatusText(diagnostic)}
@@ -380,6 +759,8 @@ const PathOptionCard: React.FC<{
         <RegistryCandidateList
           serviceId={serviceId}
           candidates={diagnostic.candidates}
+          busy={busy}
+          onDeleteRequest={onRegistryDeleteRequest}
         />
       )}
 
@@ -394,7 +775,7 @@ const PathOptionCard: React.FC<{
             canReselectConfigPath ? onManualSelect() : onUsePath(source)
           }
         >
-          <span className="material-symbols-outlined">
+          <span className="material-symbols-outlined" aria-hidden="true">
             {canReselectConfigPath
               ? "folder_open"
               : source === "registry"
@@ -404,16 +785,16 @@ const PathOptionCard: React.FC<{
           {canReselectConfigPath ? "다시 선택" : getActionText(source)}
         </button>
 
-        {canClearPath && (
+        {source === "config" && canClearPath && (
           <button
             type="button"
-            className={`game-path-action path-clear ${
-              source === "registry" ? "danger" : "secondary"
-            }`}
+            className="game-path-action path-clear secondary"
             disabled={busy}
-            onClick={() => onClearPath(source)}
+            onClick={onClearPath}
           >
-            <span className="material-symbols-outlined">delete</span>
+            <span className="material-symbols-outlined" aria-hidden="true">
+              delete
+            </span>
             {getClearActionText(source)}
           </button>
         )}
@@ -432,8 +813,10 @@ const GamePathDiagnosticModal: React.FC<GamePathDiagnosticModalProps> = ({
   errorMessage,
   highlightManual = false,
   showRegistrySyncConfirm = false,
-  showRegistryClearConfirm = false,
   showRegistryRegisterConfirm = false,
+  selection = null,
+  selectionApplyResult = null,
+  registryDeleteTarget = null,
   manualSaveToastId,
   registrySaveToastId,
   onClose,
@@ -441,17 +824,49 @@ const GamePathDiagnosticModal: React.FC<GamePathDiagnosticModalProps> = ({
   onUsePath,
   onClearPath,
   onManualSelect,
+  onApplyTargets = NOOP,
+  onCloseSelection = NOOP,
+  onRegistryDeleteRequest = NOOP,
+  onRegistryDeleteConfirmClose = NOOP,
+  onConfirmDeleteRegistryTarget = NOOP,
   onRegistrySyncConfirmClose,
-  onRegistryClearConfirmClose,
   onRegistryRegisterRequest,
   onRegistryRegisterConfirmClose,
   onKeepLauncherConfig,
   onSyncRegistry,
-  onConfirmClearRegistry,
   onConfirmRegisterRegistry,
   onInstall,
 }) => {
   const manualRowRef = React.useRef<HTMLDivElement>(null);
+  const outerDialogRef = React.useRef<HTMLDivElement>(null);
+  const confirmationDialogOpen = Boolean(
+    registryDeleteTarget ||
+    showRegistryRegisterConfirm ||
+    showRegistrySyncConfirm,
+  );
+  const confirmationDialogClose = registryDeleteTarget
+    ? onRegistryDeleteConfirmClose
+    : showRegistryRegisterConfirm
+      ? onRegistryRegisterConfirmClose
+      : onRegistrySyncConfirmClose;
+  const getConfirmationRestoreFallback = React.useCallback(() => {
+    const candidateHeading = registryDeleteTarget
+      ? outerDialogRef.current?.querySelector<HTMLElement>(
+          `[data-registry-candidate-heading="${registryDeleteTarget.targetId}"]`,
+        )
+      : null;
+    const nextCandidateAction =
+      outerDialogRef.current?.querySelector<HTMLElement>(
+        ".game-path-candidate-delete:not(:disabled)",
+      );
+    return candidateHeading ?? nextCandidateAction ?? outerDialogRef.current;
+  }, [registryDeleteTarget]);
+  const confirmationDialogRef = useNestedDialogFocus(
+    confirmationDialogOpen,
+    busy,
+    confirmationDialogClose,
+    getConfirmationRestoreFallback,
+  );
 
   React.useEffect(() => {
     if (!isOpen || !diagnostics || !highlightManual) return;
@@ -476,6 +891,19 @@ const GamePathDiagnosticModal: React.FC<GamePathDiagnosticModalProps> = ({
     ? getRegistryRegistrationEligibility(diagnostics)
     : "not-applicable";
   const canonicalCandidate = diagnostics?.registry.candidates[0];
+  const registryDeleteCandidate = diagnostics?.registry.candidates.find(
+    (candidate) => candidate.targetId === registryDeleteTarget?.targetId,
+  );
+  const registryDeleteCandidateIndex = registryDeleteCandidate
+    ? (diagnostics?.registry.candidates.indexOf(registryDeleteCandidate) ?? -1)
+    : -1;
+  const hasNestedDialog = Boolean(
+    selection ||
+    registryDeleteTarget ||
+    showRegistrySyncConfirm ||
+    showRegistryRegisterConfirm,
+  );
+  const outerInteractionBlocked = busy || hasNestedDialog;
 
   if (!isOpen) return null;
 
@@ -483,160 +911,207 @@ const GamePathDiagnosticModal: React.FC<GamePathDiagnosticModalProps> = ({
     <div
       className="game-path-modal-overlay"
       aria-busy={busy}
-      onClick={busy ? undefined : onClose}
+      onClick={outerInteractionBlocked ? undefined : onClose}
     >
       <div
+        ref={outerDialogRef}
         className="game-path-modal"
+        role="dialog"
+        aria-modal={hasNestedDialog ? undefined : "true"}
+        aria-labelledby="game-path-diagnostic-title"
+        tabIndex={-1}
         onClick={(event) => event.stopPropagation()}
       >
-        <header className="game-path-modal-header">
-          <div className="game-path-title-group">
-            <h2 className="game-path-title">게임 경로 진단</h2>
-            <p className="game-path-subtitle">{subtitle}</p>
-          </div>
-          <div className="game-path-context-controls">
-            <GamePathServiceSelect
-              value={serviceId}
-              disabled={busy}
-              onChange={(nextServiceId) =>
-                onContextChange(nextServiceId, gameId)
-              }
-            />
-            <GamePathGameSelect
-              value={gameId}
-              disabled={busy}
-              onChange={(nextGameId) => onContextChange(serviceId, nextGameId)}
-            />
-          </div>
-        </header>
-
-        <div className="game-path-modal-body">
-          {!diagnostics ? (
-            <div className="game-path-loading">
-              <span className="material-symbols-outlined">sync</span>
-              경로를 확인하는 중...
+        <div
+          className="game-path-modal-background"
+          aria-hidden={hasNestedDialog ? "true" : undefined}
+          inert={hasNestedDialog ? true : undefined}
+        >
+          <header className="game-path-modal-header">
+            <div className="game-path-title-group">
+              <h2 id="game-path-diagnostic-title" className="game-path-title">
+                게임 경로 진단
+              </h2>
+              <p className="game-path-subtitle">{subtitle}</p>
             </div>
-          ) : (
-            <>
-              <div className="game-path-options">
-                <PathOptionCard
-                  title="레지스트리"
-                  source="registry"
-                  diagnostic={diagnostics.registry}
-                  serviceId={serviceId}
-                  recommended={diagnostics.recommendedSource === "registry"}
-                  busy={busy}
-                  onUsePath={onUsePath}
-                  onClearPath={onClearPath}
-                  onManualSelect={onManualSelect}
-                />
-                <PathOptionCard
-                  title="런처 내 설정"
-                  source="config"
-                  diagnostic={diagnostics.config}
-                  recommended={diagnostics.recommendedSource === "config"}
-                  busy={busy}
-                  onUsePath={onUsePath}
-                  onClearPath={onClearPath}
-                  onManualSelect={onManualSelect}
-                />
-              </div>
+            <div className="game-path-context-controls">
+              <GamePathServiceSelect
+                value={serviceId}
+                disabled={outerInteractionBlocked}
+                onChange={(nextServiceId) =>
+                  onContextChange(nextServiceId, gameId)
+                }
+              />
+              <GamePathGameSelect
+                value={gameId}
+                disabled={outerInteractionBlocked}
+                onChange={(nextGameId) =>
+                  onContextChange(serviceId, nextGameId)
+                }
+              />
+            </div>
+          </header>
 
-              {(registrationEligibility === "eligible" ||
-                registrationEligibility === "unknown" ||
-                registrationEligibility === "blocked") && (
-                <div className="game-path-registry-register-row">
+          <div className="game-path-modal-body">
+            {!diagnostics ? (
+              <div className="game-path-loading">
+                <span className="material-symbols-outlined" aria-hidden="true">
+                  sync
+                </span>
+                경로를 확인하는 중...
+              </div>
+            ) : (
+              <>
+                <div className="game-path-options">
+                  <PathOptionCard
+                    title="레지스트리"
+                    source="registry"
+                    diagnostic={diagnostics.registry}
+                    serviceId={serviceId}
+                    recommended={diagnostics.recommendedSource === "registry"}
+                    busy={outerInteractionBlocked}
+                    onUsePath={onUsePath}
+                    onClearPath={onClearPath}
+                    onManualSelect={onManualSelect}
+                    onRegistryDeleteRequest={onRegistryDeleteRequest}
+                  />
+                  <PathOptionCard
+                    title="런처 내 설정"
+                    source="config"
+                    diagnostic={diagnostics.config}
+                    recommended={diagnostics.recommendedSource === "config"}
+                    busy={outerInteractionBlocked}
+                    onUsePath={onUsePath}
+                    onClearPath={onClearPath}
+                    onManualSelect={onManualSelect}
+                    onRegistryDeleteRequest={onRegistryDeleteRequest}
+                  />
+                </div>
+
+                {(registrationEligibility === "eligible" ||
+                  registrationEligibility === "unknown" ||
+                  registrationEligibility === "blocked") && (
+                  <div className="game-path-registry-register-row">
+                    <div>
+                      <strong>카카오게임즈 레지스트리 복구</strong>
+                      <span>
+                        {registrationEligibility === "eligible"
+                          ? "런처 내 설정 경로를 Kakaogames 기본 키에 등록할 수 있습니다."
+                          : registrationEligibility === "unknown"
+                            ? "레지스트리 상태를 확인할 수 없어 안전하게 등록할 수 없습니다. 다시 진단해 주세요."
+                            : "기존 레지스트리 경로값이 있어 새 경로를 등록할 수 없습니다."}
+                      </span>
+                    </div>
+                    <button
+                      type="button"
+                      className="game-path-action secondary"
+                      disabled={
+                        outerInteractionBlocked ||
+                        registrationEligibility !== "eligible"
+                      }
+                      onClick={onRegistryRegisterRequest}
+                    >
+                      <span
+                        className="material-symbols-outlined"
+                        aria-hidden="true"
+                      >
+                        add_link
+                      </span>
+                      레지스트리에 경로 등록
+                    </button>
+                  </div>
+                )}
+
+                <div
+                  ref={manualRowRef}
+                  className={`game-path-manual-row ${
+                    highlightManual ? "is-highlighted" : ""
+                  }`}
+                >
                   <div>
-                    <strong>카카오게임즈 레지스트리 복구</strong>
+                    <strong>수동 설정</strong>
                     <span>
-                      {registrationEligibility === "eligible"
-                        ? "런처 내 설정 경로를 Kakaogames 기본 키에 등록할 수 있습니다."
-                        : registrationEligibility === "unknown"
-                          ? "레지스트리 상태를 확인할 수 없어 안전하게 등록할 수 없습니다. 다시 진단해 주세요."
-                          : "기존 레지스트리 경로값이 있어 새 경로를 등록할 수 없습니다."}
+                      선택한 폴더 안에 {diagnostics.executableName}가 있어야
+                      합니다.
                     </span>
                   </div>
                   <button
                     type="button"
                     className="game-path-action secondary"
-                    disabled={busy || registrationEligibility !== "eligible"}
-                    onClick={onRegistryRegisterRequest}
+                    disabled={outerInteractionBlocked}
+                    onClick={onManualSelect}
                   >
-                    <span className="material-symbols-outlined">add_link</span>
-                    레지스트리에 경로 등록
+                    <span
+                      className="material-symbols-outlined"
+                      aria-hidden="true"
+                    >
+                      folder_open
+                    </span>
+                    폴더 선택
                   </button>
                 </div>
-              )}
+              </>
+            )}
 
-              <div
-                ref={manualRowRef}
-                className={`game-path-manual-row ${
-                  highlightManual ? "is-highlighted" : ""
-                }`}
-              >
-                <div>
-                  <strong>수동 설정</strong>
-                  <span>
-                    선택한 폴더 안에 {diagnostics.executableName}가 있어야
-                    합니다.
-                  </span>
-                </div>
-                <button
-                  type="button"
-                  className="game-path-action secondary"
-                  disabled={busy}
-                  onClick={onManualSelect}
-                >
-                  <span className="material-symbols-outlined">folder_open</span>
-                  폴더 선택
-                </button>
+            {errorMessage && !hasNestedDialog && (
+              <div className="game-path-error-banner" role="alert">
+                <span className="material-symbols-outlined" aria-hidden="true">
+                  error
+                </span>
+                {errorMessage}
               </div>
-            </>
-          )}
+            )}
+          </div>
 
-          {errorMessage && (
-            <div className="game-path-error-banner">
-              <span className="material-symbols-outlined">error</span>
-              {errorMessage}
-            </div>
-          )}
-        </div>
-
-        <footer className="game-path-modal-footer">
-          <button
-            type="button"
-            className="game-path-action ghost"
-            disabled={busy}
-            onClick={onClose}
-          >
-            닫기
-          </button>
-          {onInstall && (
+          <footer className="game-path-modal-footer">
             <button
               type="button"
-              className="game-path-action primary"
-              disabled={busy}
-              onClick={onInstall}
+              className="game-path-action ghost"
+              disabled={outerInteractionBlocked}
+              onClick={onClose}
             >
-              <span className="material-symbols-outlined">download</span>
-              설치하기
+              닫기
             </button>
-          )}
-        </footer>
+            {onInstall && (
+              <button
+                type="button"
+                className="game-path-action primary"
+                disabled={outerInteractionBlocked}
+                onClick={onInstall}
+              >
+                <span className="material-symbols-outlined" aria-hidden="true">
+                  download
+                </span>
+                설치하기
+              </button>
+            )}
+          </footer>
+        </div>
 
         {showRegistrySyncConfirm &&
           diagnostics?.config.path &&
           diagnostics?.registry.path && (
             <div className="game-path-confirm-overlay">
               <div
+                ref={confirmationDialogRef}
                 className="game-path-confirm-dialog"
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby="game-path-registry-sync-title"
                 onClick={(event) => event.stopPropagation()}
               >
                 <div className="game-path-confirm-icon">
-                  <span className="material-symbols-outlined">warning</span>
+                  <span
+                    className="material-symbols-outlined"
+                    aria-hidden="true"
+                  >
+                    warning
+                  </span>
                 </div>
                 <div className="game-path-confirm-content">
-                  <h3>레지스트리 설치 경로를 변경할까요?</h3>
+                  <h3 id="game-path-registry-sync-title">
+                    레지스트리 설치 경로를 변경할까요?
+                  </h3>
                   <p>
                     레지스트리는 게임이 설치될 때 게임 쪽에서 자동으로 추가하는
                     값입니다. 현재 값이 왜 손상되었거나 달라졌는지는 런처에서 알
@@ -663,6 +1138,7 @@ const GamePathDiagnosticModal: React.FC<GamePathDiagnosticModalProps> = ({
                     type="button"
                     className="game-path-action ghost"
                     disabled={busy}
+                    data-dialog-initial-focus="true"
                     onClick={onRegistrySyncConfirmClose}
                   >
                     취소
@@ -681,7 +1157,12 @@ const GamePathDiagnosticModal: React.FC<GamePathDiagnosticModalProps> = ({
                     disabled={busy}
                     onClick={onSyncRegistry}
                   >
-                    <span className="material-symbols-outlined">warning</span>
+                    <span
+                      className="material-symbols-outlined"
+                      aria-hidden="true"
+                    >
+                      warning
+                    </span>
                     레지스트리에 반영
                   </button>
                 </div>
@@ -695,14 +1176,25 @@ const GamePathDiagnosticModal: React.FC<GamePathDiagnosticModalProps> = ({
           canonicalCandidate && (
             <div className="game-path-confirm-overlay">
               <div
+                ref={confirmationDialogRef}
                 className="game-path-confirm-dialog"
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby="game-path-registry-register-title"
                 onClick={(event) => event.stopPropagation()}
               >
                 <div className="game-path-confirm-icon">
-                  <span className="material-symbols-outlined">add_link</span>
+                  <span
+                    className="material-symbols-outlined"
+                    aria-hidden="true"
+                  >
+                    add_link
+                  </span>
                 </div>
                 <div className="game-path-confirm-content">
-                  <h3>레지스트리에 게임 경로를 등록할까요?</h3>
+                  <h3 id="game-path-registry-register-title">
+                    레지스트리에 게임 경로를 등록할까요?
+                  </h3>
                   <p>
                     런처 내 설정 경로를 카카오게임즈 기본 레지스트리 값으로
                     등록합니다. 확인하는 동안 기존 값이 생기거나 상태를 읽을 수
@@ -729,6 +1221,7 @@ const GamePathDiagnosticModal: React.FC<GamePathDiagnosticModalProps> = ({
                     type="button"
                     className="game-path-action ghost"
                     disabled={busy}
+                    data-dialog-initial-focus="true"
                     onClick={onRegistryRegisterConfirmClose}
                   >
                     취소
@@ -739,7 +1232,12 @@ const GamePathDiagnosticModal: React.FC<GamePathDiagnosticModalProps> = ({
                     disabled={busy}
                     onClick={onConfirmRegisterRegistry}
                   >
-                    <span className="material-symbols-outlined">add_link</span>
+                    <span
+                      className="material-symbols-outlined"
+                      aria-hidden="true"
+                    >
+                      add_link
+                    </span>
                     경로 등록
                   </button>
                 </div>
@@ -747,21 +1245,43 @@ const GamePathDiagnosticModal: React.FC<GamePathDiagnosticModalProps> = ({
             </div>
           )}
 
-        {showRegistryClearConfirm && diagnostics?.registry.path && (
+        {selection && (
+          <TargetSelectionDialog
+            selection={selection}
+            result={selectionApplyResult}
+            errorMessage={errorMessage}
+            busy={busy}
+            onApply={onApplyTargets}
+            onClose={onCloseSelection}
+          />
+        )}
+
+        {registryDeleteTarget && registryDeleteCandidate && (
           <div className="game-path-confirm-overlay">
             <div
+              ref={confirmationDialogRef}
               className="game-path-confirm-dialog is-danger"
+              role="dialog"
+              aria-modal="true"
+              aria-labelledby="game-path-registry-delete-title"
               onClick={(event) => event.stopPropagation()}
             >
               <div className="game-path-confirm-icon">
-                <span className="material-symbols-outlined">warning</span>
+                <span className="material-symbols-outlined" aria-hidden="true">
+                  warning
+                </span>
               </div>
               <div className="game-path-confirm-content">
-                <h3>레지스트리 설치 경로를 삭제할까요?</h3>
+                <h3 id="game-path-registry-delete-title">
+                  레지스트리 경로값을 삭제할까요?
+                </h3>
                 <p>
-                  레지스트리는 게임이 설치될 때 게임 쪽에서 자동으로 추가하는
-                  값입니다. 현재 값이 왜 손상되었거나 달라졌는지는 런처에서 알
-                  수 없습니다.
+                  {getRegistryCandidateLabel(
+                    serviceId,
+                    registryDeleteCandidateIndex,
+                  )}
+                  의 InstallPath 값만 삭제합니다. 레지스트리 키 자체는
+                  유지됩니다.
                 </p>
                 <p>
                   삭제하면 런처 외부의 게임 실행/패치 프로그램에서 게임 경로를
@@ -769,9 +1289,33 @@ const GamePathDiagnosticModal: React.FC<GamePathDiagnosticModalProps> = ({
                 </p>
                 <div className="game-path-confirm-paths">
                   <div>
-                    <span>삭제 대상</span>
-                    <strong>{diagnostics.registry.path}</strong>
+                    <span>후보</span>
+                    <strong>
+                      {getRegistryCandidateLabel(
+                        serviceId,
+                        registryDeleteCandidateIndex,
+                      )}
+                    </strong>
                   </div>
+                  <div>
+                    <span>키</span>
+                    <strong>{registryDeleteCandidate.registryPath}</strong>
+                  </div>
+                  <div>
+                    <span>삭제할 경로값</span>
+                    <strong>{registryDeleteTarget.expectedPath}</strong>
+                  </div>
+                  {errorMessage && (
+                    <div className="game-path-nested-error" role="alert">
+                      <span
+                        className="material-symbols-outlined"
+                        aria-hidden="true"
+                      >
+                        error
+                      </span>
+                      {errorMessage}
+                    </div>
+                  )}
                 </div>
               </div>
               <div className="game-path-confirm-actions">
@@ -779,7 +1323,8 @@ const GamePathDiagnosticModal: React.FC<GamePathDiagnosticModalProps> = ({
                   type="button"
                   className="game-path-action ghost"
                   disabled={busy}
-                  onClick={onRegistryClearConfirmClose}
+                  data-dialog-initial-focus="true"
+                  onClick={onRegistryDeleteConfirmClose}
                 >
                   취소
                 </button>
@@ -787,9 +1332,14 @@ const GamePathDiagnosticModal: React.FC<GamePathDiagnosticModalProps> = ({
                   type="button"
                   className="game-path-action danger"
                   disabled={busy}
-                  onClick={onConfirmClearRegistry}
+                  onClick={onConfirmDeleteRegistryTarget}
                 >
-                  <span className="material-symbols-outlined">delete</span>
+                  <span
+                    className="material-symbols-outlined"
+                    aria-hidden="true"
+                  >
+                    delete
+                  </span>
                   레지스트리 값 삭제
                 </button>
               </div>

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -7,7 +7,10 @@ import { ErrorBoundary } from "./components/ErrorBoundary";
 import FatalErrorModal from "./components/modals/FatalErrorModal";
 import { GameStateProvider } from "./contexts/GameStateContext";
 import { DEBUG_APP_CONFIG } from "../shared/config";
+import { removeLauncherSplashForGamePathDiagnosticQaFixture } from "./qa/game-path-diagnostic-qa-dom";
+import { GamePathDiagnosticQaFixture } from "./qa/GamePathDiagnosticQaFixture";
 import { logger } from "./utils/logger";
+import { parseGamePathDiagnosticQaSearch } from "../shared/qa/game-path-diagnostic";
 
 import type { ErrorReportData } from "../shared/debug-log-policy";
 import type { FatalErrorPayload } from "../shared/types";
@@ -15,17 +18,22 @@ import type { FatalErrorPayload } from "../shared/types";
 import "./App.css";
 
 const isDebug = window.location.hash === DEBUG_APP_CONFIG.HASH;
+const gamePathDiagnosticQaFixture = parseGamePathDiagnosticQaSearch(
+  window.location.search,
+);
+removeLauncherSplashForGamePathDiagnosticQaFixture(gamePathDiagnosticQaFixture);
 
-if (!isDebug) {
+if (!isDebug && !gamePathDiagnosticQaFixture) {
   logger.log("[Renderer] Renderer Logger initialized.");
 }
 
 export const Root = () => {
   const [fatalError, setFatalError] = useState<FatalErrorPayload | null>(null);
   const [reportData, setReportData] = useState<
-    (ErrorReportData & {
-      type: "bug" | "suggestion";
-    }) | null
+    | (ErrorReportData & {
+        type: "bug" | "suggestion";
+      })
+    | null
   >(null);
   const launcherVersion = __APP_VERSION__;
 
@@ -100,6 +108,13 @@ export const Root = () => {
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <Root />
+    {gamePathDiagnosticQaFixture ? (
+      <GamePathDiagnosticQaFixture
+        mode={gamePathDiagnosticQaFixture.fixtureMode}
+        runId={gamePathDiagnosticQaFixture.runId}
+      />
+    ) : (
+      <Root />
+    )}
   </React.StrictMode>,
 );

--- a/src/renderer/qa/GamePathDiagnosticQaFixture.css
+++ b/src/renderer/qa/GamePathDiagnosticQaFixture.css
@@ -1,0 +1,20 @@
+.game-path-diagnostic-qa-fixture {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  background: #000;
+}
+
+.game-path-diagnostic-qa-surface {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  color: #555;
+  background:
+    linear-gradient(rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0.82)),
+    radial-gradient(circle at 50% 10%, #2a261c, #080808 58%);
+  font-size: 12px;
+  letter-spacing: 0.08em;
+}

--- a/src/renderer/qa/GamePathDiagnosticQaFixture.test.tsx
+++ b/src/renderer/qa/GamePathDiagnosticQaFixture.test.tsx
@@ -1,0 +1,238 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { removeLauncherSplashForGamePathDiagnosticQaFixture } from "./game-path-diagnostic-qa-dom";
+import { GamePathDiagnosticQaFixture } from "./GamePathDiagnosticQaFixture";
+import { parseGamePathDiagnosticQaSearch } from "../../shared/qa/game-path-diagnostic";
+
+const runId = "qa-ms64-12345678";
+
+describe("GamePathDiagnostic QA renderer request", () => {
+  it.each(["diagnostic", "selection", "partial", "delete"] as const)(
+    "accepts the allowlisted %s fixture",
+    (fixtureMode) => {
+      expect(
+        parseGamePathDiagnosticQaSearch(
+          `?codexQaRun=${runId}&codexQaFixture=${fixtureMode}`,
+        ),
+      ).toEqual({ runId, fixtureMode });
+    },
+  );
+
+  it.each([
+    "?codexQaFixture=outer",
+    `?codexQaRun=${runId}`,
+    `?codexQaRun=${runId}&codexQaFixture=../../x.html`,
+    `?codexQaRun=${runId}&codexQaFixture=diagnostic&script=alert(1)`,
+    `?codexQaRun=${runId}&codexQaRun=other&codexQaFixture=diagnostic`,
+  ])("rejects non-owned or non-allowlisted query %s", (search) => {
+    expect(parseGamePathDiagnosticQaSearch(search)).toBeNull();
+  });
+});
+
+describe("GamePathDiagnostic QA fixture", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let electronApiDescriptor: PropertyDescriptor | undefined;
+  let innerWidthDescriptor: PropertyDescriptor | undefined;
+  let innerHeightDescriptor: PropertyDescriptor | undefined;
+  let previousScale: string;
+  let previousScalePriority: string;
+
+  const setViewport = (width: number, height: number) => {
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      value: width,
+    });
+    Object.defineProperty(window, "innerHeight", {
+      configurable: true,
+      value: height,
+    });
+  };
+
+  beforeEach(() => {
+    (
+      globalThis as typeof globalThis & {
+        IS_REACT_ACT_ENVIRONMENT: boolean;
+      }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+    innerWidthDescriptor = Object.getOwnPropertyDescriptor(
+      window,
+      "innerWidth",
+    );
+    innerHeightDescriptor = Object.getOwnPropertyDescriptor(
+      window,
+      "innerHeight",
+    );
+    previousScale =
+      document.documentElement.style.getPropertyValue("--app-scale");
+    previousScalePriority =
+      document.documentElement.style.getPropertyPriority("--app-scale");
+    setViewport(1024, 683);
+    electronApiDescriptor = Object.getOwnPropertyDescriptor(
+      window,
+      "electronAPI",
+    );
+    Object.defineProperty(window, "electronAPI", {
+      configurable: true,
+      value: new Proxy(
+        {},
+        {
+          get() {
+            throw new Error("QA fixture must not call product Electron APIs");
+          },
+        },
+      ),
+    });
+    container = document.createElement("div");
+    document.body.append(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    document.getElementById("launcher-splash")?.remove();
+    if (electronApiDescriptor) {
+      Object.defineProperty(window, "electronAPI", electronApiDescriptor);
+    } else {
+      Reflect.deleteProperty(window, "electronAPI");
+    }
+    if (innerWidthDescriptor) {
+      Object.defineProperty(window, "innerWidth", innerWidthDescriptor);
+    } else {
+      Reflect.deleteProperty(window, "innerWidth");
+    }
+    if (innerHeightDescriptor) {
+      Object.defineProperty(window, "innerHeight", innerHeightDescriptor);
+    } else {
+      Reflect.deleteProperty(window, "innerHeight");
+    }
+    if (previousScale) {
+      document.documentElement.style.setProperty(
+        "--app-scale",
+        previousScale,
+        previousScalePriority,
+      );
+    } else {
+      document.documentElement.style.removeProperty("--app-scale");
+    }
+  });
+
+  const renderFixture = async (
+    fixtureMode: "diagnostic" | "selection" | "partial" | "delete",
+  ) => {
+    await act(async () => {
+      root.render(
+        <GamePathDiagnosticQaFixture mode={fixtureMode} runId={runId} />,
+      );
+    });
+  };
+
+  it("renders the product outer modal with registry first and launcher config second", async () => {
+    await renderFixture("diagnostic");
+
+    expect(
+      container.querySelector('[data-qa-fixture="diagnostic"]'),
+    ).not.toBeNull();
+    expect(container.querySelectorAll('[role="dialog"]')).toHaveLength(1);
+    const options = Array.from(
+      container.querySelectorAll(".game-path-option-title"),
+    ).map((node) => node.textContent);
+    expect(options).toEqual(["레지스트리", "런처 내 설정"]);
+  });
+
+  it("removes the launcher splash before fixture mount but preserves normal startup ownership", async () => {
+    const splash = document.createElement("div");
+    splash.id = "launcher-splash";
+    document.body.append(splash);
+
+    expect(removeLauncherSplashForGamePathDiagnosticQaFixture(null)).toBe(
+      false,
+    );
+    expect(splash.isConnected).toBe(true);
+
+    const fixtureRequest = parseGamePathDiagnosticQaSearch(
+      `?codexQaRun=${runId}&codexQaFixture=diagnostic`,
+    );
+    expect(
+      removeLauncherSplashForGamePathDiagnosticQaFixture(fixtureRequest),
+    ).toBe(true);
+    await renderFixture("diagnostic");
+    expect(document.getElementById("launcher-splash")).toBeNull();
+  });
+
+  it("tracks the App viewport scale on mount/resize and restores the previous value", async () => {
+    document.documentElement.style.setProperty("--app-scale", "0.5");
+    await renderFixture("diagnostic");
+
+    expect(
+      Number(document.documentElement.style.getPropertyValue("--app-scale")),
+    ).toBeCloseTo(1024 / 1440, 6);
+
+    setViewport(1440, 960);
+    await act(async () => window.dispatchEvent(new Event("resize")));
+    expect(
+      Number(document.documentElement.style.getPropertyValue("--app-scale")),
+    ).toBe(1);
+
+    setViewport(1920, 1080);
+    await act(async () => window.dispatchEvent(new Event("resize")));
+    expect(
+      Number(document.documentElement.style.getPropertyValue("--app-scale")),
+    ).toBe(1.125);
+
+    await act(async () => root.render(<div>fixture closed</div>));
+    expect(document.documentElement.style.getPropertyValue("--app-scale")).toBe(
+      "0.5",
+    );
+  });
+
+  it("renders readonly selection context with Main defaults and exact CTA", async () => {
+    await renderFixture("selection");
+
+    const dialogs = container.querySelectorAll('[role="dialog"]');
+    expect(dialogs).toHaveLength(2);
+    expect(dialogs[0].getAttribute("aria-modal")).toBeNull();
+    expect(dialogs[1].getAttribute("aria-modal")).toBe("true");
+    expect(dialogs[1].textContent).toContain("Kakao Games");
+    expect(dialogs[1].textContent).toContain("POE2");
+    expect(dialogs[1].textContent).toContain("Path of Exile 2");
+
+    const checkboxes = Array.from(
+      container.querySelectorAll<HTMLInputElement>('input[type="checkbox"]'),
+    );
+    expect(checkboxes.map((input) => [input.value, input.checked])).toEqual([
+      ["registry-primary", true],
+      ["registry-compatibility", false],
+      ["config", true],
+    ]);
+    expect(
+      Array.from(container.querySelectorAll("button")).find(
+        (button) => button.textContent?.trim() === "선택 (2개)",
+      ),
+    ).toBeDefined();
+  });
+
+  it("renders cumulative partial results with failed-only retry", async () => {
+    await renderFixture("partial");
+
+    expect(container.textContent).toContain("기본 레지스트리적용 완료");
+    expect(container.textContent).toContain("호환 레지스트리적용 실패");
+    expect(container.textContent).toContain("런처 내 설정변경 없음");
+    expect(container.textContent).toContain("실패 항목 다시 시도 (1개)");
+  });
+
+  it("renders the exact candidate and path in delete confirmation", async () => {
+    await renderFixture("delete");
+
+    const dialog = container.querySelector(
+      '[aria-labelledby="game-path-registry-delete-title"]',
+    );
+    expect(dialog?.textContent).toContain("Kakaogames (기본)");
+    expect(dialog?.textContent).toContain(
+      String.raw`C:\Games\Kakao Games\Path of Exile 2`,
+    );
+  });
+});

--- a/src/renderer/qa/GamePathDiagnosticQaFixture.tsx
+++ b/src/renderer/qa/GamePathDiagnosticQaFixture.tsx
@@ -1,0 +1,195 @@
+import React from "react";
+
+import { type GamePathDiagnosticQaFixtureMode } from "../../shared/qa/game-path-diagnostic";
+import GamePathDiagnosticModal from "../components/modals/GamePathDiagnosticModal";
+
+import type {
+  GameInstallPathDiagnostics,
+  GameInstallPathSelectionDescriptor,
+} from "../../shared/types";
+import type { GamePathSelectionPresentationResult } from "../utils/game-path-modal-state";
+
+import "./GamePathDiagnosticQaFixture.css";
+
+const selectedPath = String.raw`C:\Games\Kakao Games\Path of Exile 2`;
+const compatibilityPath = String.raw`D:\DaumGames\Path of Exile 2`;
+const configPath = String.raw`E:\Launcher Settings\Path of Exile 2`;
+const primaryRegistryPath = String.raw`HKCU:\Software\Kakaogames\POE2`;
+const compatibilityRegistryPath = String.raw`HKCU:\Software\DaumGames\POE2`;
+
+const diagnostics: GameInstallPathDiagnostics = {
+  serviceId: "Kakao Games",
+  gameId: "POE2",
+  executableName: "PathOfExile_KG.exe",
+  config: {
+    source: "config",
+    path: configPath,
+    state: "found",
+    verification: "valid",
+  },
+  registry: {
+    source: "registry",
+    path: selectedPath,
+    state: "found",
+    verification: "valid",
+    registryPath: primaryRegistryPath,
+    registryValueName: "InstallPath",
+    aggregateState: "valid",
+    candidates: [
+      {
+        targetId: "registry-primary",
+        path: selectedPath,
+        state: "found",
+        verification: "valid",
+        registryPath: primaryRegistryPath,
+        registryValueName: "InstallPath",
+        isActive: true,
+      },
+      {
+        targetId: "registry-compatibility",
+        path: compatibilityPath,
+        state: "found",
+        verification: "valid",
+        registryPath: compatibilityRegistryPath,
+        registryValueName: "InstallPath",
+        isActive: false,
+      },
+    ],
+  },
+  hasPathConflict: true,
+  isPathConflictAcknowledged: false,
+  recommendedSource: "registry",
+};
+
+const selection: GameInstallPathSelectionDescriptor = {
+  selectionId: "qa-static-selection",
+  serviceId: "Kakao Games",
+  gameId: "POE2",
+  path: selectedPath,
+  targets: [
+    {
+      targetId: "registry-primary",
+      currentPath: selectedPath,
+      selectedByDefault: true,
+      completed: false,
+      disabled: false,
+      registryPath: primaryRegistryPath,
+      registryValueName: "InstallPath",
+    },
+    {
+      targetId: "registry-compatibility",
+      currentPath: compatibilityPath,
+      selectedByDefault: false,
+      completed: false,
+      disabled: false,
+      registryPath: compatibilityRegistryPath,
+      registryValueName: "InstallPath",
+    },
+    {
+      targetId: "config",
+      currentPath: configPath,
+      selectedByDefault: true,
+      completed: false,
+      disabled: false,
+    },
+  ],
+};
+
+const partialResult: GamePathSelectionPresentationResult = {
+  ok: true,
+  overall: "partial",
+  results: [
+    {
+      targetId: "registry-primary",
+      status: "applied",
+      path: selectedPath,
+    },
+    {
+      targetId: "registry-compatibility",
+      status: "failed",
+      code: "mutation-failed",
+      retryable: true,
+    },
+    {
+      targetId: "config",
+      status: "unchanged",
+      path: selectedPath,
+    },
+  ],
+  retryableTargetIds: ["registry-compatibility"],
+};
+
+const NOOP = () => undefined;
+
+export const GamePathDiagnosticQaFixture: React.FC<{
+  readonly mode: GamePathDiagnosticQaFixtureMode;
+  readonly runId: string;
+}> = ({ mode, runId }) => {
+  const showSelection = mode === "selection" || mode === "partial";
+  const showDelete = mode === "delete";
+
+  React.useLayoutEffect(() => {
+    const root = document.documentElement;
+    const previousScale = root.style.getPropertyValue("--app-scale");
+    const previousPriority = root.style.getPropertyPriority("--app-scale");
+    const updateScale = () => {
+      root.style.setProperty(
+        "--app-scale",
+        Math.min(window.innerWidth / 1440, window.innerHeight / 960).toString(),
+      );
+    };
+
+    updateScale();
+    window.addEventListener("resize", updateScale);
+    return () => {
+      window.removeEventListener("resize", updateScale);
+      if (previousScale) {
+        root.style.setProperty("--app-scale", previousScale, previousPriority);
+      } else {
+        root.style.removeProperty("--app-scale");
+      }
+    };
+  }, []);
+
+  return (
+    <main
+      className="game-path-diagnostic-qa-fixture"
+      data-qa-fixture={mode}
+      data-qa-run-id={runId}
+    >
+      <div className="game-path-diagnostic-qa-surface" aria-hidden="true">
+        <span>MS6.4 Game Path Diagnostic Fixture</span>
+      </div>
+      <GamePathDiagnosticModal
+        isOpen
+        mode="diagnostic"
+        serviceId="Kakao Games"
+        gameId="POE2"
+        diagnostics={diagnostics}
+        selection={showSelection ? selection : null}
+        selectionApplyResult={mode === "partial" ? partialResult : null}
+        registryDeleteTarget={
+          showDelete
+            ? { targetId: "registry-primary", expectedPath: selectedPath }
+            : null
+        }
+        onClose={NOOP}
+        onContextChange={NOOP}
+        onUsePath={NOOP}
+        onClearPath={NOOP}
+        onManualSelect={NOOP}
+        onApplyTargets={NOOP}
+        onCloseSelection={NOOP}
+        onRegistryDeleteRequest={NOOP}
+        onRegistryDeleteConfirmClose={NOOP}
+        onConfirmDeleteRegistryTarget={NOOP}
+        onRegistrySyncConfirmClose={NOOP}
+        onRegistryRegisterRequest={NOOP}
+        onRegistryRegisterConfirmClose={NOOP}
+        onKeepLauncherConfig={NOOP}
+        onSyncRegistry={NOOP}
+        onConfirmRegisterRegistry={NOOP}
+      />
+    </main>
+  );
+};

--- a/src/renderer/qa/game-path-diagnostic-qa-dom.ts
+++ b/src/renderer/qa/game-path-diagnostic-qa-dom.ts
@@ -1,0 +1,15 @@
+import type { GamePathDiagnosticQaFixtureMode } from "../../shared/qa/game-path-diagnostic";
+
+export const removeLauncherSplashForGamePathDiagnosticQaFixture = (
+  fixture: {
+    readonly runId: string;
+    readonly fixtureMode: GamePathDiagnosticQaFixtureMode;
+  } | null,
+  targetDocument: Document = document,
+): boolean => {
+  if (!fixture) return false;
+  const splash = targetDocument.getElementById("launcher-splash");
+  if (!splash) return false;
+  splash.remove();
+  return true;
+};

--- a/src/renderer/utils/game-path-modal-state.test.ts
+++ b/src/renderer/utils/game-path-modal-state.test.ts
@@ -1,8 +1,19 @@
 import { describe, expect, it } from "vitest";
 
-import { updateGamePathModalForContext } from "./game-path-modal-state";
+import {
+  applyGamePathSelectionBatchForContext,
+  updateGamePathModalForContext,
+} from "./game-path-modal-state";
+import * as gamePathModalStateModule from "./game-path-modal-state";
+
+import type {
+  GameInstallPathDiagnostics,
+  GameInstallPathSelectionBatchResult,
+  GameInstallPathSelectionDescriptor,
+} from "../../shared/types";
 
 type FixtureState = {
+  generation: number;
   serviceId: "Kakao Games" | "GGG";
   gameId: "POE1" | "POE2";
   busy: boolean;
@@ -12,6 +23,7 @@ type FixtureState = {
 
 describe("updateGamePathModalForContext", () => {
   const pendingIdentity = {
+    generation: 1,
     serviceId: "Kakao Games" as const,
     gameId: "POE2" as const,
   };
@@ -26,6 +38,7 @@ describe("updateGamePathModalForContext", () => {
     "leaves a new modal untouched after %s from the previous identity",
     (_label, latePatch) => {
       const newModal: FixtureState = {
+        generation: 2,
         serviceId: "Kakao Games",
         gameId: "POE1",
         busy: false,
@@ -53,5 +66,293 @@ describe("updateGamePathModalForContext", () => {
         (matched) => ({ ...matched, busy: false }),
       ),
     ).toBeNull();
+  });
+
+  it("rejects a delayed same-context result from a previous modal generation", () => {
+    const newModal: FixtureState = {
+      generation: 2,
+      serviceId: "Kakao Games",
+      gameId: "POE2",
+      busy: true,
+      diagnostics: "new-modal",
+    };
+
+    const updated = updateGamePathModalForContext(
+      newModal,
+      "Kakao Games",
+      "POE2",
+      (matched) => ({ ...matched, diagnostics: "stale", busy: false }),
+      { generation: 1 },
+    );
+
+    expect(updated).toBe(newModal);
+    expect(updated).toEqual(newModal);
+  });
+});
+
+describe("game path modal operation tracker", () => {
+  it("rejects synchronous duplicate re-entry and invalidates prior-generation tokens", () => {
+    const createTracker = (gamePathModalStateModule as Record<string, unknown>)
+      .createGamePathModalOperationTracker;
+    expect(createTracker).toBeTypeOf("function");
+    if (typeof createTracker !== "function") return;
+
+    const tracker = createTracker() as {
+      activateGeneration(generation: number): void;
+      begin(
+        operation: string,
+        identity: {
+          generation: number;
+          serviceId: "Kakao Games";
+          gameId: "POE2";
+          selectionId?: string;
+        },
+      ): { token: number } | null;
+      finish(request: { token: number }): boolean;
+      hasActive(generation: number): boolean;
+    };
+    tracker.activateGeneration(1);
+    const original = tracker.begin("apply", {
+      generation: 1,
+      serviceId: "Kakao Games",
+      gameId: "POE2",
+      selectionId: "selection-1",
+    });
+
+    expect(original).not.toBeNull();
+    expect(
+      tracker.begin("apply", {
+        generation: 1,
+        serviceId: "Kakao Games",
+        gameId: "POE2",
+        selectionId: "selection-1",
+      }),
+    ).toBeNull();
+    expect(tracker.hasActive(1)).toBe(true);
+
+    tracker.activateGeneration(2);
+    expect(tracker.finish(original!)).toBe(false);
+    expect(tracker.hasActive(2)).toBe(false);
+    expect(
+      tracker.begin("picker", {
+        generation: 2,
+        serviceId: "Kakao Games",
+        gameId: "POE2",
+      }),
+    ).not.toBeNull();
+  });
+});
+
+describe("applyGamePathSelectionBatchForContext", () => {
+  const diagnostics = {
+    serviceId: "Kakao Games",
+    gameId: "POE2",
+    config: { path: String.raw`F:\\Fresh Config` },
+    registry: { path: String.raw`F:\\Fresh Registry` },
+  } as GameInstallPathDiagnostics;
+  const selection = {
+    selectionId: "selection-1",
+    serviceId: "Kakao Games",
+    gameId: "POE2",
+    path: String.raw`F:\\Selected`,
+    targets: [],
+  } as GameInstallPathSelectionDescriptor;
+  const result: GameInstallPathSelectionBatchResult = {
+    ok: true,
+    overall: "partial",
+    results: [
+      {
+        targetId: "registry-primary",
+        status: "applied",
+        path: selection.path,
+      },
+      {
+        targetId: "config",
+        status: "failed",
+        code: "target-changed",
+        retryable: true,
+      },
+    ],
+    retryableTargetIds: ["config"],
+    diagnostics,
+    selection,
+  };
+
+  it("keeps both coherent diagnostic columns and the exact retry set", () => {
+    const current: {
+      generation: number;
+      serviceId: "Kakao Games";
+      gameId: "POE2";
+      diagnostics: GameInstallPathDiagnostics | null;
+      selection?: GameInstallPathSelectionDescriptor;
+      selectionApplyResult?: GameInstallPathSelectionBatchResult;
+      busy: boolean;
+    } = {
+      generation: 1,
+      serviceId: "Kakao Games" as const,
+      gameId: "POE2" as const,
+      diagnostics: null,
+      selection,
+      selectionApplyResult: undefined,
+      busy: true,
+    };
+
+    const updated = applyGamePathSelectionBatchForContext(
+      current,
+      "Kakao Games",
+      "POE2",
+      result,
+    );
+
+    expect(updated?.diagnostics).toBe(diagnostics);
+    expect(updated?.diagnostics?.registry.path).toBe(
+      String.raw`F:\\Fresh Registry`,
+    );
+    expect(updated?.diagnostics?.config.path).toBe(
+      String.raw`F:\\Fresh Config`,
+    );
+    expect(updated?.selectionApplyResult?.retryableTargetIds).toEqual([
+      "config",
+    ]);
+    expect(updated?.busy).toBe(false);
+  });
+
+  it("does not overwrite a newly selected context with a late batch", () => {
+    const newContext = {
+      generation: 2,
+      serviceId: "GGG" as const,
+      gameId: "POE1" as const,
+      diagnostics: null,
+      selection: undefined,
+      selectionApplyResult: undefined,
+      busy: false,
+    };
+
+    expect(
+      applyGamePathSelectionBatchForContext(
+        newContext,
+        "Kakao Games",
+        "POE2",
+        result,
+      ),
+    ).toBe(newContext);
+  });
+
+  it("keeps earlier successful target results when a failed-only retry completes", () => {
+    const current = {
+      generation: 1,
+      serviceId: "Kakao Games" as const,
+      gameId: "POE2" as const,
+      diagnostics,
+      selection,
+      selectionApplyResult: result,
+      busy: true,
+    };
+    const retryResult: GameInstallPathSelectionBatchResult = {
+      ok: true,
+      overall: "success",
+      results: [
+        {
+          targetId: "config",
+          status: "applied",
+          path: selection.path,
+        },
+      ],
+      retryableTargetIds: [],
+      diagnostics,
+      selection,
+    };
+
+    const updated = applyGamePathSelectionBatchForContext(
+      current,
+      "Kakao Games",
+      "POE2",
+      retryResult,
+    );
+
+    expect(updated?.selectionApplyResult?.results).toEqual([
+      {
+        targetId: "registry-primary",
+        status: "applied",
+        path: selection.path,
+      },
+      {
+        targetId: "config",
+        status: "applied",
+        path: selection.path,
+      },
+    ]);
+  });
+
+  it.each([
+    "selection-busy",
+    "selection-not-found",
+    "selection-expired",
+    "selection-invalidated",
+  ] as const)(
+    "keeps cumulative success visible when a retry returns %s without diagnostics",
+    (failureCode) => {
+      const current = {
+        generation: 1,
+        serviceId: "Kakao Games" as const,
+        gameId: "POE2" as const,
+        diagnostics,
+        selection,
+        selectionApplyResult: result,
+        busy: true,
+      };
+      const retryFailure: GameInstallPathSelectionBatchResult =
+        failureCode === "selection-invalidated"
+          ? {
+              ok: false,
+              overall: "failed",
+              failureCode,
+              results: [],
+              retryableTargetIds: [],
+            }
+          : {
+              ok: false,
+              overall: "failed",
+              failureCode,
+              results: [],
+              retryableTargetIds: [],
+            };
+
+      const updated = applyGamePathSelectionBatchForContext(
+        current,
+        "Kakao Games",
+        "POE2",
+        retryFailure,
+        { generation: 1, selectionId: selection.selectionId },
+      );
+
+      expect(updated?.selectionApplyResult?.results).toEqual(result.results);
+      expect(updated?.selectionApplyResult?.retryableTargetIds).toEqual([]);
+      expect(updated?.diagnostics).toBe(diagnostics);
+      expect(updated?.selection).toBe(selection);
+      expect(updated?.busy).toBe(false);
+    },
+  );
+
+  it("ignores an apply completion when generation or requested selection changed", () => {
+    const current = {
+      generation: 2,
+      serviceId: "Kakao Games" as const,
+      gameId: "POE2" as const,
+      diagnostics,
+      selection: { ...selection, selectionId: "selection-2" },
+      selectionApplyResult: undefined,
+      busy: true,
+    };
+
+    const updated = applyGamePathSelectionBatchForContext(
+      current,
+      "Kakao Games",
+      "POE2",
+      result,
+      { generation: 1, selectionId: "selection-1" },
+    );
+
+    expect(updated).toBe(current);
   });
 });

--- a/src/renderer/utils/game-path-modal-state.test.ts
+++ b/src/renderer/utils/game-path-modal-state.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+
+import { updateGamePathModalForContext } from "./game-path-modal-state";
+
+type FixtureState = {
+  serviceId: "Kakao Games" | "GGG";
+  gameId: "POE1" | "POE2";
+  busy: boolean;
+  diagnostics: string;
+  errorMessage?: string;
+};
+
+describe("updateGamePathModalForContext", () => {
+  const pendingIdentity = {
+    serviceId: "Kakao Games" as const,
+    gameId: "POE2" as const,
+  };
+
+  it.each([
+    ["late success", { diagnostics: "late-success", busy: false }],
+    [
+      "late failure",
+      { diagnostics: "late-failure", busy: false, errorMessage: "failed" },
+    ],
+  ] as const)(
+    "leaves a new modal untouched after %s from the previous identity",
+    (_label, latePatch) => {
+      const newModal: FixtureState = {
+        serviceId: "Kakao Games",
+        gameId: "POE1",
+        busy: false,
+        diagnostics: "new-modal",
+      };
+
+      const result = updateGamePathModalForContext(
+        newModal,
+        pendingIdentity.serviceId,
+        pendingIdentity.gameId,
+        (matched) => ({ ...matched, ...latePatch }),
+      );
+
+      expect(result).toBe(newModal);
+      expect(result).toEqual(newModal);
+    },
+  );
+
+  it("keeps a closed modal closed after a late result", () => {
+    expect(
+      updateGamePathModalForContext(
+        null,
+        pendingIdentity.serviceId,
+        pendingIdentity.gameId,
+        (matched) => ({ ...matched, busy: false }),
+      ),
+    ).toBeNull();
+  });
+});

--- a/src/renderer/utils/game-path-modal-state.ts
+++ b/src/renderer/utils/game-path-modal-state.ts
@@ -1,0 +1,25 @@
+import type { AppConfig } from "../../shared/types";
+
+type GamePathModalIdentity = {
+  serviceId: AppConfig["serviceChannel"];
+  gameId: AppConfig["activeGame"];
+};
+
+export const updateGamePathModalForContext = <
+  State extends GamePathModalIdentity,
+>(
+  current: State | null,
+  serviceId: AppConfig["serviceChannel"],
+  gameId: AppConfig["activeGame"],
+  update: (matched: State) => State,
+): State | null => {
+  if (
+    !current ||
+    current.serviceId !== serviceId ||
+    current.gameId !== gameId
+  ) {
+    return current;
+  }
+
+  return update(current);
+};

--- a/src/renderer/utils/game-path-modal-state.ts
+++ b/src/renderer/utils/game-path-modal-state.ts
@@ -1,8 +1,97 @@
-import type { AppConfig } from "../../shared/types";
+import type {
+  AppConfig,
+  GameInstallPathDiagnostics,
+  GameInstallPathSelectionBatchFailureCode,
+  GameInstallPathSelectionBatchResult,
+  GameInstallPathSelectionDescriptor,
+  GameInstallPathTargetApplyResult,
+  GameInstallPathTargetId,
+} from "../../shared/types";
 
 type GamePathModalIdentity = {
+  generation?: number;
   serviceId: AppConfig["serviceChannel"];
   gameId: AppConfig["activeGame"];
+  selection?: Pick<GameInstallPathSelectionDescriptor, "selectionId"> | null;
+};
+
+export type GamePathModalRequestIdentity = {
+  readonly generation: number;
+  readonly serviceId: AppConfig["serviceChannel"];
+  readonly gameId: AppConfig["activeGame"];
+  readonly selectionId?: string;
+};
+
+export type GamePathModalOperation =
+  | "diagnostics"
+  | "picker"
+  | "apply"
+  | "delete"
+  | "config-clear"
+  | "conflict"
+  | "register";
+
+export type GamePathModalOperationRequest = GamePathModalRequestIdentity & {
+  readonly operation: GamePathModalOperation;
+  readonly token: number;
+};
+
+export const createGamePathModalOperationTracker = () => {
+  let activeGeneration: number | null = null;
+  let nextToken = 0;
+  const activeByOperation = new Map<
+    GamePathModalOperation,
+    GamePathModalOperationRequest
+  >();
+
+  const activateGeneration = (generation: number): void => {
+    activeGeneration = generation;
+    activeByOperation.clear();
+  };
+
+  const invalidate = (): void => {
+    activeGeneration = null;
+    activeByOperation.clear();
+  };
+
+  const begin = (
+    operation: GamePathModalOperation,
+    identity: GamePathModalRequestIdentity,
+  ): GamePathModalOperationRequest | null => {
+    if (
+      activeGeneration !== identity.generation ||
+      activeByOperation.size > 0
+    ) {
+      return null;
+    }
+
+    const request = {
+      ...identity,
+      operation,
+      token: ++nextToken,
+    };
+    activeByOperation.set(operation, request);
+    return request;
+  };
+
+  const finish = (request: GamePathModalOperationRequest): boolean => {
+    const active = activeByOperation.get(request.operation);
+    if (
+      activeGeneration !== request.generation ||
+      !active ||
+      active.token !== request.token
+    ) {
+      return false;
+    }
+
+    activeByOperation.delete(request.operation);
+    return true;
+  };
+
+  const hasActive = (generation: number): boolean =>
+    activeGeneration === generation && activeByOperation.size > 0;
+
+  return { activateGeneration, invalidate, begin, finish, hasActive };
 };
 
 export const updateGamePathModalForContext = <
@@ -12,14 +101,110 @@ export const updateGamePathModalForContext = <
   serviceId: AppConfig["serviceChannel"],
   gameId: AppConfig["activeGame"],
   update: (matched: State) => State,
+  expected?: Pick<GamePathModalRequestIdentity, "generation" | "selectionId">,
 ): State | null => {
   if (
     !current ||
     current.serviceId !== serviceId ||
-    current.gameId !== gameId
+    current.gameId !== gameId ||
+    (expected && current.generation !== expected.generation) ||
+    (expected?.selectionId !== undefined &&
+      current.selection?.selectionId !== expected.selectionId)
   ) {
     return current;
   }
 
   return update(current);
+};
+
+export interface GamePathSelectionPresentationResult {
+  readonly ok: boolean;
+  readonly overall: "success" | "partial" | "failed";
+  readonly results: readonly GameInstallPathTargetApplyResult[];
+  readonly retryableTargetIds: readonly GameInstallPathTargetId[];
+  readonly failureCode?: GameInstallPathSelectionBatchFailureCode;
+}
+
+type GamePathSelectionBatchState = GamePathModalIdentity & {
+  diagnostics: GameInstallPathDiagnostics | null;
+  selection?: GameInstallPathSelectionDescriptor;
+  selectionApplyResult?: GamePathSelectionPresentationResult;
+  busy: boolean;
+};
+
+const TARGET_RESULT_ORDER = [
+  "registry-primary",
+  "registry-compatibility",
+  "config",
+] as const;
+
+const mergeGamePathSelectionBatchResults = (
+  previous: GamePathSelectionPresentationResult | undefined,
+  next: GameInstallPathSelectionBatchResult,
+): GamePathSelectionPresentationResult => {
+  const resultsByTarget = new Map(
+    previous?.results.map((result) => [result.targetId, result]) ?? [],
+  );
+  for (const result of next.results) {
+    resultsByTarget.set(result.targetId, result);
+  }
+  const results = TARGET_RESULT_ORDER.flatMap((targetId) => {
+    const result = resultsByTarget.get(targetId);
+    return result ? [result] : [];
+  });
+  const succeededCount = results.filter(
+    (result) => result.status === "applied" || result.status === "unchanged",
+  ).length;
+  const failedCount = results.length - succeededCount;
+  const overall =
+    results.length === 0
+      ? next.overall
+      : failedCount === 0
+        ? "success"
+        : succeededCount > 0
+          ? "partial"
+          : "failed";
+
+  return {
+    ok: succeededCount > 0,
+    overall,
+    results,
+    retryableTargetIds: next.retryableTargetIds,
+    ...("failureCode" in next ? { failureCode: next.failureCode } : {}),
+  };
+};
+
+export const applyGamePathSelectionBatchForContext = <
+  State extends GamePathSelectionBatchState,
+>(
+  current: State | null,
+  serviceId: AppConfig["serviceChannel"],
+  gameId: AppConfig["activeGame"],
+  result: GameInstallPathSelectionBatchResult,
+  expected?: Pick<GamePathModalRequestIdentity, "generation" | "selectionId">,
+): State | null => {
+  if (
+    expected?.selectionId !== undefined &&
+    "selection" in result &&
+    result.selection.selectionId !== expected.selectionId
+  ) {
+    return current;
+  }
+
+  return updateGamePathModalForContext(
+    current,
+    serviceId,
+    gameId,
+    (matched) => ({
+      ...matched,
+      ...("diagnostics" in result ? { diagnostics: result.diagnostics } : {}),
+      ...("selection" in result ? { selection: result.selection } : {}),
+      selectionApplyResult: mergeGamePathSelectionBatchResults(
+        matched.selectionApplyResult,
+        result,
+      ),
+      busy: false,
+    }),
+    expected,
+  );
 };

--- a/src/renderer/utils/game-path-registry-registration.ts
+++ b/src/renderer/utils/game-path-registry-registration.ts
@@ -1,0 +1,40 @@
+import type { GameInstallPathDiagnostics } from "../../shared/types";
+
+export type RegistryRegistrationEligibility =
+  "eligible" | "unknown" | "blocked" | "not-applicable";
+
+export const getRegistryRegistrationEligibility = (
+  diagnostics: GameInstallPathDiagnostics,
+): RegistryRegistrationEligibility => {
+  if (
+    diagnostics.serviceId !== "Kakao Games" ||
+    !diagnostics.config.path ||
+    diagnostics.config.verification !== "valid" ||
+    diagnostics.registry.aggregateState === "valid"
+  ) {
+    return "not-applicable";
+  }
+
+  if (
+    diagnostics.registry.candidates.some(
+      (candidate) =>
+        candidate.state === "read-failed" ||
+        candidate.verification === "unknown",
+    )
+  ) {
+    return "unknown";
+  }
+
+  const absentStates = new Set(["key-missing", "value-missing", "value-empty"]);
+  if (
+    diagnostics.registry.candidates.length === 2 &&
+    diagnostics.registry.candidates.every(
+      (candidate) =>
+        candidate.path === null && absentStates.has(candidate.state),
+    )
+  ) {
+    return "eligible";
+  }
+
+  return "blocked";
+};

--- a/src/renderer/utils/game-path-registry-warning.test.ts
+++ b/src/renderer/utils/game-path-registry-warning.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createGamePathRegistryWarning,
+  dedupeOperationalNotifications,
+} from "./game-path-registry-warning";
+
+import type {
+  GameInstallPathRegistryAdvisory,
+  GameStatusState,
+} from "../../shared/types";
+
+const activeContext = {
+  serviceId: "Kakao Games" as const,
+  gameId: "POE2" as const,
+};
+
+const createStatus = (
+  advisoryState?: GameInstallPathRegistryAdvisory["state"],
+  overrides: Partial<GameStatusState> = {},
+): GameStatusState => ({
+  serviceId: "Kakao Games",
+  gameId: "POE2",
+  status: "idle",
+  installPathHealth: {
+    installationStatus: "installed",
+    checkedAt: 1234,
+    ...(advisoryState ? { registryAdvisory: { state: advisoryState } } : {}),
+  },
+  ...overrides,
+});
+
+describe("game path registry warning", () => {
+  it.each([
+    ["absent", "경로가 없습니다"],
+    ["invalid", "올바르지 않습니다"],
+    ["unknown", "확인하지 못했습니다"],
+  ] as const)(
+    "creates a nonblocking %s warning from active install-path health",
+    (state, message) => {
+      const warning = createGamePathRegistryWarning(
+        createStatus(state),
+        activeContext,
+      );
+
+      expect(warning).toEqual(
+        expect.objectContaining({
+          id: "game-path-registry:Kakao Games:POE2",
+          contextKey: "Kakao Games:POE2",
+          tone: "amber",
+          serviceId: "Kakao Games",
+          gameId: "POE2",
+          message: expect.stringContaining(message),
+        }),
+      );
+    },
+  );
+
+  it("does not warn for healthy, GGG, or another active context state", () => {
+    expect(
+      createGamePathRegistryWarning(createStatus(), activeContext),
+    ).toBeNull();
+    expect(
+      createGamePathRegistryWarning(
+        createStatus("absent", { serviceId: "GGG" }),
+        { serviceId: "GGG", gameId: "POE2" },
+      ),
+    ).toBeNull();
+    expect(
+      createGamePathRegistryWarning(createStatus("absent"), {
+        serviceId: "Kakao Games",
+        gameId: "POE1",
+      }),
+    ).toBeNull();
+  });
+
+  it("keeps warning identity exact when the selected context changes", () => {
+    const oldStatus = createStatus("absent", { gameId: "POE1" });
+
+    expect(createGamePathRegistryWarning(oldStatus, activeContext)).toBeNull();
+    expect(
+      createGamePathRegistryWarning(oldStatus, {
+        serviceId: "Kakao Games",
+        gameId: "POE1",
+      }),
+    ).toEqual(
+      expect.objectContaining({
+        serviceId: "Kakao Games",
+        gameId: "POE1",
+      }),
+    );
+  });
+
+  it("deduplicates operational notifications by stable context id", () => {
+    const warning = createGamePathRegistryWarning(
+      createStatus("absent"),
+      activeContext,
+    );
+    if (!warning) throw new Error("Expected warning fixture");
+
+    expect(dedupeOperationalNotifications([warning, warning])).toEqual([
+      warning,
+    ]);
+  });
+});

--- a/src/renderer/utils/game-path-registry-warning.ts
+++ b/src/renderer/utils/game-path-registry-warning.ts
@@ -1,0 +1,53 @@
+import type {
+  AppConfig,
+  GameStatusState,
+  OperationalNotification,
+} from "../../shared/types";
+
+const getWarningMessage = (statusState: GameStatusState) => {
+  const advisoryState = statusState.installPathHealth?.registryAdvisory?.state;
+  if (advisoryState === "absent") {
+    return "게임은 설치되어 있지만 카카오게임즈 레지스트리 경로가 없습니다. 경로 진단에서 확인해 주세요.";
+  }
+
+  if (advisoryState === "unknown") {
+    return "게임은 설치되어 있지만 카카오게임즈 레지스트리 경로를 확인하지 못했습니다. 경로 진단에서 확인해 주세요.";
+  }
+
+  return "게임은 설치되어 있지만 카카오게임즈 레지스트리 경로가 올바르지 않습니다. 경로 진단에서 확인해 주세요.";
+};
+
+export const createGamePathRegistryWarning = (
+  statusState: GameStatusState,
+  activeContext: {
+    serviceId: AppConfig["serviceChannel"];
+    gameId: AppConfig["activeGame"];
+  },
+): OperationalNotification | null => {
+  const advisory = statusState.installPathHealth?.registryAdvisory;
+  if (
+    statusState.serviceId !== activeContext.serviceId ||
+    statusState.gameId !== activeContext.gameId ||
+    statusState.serviceId !== "Kakao Games" ||
+    !advisory
+  ) {
+    return null;
+  }
+
+  const contextKey = `${statusState.serviceId}:${statusState.gameId}`;
+  return {
+    id: `game-path-registry:${contextKey}`,
+    contextKey,
+    level: "warn",
+    tone: "amber",
+    title: `${statusState.gameId} 게임 경로 확인 필요`,
+    message: getWarningMessage(statusState),
+    serviceId: statusState.serviceId,
+    gameId: statusState.gameId,
+    action: "open-game-path-diagnostic",
+  };
+};
+
+export const dedupeOperationalNotifications = (
+  notifications: readonly OperationalNotification[],
+) => [...new Map(notifications.map((item) => [item.id, item])).values()];

--- a/src/renderer/utils/game-start-label.test.ts
+++ b/src/renderer/utils/game-start-label.test.ts
@@ -2,12 +2,12 @@ import { describe, expect, it } from "vitest";
 
 import {
   getGameStartButtonLabel,
+  shouldOpenGamePathDiagnostic,
   shouldShowUpdateLabel,
 } from "./game-start-label";
 import { RunStatus } from "../../shared/types";
 
 const launchActiveStatuses: RunStatus[] = [
-  "install_check_blocked",
   "preparing",
   "processing",
   "authenticating",
@@ -25,6 +25,15 @@ describe("game start button label", () => {
     expect(getGameStartButtonLabel("idle", true)).toBe("업데이트");
     expect(getGameStartButtonLabel("error", true)).toBe("업데이트");
     expect(getGameStartButtonLabel("stopping", true)).toBe("업데이트");
+  });
+
+  it("shows an honest path-check label when installation verification is blocked", () => {
+    expect(getGameStartButtonLabel("install_check_blocked", true)).toBe(
+      "경로 확인",
+    );
+    expect(shouldShowUpdateLabel("install_check_blocked", true)).toBe(false);
+    expect(shouldOpenGamePathDiagnostic("install_check_blocked")).toBe(true);
+    expect(shouldOpenGamePathDiagnostic("idle")).toBe(false);
   });
 
   it("does not show update label while game launch or play is already active", () => {

--- a/src/renderer/utils/game-start-label.ts
+++ b/src/renderer/utils/game-start-label.ts
@@ -20,11 +20,15 @@ export const shouldShowUpdateLabel = (
   );
 };
 
+export const shouldOpenGamePathDiagnostic = (status: RunStatus) =>
+  status === "uninstalled" || status === "install_check_blocked";
+
 export const getGameStartButtonLabel = (
   status: RunStatus,
   isUpdateNeeded: boolean,
 ) => {
   if (status === "uninstalled") return "설치하기";
+  if (status === "install_check_blocked") return "경로 확인";
   if (shouldShowUpdateLabel(status, isUpdateNeeded)) return "업데이트";
   return "게임 시작";
 };

--- a/src/shared/qa/game-path-diagnostic.ts
+++ b/src/shared/qa/game-path-diagnostic.ts
@@ -1,0 +1,52 @@
+export const GAME_PATH_DIAGNOSTIC_QA_FIXTURE_MODES = [
+  "diagnostic",
+  "selection",
+  "partial",
+  "delete",
+] as const;
+
+export type GamePathDiagnosticQaFixtureMode =
+  (typeof GAME_PATH_DIAGNOSTIC_QA_FIXTURE_MODES)[number];
+
+const GAME_PATH_DIAGNOSTIC_QA_QUERY_KEYS = new Set([
+  "codexQaRun",
+  "codexQaFixture",
+]);
+const QA_RUN_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{7,127}$/;
+
+export const isGamePathDiagnosticQaFixtureMode = (
+  value: unknown,
+): value is GamePathDiagnosticQaFixtureMode =>
+  typeof value === "string" &&
+  GAME_PATH_DIAGNOSTIC_QA_FIXTURE_MODES.some((mode) => mode === value);
+
+export const isGamePathDiagnosticQaRunId = (value: unknown): value is string =>
+  typeof value === "string" && QA_RUN_ID_PATTERN.test(value);
+
+export const parseGamePathDiagnosticQaSearch = (
+  search: string,
+): {
+  readonly runId: string;
+  readonly fixtureMode: GamePathDiagnosticQaFixtureMode;
+} | null => {
+  const params = new URLSearchParams(search);
+  const keys = [...params.keys()];
+  if (
+    keys.some((key) => !GAME_PATH_DIAGNOSTIC_QA_QUERY_KEYS.has(key)) ||
+    params.getAll("codexQaRun").length !== 1 ||
+    params.getAll("codexQaFixture").length !== 1
+  ) {
+    return null;
+  }
+
+  const runId = params.get("codexQaRun");
+  const fixtureMode = params.get("codexQaFixture");
+  if (
+    !isGamePathDiagnosticQaRunId(runId) ||
+    !isGamePathDiagnosticQaFixtureMode(fixtureMode)
+  ) {
+    return null;
+  }
+
+  return { runId, fixtureMode };
+};

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -136,6 +136,174 @@ export type GameInstallPathRegistryState =
 export type GameInstallPathConfigState =
   "found" | "empty" | "context-unavailable";
 
+export type GameInstallPathTargetId =
+  "registry-primary" | "registry-compatibility" | "config";
+
+export type GameInstallPathRegistryTargetId = Exclude<
+  GameInstallPathTargetId,
+  "config"
+>;
+
+export type GameInstallPathTargetSnapshot =
+  | {
+      readonly targetId: GameInstallPathRegistryTargetId;
+      readonly currentPath: string | null;
+      readonly registryState: GameInstallPathRegistryState;
+    }
+  | {
+      readonly targetId: "config";
+      readonly currentPath: string | null;
+    };
+
+export type GameInstallPathTargetApplyStatus =
+  "applied" | "unchanged" | "failed";
+
+export type GameInstallPathTargetApplyFailureCode =
+  | "target-not-allowed"
+  | "invalid-snapshot"
+  | "install-path-empty"
+  | "install-path-invalid"
+  | "install-path-check-failed"
+  | "target-read-failed"
+  | "target-changed"
+  | "selection-invalidated"
+  | "context-unavailable"
+  | "mutation-failed"
+  | "readback-failed";
+
+export type GameInstallPathTargetApplyResult =
+  | {
+      readonly targetId: GameInstallPathTargetId;
+      readonly status: Exclude<GameInstallPathTargetApplyStatus, "failed">;
+      readonly path: string;
+    }
+  | {
+      readonly targetId: GameInstallPathTargetId;
+      readonly status: "failed";
+      readonly code: GameInstallPathTargetApplyFailureCode;
+      readonly retryable: boolean;
+    };
+
+export type GameInstallPathSelectionTargetDisabledReason =
+  "target-read-failed" | "target-completed";
+
+export interface GameInstallPathSelectionTargetDescriptor {
+  readonly targetId: GameInstallPathTargetId;
+  readonly currentPath: string | null;
+  readonly selectedByDefault: boolean;
+  readonly completed: boolean;
+  readonly disabled: boolean;
+  readonly disabledReason?: GameInstallPathSelectionTargetDisabledReason;
+  readonly registryPath?: string;
+  readonly registryValueName?: string;
+}
+
+export interface GameInstallPathSelectionDescriptor {
+  readonly selectionId: string;
+  readonly serviceId: AppConfig["serviceChannel"];
+  readonly gameId: AppConfig["activeGame"];
+  readonly path: string;
+  readonly targets: readonly GameInstallPathSelectionTargetDescriptor[];
+}
+
+export type GameInstallPathSelectionResult =
+  | {
+      readonly ok: true;
+      readonly status: "selected";
+      readonly selection: GameInstallPathSelectionDescriptor;
+    }
+  | {
+      readonly ok: false;
+      readonly status: "canceled";
+    }
+  | {
+      readonly ok: false;
+      readonly status: "invalid";
+      readonly code:
+        | "install-path-empty"
+        | "install-path-invalid"
+        | "install-path-check-failed";
+      readonly verification: "missing" | "unknown";
+    }
+  | {
+      readonly ok: false;
+      readonly status: "unavailable";
+      readonly code: "selection-id-unavailable";
+    };
+
+export interface GameInstallPathSelectionApplyRequest {
+  readonly selectionId: string;
+  readonly targetIds: readonly GameInstallPathTargetId[];
+}
+
+export type GameInstallPathSelectionBatchFailureCode =
+  | "selection-not-found"
+  | "selection-expired"
+  | "selection-owner-mismatch"
+  | "selection-busy"
+  | "selection-invalidated"
+  | "invalid-target-ids"
+  | "duplicate-target-ids"
+  | "target-not-allowed"
+  | "target-completed";
+
+export type GameInstallPathSelectionBatchResult =
+  | {
+      readonly ok: false;
+      readonly overall: "failed";
+      readonly failureCode: GameInstallPathSelectionBatchFailureCode;
+      readonly results: readonly [];
+      readonly retryableTargetIds: readonly [];
+    }
+  | {
+      readonly ok: boolean;
+      readonly overall: "partial" | "failed";
+      readonly failureCode: "selection-invalidated";
+      readonly results: readonly GameInstallPathTargetApplyResult[];
+      readonly retryableTargetIds: readonly [];
+    }
+  | {
+      readonly ok: boolean;
+      readonly overall: "success" | "partial" | "failed";
+      readonly results: readonly GameInstallPathTargetApplyResult[];
+      readonly retryableTargetIds: readonly GameInstallPathTargetId[];
+      readonly diagnostics: GameInstallPathDiagnostics;
+      readonly selection: GameInstallPathSelectionDescriptor;
+    };
+
+export interface GameInstallPathRegistryTargetDeleteRequest {
+  readonly targetId: GameInstallPathRegistryTargetId;
+  readonly expectedPath: string;
+}
+
+export type GameInstallPathRegistryTargetDeleteFailureCode =
+  | "target-not-allowed"
+  | "expected-path-empty"
+  | "target-changed"
+  | "target-missing"
+  | "target-read-failed"
+  | "mutation-failed"
+  | "readback-failed";
+
+export type GameInstallPathRegistryTargetDeleteResult =
+  | {
+      readonly targetId: GameInstallPathRegistryTargetId;
+      readonly status: "deleted" | "unchanged";
+    }
+  | {
+      readonly targetId: GameInstallPathRegistryTargetId;
+      readonly status: "failed";
+      readonly code: GameInstallPathRegistryTargetDeleteFailureCode;
+      readonly retryable: boolean;
+    };
+
+export interface GameInstallPathRegistryTargetDeleteActionResult {
+  readonly ok: boolean;
+  readonly source: "registry";
+  readonly result: GameInstallPathRegistryTargetDeleteResult;
+  readonly diagnostics: GameInstallPathDiagnostics;
+}
+
 export interface GameInstallPathConfigDiagnostic {
   source: "config";
   path: string | null;
@@ -162,6 +330,7 @@ export type GameInstallPathRegistryAggregateState =
   "valid" | "absent" | "invalid" | "unknown";
 
 export interface GameInstallPathRegistryCandidateDiagnostic {
+  readonly targetId: GameInstallPathRegistryTargetId;
   path: string | null;
   state: GameInstallPathRegistryState;
   verification: GameInstallPathVerificationStatus;
@@ -194,8 +363,10 @@ export interface GameInstallPathRegistryTarget {
   expectedPath: string;
 }
 
-export interface GameInstallPathConflictTarget extends GameInstallPathRegistryTarget {
-  expectedConfigPath: string;
+export interface GameInstallPathConflictTarget {
+  readonly targetId: GameInstallPathRegistryTargetId;
+  readonly expectedPath: string;
+  readonly expectedConfigPath: string;
 }
 
 export interface GameInstallPathRegisterRequest {
@@ -578,10 +749,14 @@ export interface ElectronAPI {
     gameId: AppConfig["activeGame"],
     installPath: string,
   ) => Promise<GameInstallPathSaveResult>;
-  pickGameInstallPath: (
+  pickGameInstallPathTargets: (
     serviceId: AppConfig["serviceChannel"],
     gameId: AppConfig["activeGame"],
-  ) => Promise<GameInstallPathSaveResult>;
+  ) => Promise<GameInstallPathSelectionResult>;
+  applyGameInstallPathTargets: (
+    selectionId: string,
+    targetIds: readonly GameInstallPathTargetId[],
+  ) => Promise<GameInstallPathSelectionBatchResult>;
   resolveGameInstallPathConflict: (
     serviceId: AppConfig["serviceChannel"],
     gameId: AppConfig["activeGame"],
@@ -591,9 +766,12 @@ export interface ElectronAPI {
   clearGameInstallPath: (
     serviceId: AppConfig["serviceChannel"],
     gameId: AppConfig["activeGame"],
-    source: GameInstallPathClearSource,
-    registryTarget?: GameInstallPathRegistryTarget,
   ) => Promise<GameInstallPathClearResult>;
+  deleteGameInstallPathRegistryTarget: (
+    serviceId: AppConfig["serviceChannel"],
+    gameId: AppConfig["activeGame"],
+    request: GameInstallPathRegistryTargetDeleteRequest,
+  ) => Promise<GameInstallPathRegistryTargetDeleteActionResult>;
   registerGameInstallPath: (
     serviceId: AppConfig["serviceChannel"],
     gameId: AppConfig["activeGame"],

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -154,6 +154,22 @@ export interface GameInstallPathRegistryDiagnostic {
   error?: string;
   registryPath: string;
   registryValueName: string;
+  aggregateState: GameInstallPathRegistryAggregateState;
+  candidates: GameInstallPathRegistryCandidateDiagnostic[];
+}
+
+export type GameInstallPathRegistryAggregateState =
+  "valid" | "absent" | "invalid" | "unknown";
+
+export interface GameInstallPathRegistryCandidateDiagnostic {
+  path: string | null;
+  state: GameInstallPathRegistryState;
+  verification: GameInstallPathVerificationStatus;
+  executablePath?: string;
+  error?: string;
+  registryPath: string;
+  registryValueName: string;
+  isActive: boolean;
 }
 
 export interface GameInstallPathDiagnostics {
@@ -171,6 +187,20 @@ export type GameInstallPathConflictAction =
   "launcher-config-only" | "sync-registry";
 
 export type GameInstallPathClearSource = "config" | "registry";
+
+export interface GameInstallPathRegistryTarget {
+  registryPath: string;
+  registryValueName: string;
+  expectedPath: string;
+}
+
+export interface GameInstallPathConflictTarget extends GameInstallPathRegistryTarget {
+  expectedConfigPath: string;
+}
+
+export interface GameInstallPathRegisterRequest {
+  expectedConfigPath: string;
+}
 
 export type GameInstallPathSaveResult =
   | {
@@ -215,6 +245,34 @@ export type GameInstallPathConflictResolveResult =
       error?: string;
       diagnostics?: GameInstallPathDiagnostics;
     };
+
+export type GameInstallPathRegisterResult =
+  | {
+      ok: true;
+      path: string;
+      registryPath: string;
+      registryValueName: string;
+      diagnostics: GameInstallPathDiagnostics;
+    }
+  | {
+      ok: false;
+      path?: string;
+      verification: GameInstallPathVerificationStatus;
+      error?: string;
+      diagnostics?: GameInstallPathDiagnostics;
+    };
+
+export interface OperationalNotification {
+  id: string;
+  contextKey: string;
+  level: "warn";
+  tone: "amber";
+  title: string;
+  message: string;
+  serviceId: AppConfig["serviceChannel"];
+  gameId: AppConfig["activeGame"];
+  action: "open-game-path-diagnostic";
+}
 
 export interface PatchReservation {
   id: string; // 고유 ID (UUID 또는 timestamp)
@@ -308,6 +366,19 @@ export interface GameStatusState {
   status: RunStatus;
   errorCode?: string;
   timestamp?: number;
+  installPathHealth?: GameInstallPathHealth;
+}
+
+export type GameInstallationStatus = "installed" | "uninstalled" | "unknown";
+
+export interface GameInstallPathRegistryAdvisory {
+  state: Exclude<GameInstallPathRegistryAggregateState, "valid">;
+}
+
+export interface GameInstallPathHealth {
+  installationStatus: GameInstallationStatus;
+  checkedAt: number;
+  registryAdvisory?: GameInstallPathRegistryAdvisory;
 }
 
 export interface FileProgress {
@@ -515,12 +586,19 @@ export interface ElectronAPI {
     serviceId: AppConfig["serviceChannel"],
     gameId: AppConfig["activeGame"],
     action: GameInstallPathConflictAction,
+    registryTarget: GameInstallPathConflictTarget,
   ) => Promise<GameInstallPathConflictResolveResult>;
   clearGameInstallPath: (
     serviceId: AppConfig["serviceChannel"],
     gameId: AppConfig["activeGame"],
     source: GameInstallPathClearSource,
+    registryTarget?: GameInstallPathRegistryTarget,
   ) => Promise<GameInstallPathClearResult>;
+  registerGameInstallPath: (
+    serviceId: AppConfig["serviceChannel"],
+    gameId: AppConfig["activeGame"],
+    request: GameInstallPathRegisterRequest,
+  ) => Promise<GameInstallPathRegisterResult>;
   minimizeWindow: () => void;
   closeWindow: () => void;
   getConfig: (
@@ -535,7 +613,9 @@ export interface ElectronAPI {
     callback: (key: string, value: unknown) => void,
   ) => () => void;
   onProgressMessage?: (callback: (text: string) => void) => void; // Deprecated
-  onGameStatusUpdate?: (callback: (status: GameStatusState) => void) => void;
+  onGameStatusUpdate?: (
+    callback: (status: GameStatusState) => void,
+  ) => () => void;
   onDebugLog?: (callback: (log: DebugLogPayload) => void) => () => void;
   onExceptionLog?: (callback: (log: DebugLogPayload) => void) => () => void;
   onPatchProgress?: (callback: (progress: PatchProgress) => void) => () => void; // New


### PR DESCRIPTION
## Summary

- POE1·POE2 설치 경로를 `Kakaogames` 기본 경로 우선, `DaumGames` 호환 경로 fallback 순으로 진단합니다.
- 런처 설정 경로는 유효하지만 두 레지스트리 후보를 사용할 수 없으면 실행을 막지 않는 경고 알림을 표시하고, 경로 진단 모달에서 후보 상태 확인과 canonical `InstallPath` 등록을 제공합니다.
- 퍼블리셔 CDN은 런타임에서 참조하지 않고 opt-in audit로 정적 매핑 drift만 검사하며, WSL→Windows/Electron 검증은 숨김 단일 runner로 통합합니다.

## Motivation

카카오게임즈 GameStarter의 공식 live 설정인 https://common.gdn.gamecdn.net/live/config/kakaogames/poe.gamestarter.json 및 https://common.gdn.gamecdn.net/live/config/kakaogames/poe2.gamestarter.json 은 `HKCU\SOFTWARE\Kakaogames\POE{,2}`를 기본 후보로, 기존 `HKCU\SOFTWARE\DaumGames\POE{,2}`를 fallback 후보로 제시합니다. 전환 전후 설치 사용자를 함께 지원하면서 레지스트리 경로 누락을 사용자가 진단·복구할 수 있어야 합니다. 공식 JSON은 `InstallPath` 값 이름까지 명시하지 않으므로 기존 계약과 안전한 fresh-read 검증을 유지합니다.