### PR TITLE
chore: GGG 이벤트 피드 수집 및 갱신 자동화 추가

### DIFF
--- a/.github/workflows/update-promotions.yml
+++ b/.github/workflows/update-promotions.yml
@@ -1,0 +1,104 @@
+name: Update Event Promotions
+
+on:
+  schedule:
+    - cron: "17 */6 * * *"
+  workflow_dispatch:
+  push:
+    branches: [master]
+    paths:
+      - "scripts/promotions/**"
+      - "src/shared/promotions.ts"
+      - ".github/workflows/update-promotions.yml"
+  pull_request:
+    paths:
+      - "scripts/promotions/**"
+      - "src/shared/promotions.ts"
+      - ".github/workflows/update-promotions.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: event-promotions-${{ github.event_name == 'pull_request' && github.event.pull_request.number || 'publisher' }}
+  cancel-in-progress: false
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "24"
+          cache: npm
+      - run: npm ci --omit=dev --ignore-scripts --no-audit --no-fund
+      - run: node --test scripts/promotions/*.test.mjs
+
+  collect-and-publish:
+    needs: test
+    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/master' && github.repository == 'NERDHEAD-lab/POE2-unofficial-launcher'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: write
+      pages: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: gh-pages
+          path: pages
+          fetch-depth: 0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "24"
+          cache: npm
+      - run: npm ci --omit=dev --ignore-scripts --no-audit --no-fund
+      - name: Confirm existing Pages target
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api "repos/${GITHUB_REPOSITORY}/pages" > "$RUNNER_TEMP/promotions-pages.json"
+          jq -e '.build_type == "legacy" and .source.branch == "gh-pages" and .source.path == "/"' "$RUNNER_TEMP/promotions-pages.json"
+      - name: Record collection revision
+        id: base
+        working-directory: pages
+        run: echo "revision=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+      - name: Collect official GGG events
+        run: node scripts/promotions/collect.mjs --previous pages/promotions.json --output .tmp/promotions-candidate.json
+      - name: Publish only the validated feed
+        env:
+          COLLECTION_REVISION: ${{ steps.base.outputs.revision }}
+        run: node scripts/promotions/publish.mjs pages .tmp/promotions-candidate.json "$COLLECTION_REVISION"
+      - name: Request and verify Pages build
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api --method POST "repos/${GITHUB_REPOSITORY}/pages/builds"
+          for attempt in $(seq 1 30); do
+            gh api "repos/${GITHUB_REPOSITORY}/pages/builds/latest" > "$RUNNER_TEMP/promotions-build.json"
+            status=$(jq -r '.status' "$RUNNER_TEMP/promotions-build.json")
+            if [ "$status" = "built" ]; then
+              commit=$(jq -r '.commit' "$RUNNER_TEMP/promotions-build.json")
+              git -C pages fetch origin gh-pages
+              if git -C pages merge-base --is-ancestor HEAD "$commit"; then
+                jq '{status,commit,updated_at}' "$RUNNER_TEMP/promotions-build.json"
+                exit 0
+              fi
+            fi
+            if [ "$status" = "errored" ]; then
+              jq '{status,commit,error}' "$RUNNER_TEMP/promotions-build.json"
+              exit 1
+            fi
+            sleep 10
+          done
+          echo "Pages build completion not verified" >&2
+          exit 1
+      - name: Verify public HTTP 200 and matching contents
+        run: node scripts/promotions/verify-published.mjs .tmp/promotions-candidate.json

--- a/docs/work/2026-09-04-promotions-feed-collector.md
+++ b/docs/work/2026-09-04-promotions-feed-collector.md
@@ -1,0 +1,94 @@
+# GGG 이벤트 수집 및 Pages 발행
+
+> 작성일: 2026-09-04 · 상태: 로컬 검증·분리 리뷰 완료, 공개 적용 진행 · 브랜치: feat/promotions-feed-collector
+
+## 승인과 사전 확인
+
+사용자가 별도 gh-pages 작업에서 수집기 이관·구현·검증을 명시적으로 위임했다. 로컬 구현까지 승인됐으며 push, PR, master 머지, 실제 Pages 배포는 최종 승인 전 실행하지 않는다. 원래 런처 작업 트리는 읽기 전용이다. 구현자는 이 작업, 분리 설계·리뷰는 `promotions_design_review`다.
+
+- 원격은 런처와 같은 `NERDHEAD-lab/POE2-unofficial-launcher`. 최신 master `2c62c6977ebb494765e8da6d1d3c4865ee1b5465`에서 분기했다.
+- 저장된 gh-pages 작업 트리는 clean, HEAD `ace02e1a12b700d0a3ddddd8ca7f974a0bf3c693`. API에서 legacy / gh-pages / 루트 배포 확인. 이벤트 workflow는 아직 없다.
+- 실제 소비 계약은 원래 작업 트리의 미커밋 `src/shared/promotions.ts`를 읽었다. SHA256 `249D400841A9ABC4DA2D8223715E3FC416E547F06181834404284B90132FCBD6`.
+- 새 의존성, AppConfig, IPC, 서비스, 릴리스 흐름 변경은 없다. 기존 사이트·테마 workflow와 파일은 수정하지 않는다. 추가 owner 결정은 발견되지 않았다.
+
+## 설계
+
+기본 브랜치에 단일 수집 workflow와 `scripts/promotions/`를 둔다. `17 */6 * * *` 및 수동 실행으로 GGG 공식 자료를 읽고, 별도 checkout의 `gh-pages/promotions.json`만 발행한다. gh-pages에 scheduler만 두는 방식은 GitHub 기본 브랜치 제약 때문에 제외했다. 전체 Pages artifact 배포 전환은 기존 배포 구조를 바꾸므로 제외했다.
+
+JSON schemaVersion 1과 소비 URL `https://nerdhead-lab.github.io/POE2-unofficial-launcher/promotions.json`을 유지한다. 독립 수집용 validator는 런처의 실제 검증 규칙과 같으며 선택적 실제 소비자 대조 검사로 드리프트를 확인한다. 런처 TS 파일 이관이나 런타임 코드는 이 범위에 넣지 않는다.
+
+RSS와 양쪽 공지 게시판 각 최대 3페이지를 매 실행 탐색한다. 이전 미종료 원본은 다시 확인한다. 요청 간격 500ms, 요청당 15초/2MiB, 후보 최대 60개로 제한한다. 발견 실패 시 파일 교체를 중단한다. 개별 원본 실패는 마지막 정상 미종료 자료와 경고를 남긴다. 기간 추측 없이 명시 날짜·시간대·기간 및 공식 staff 첫 글만 파싱한다. 아래 사용자 후속 결정에 따라 종료된 일정은 매 정상 수집에서 제거한다.
+
+발행은 수집 시점 gh-pages revision을 기록하고 최신 gh-pages를 fast-forward로 반영한다. 그 사이 promotions.json이 바뀌면 중단해 오래된 결과의 덮어쓰기를 막는다. 다른 사이트 파일 변경은 그대로 유지한다. 한 파일만 커밋하고 일반 push한다. 경합 push 실패는 실패로 보고하며 force push하지 않는다. Pages build를 요청한 뒤 공개 URL HTTP 200과 검증된 JSON 일치를 재시도하며 확인한다.
+
+## 작업 순서와 DoD
+
+### M1 — 수집기 이관과 계약 보완
+
+- [x] [Windows-pwsh] `collector.test.mjs`, `collect.test.mjs`, `contract.test.mjs`에 두 종류, 시간대, 첫 staff 원본, 초기 3페이지, 동일 일정, override/disabled, 실패·보존·만료 제거 회귀 검사를 먼저 추가해 실패를 확인한다.
+- [x] [Windows-pwsh] 기존 `collector.mjs`, `collect.mjs`, `overrides.json`을 이관하고 `contract.mjs`에 동일 validator를 둔다. `node --test scripts/promotions/*.test.mjs` 통과.
+
+### M2 — 안전한 발행과 단일 workflow
+
+- [x] [Windows-pwsh] `publish.test.mjs`의 로컬 bare Git 저장소에서 최초/재발행, 사이트 동시 변경 보존, 피드 동시 변경 중단, 잘못된 JSON 무변경을 검증한다.
+- [x] [Windows-pwsh] `publish.mjs`, `verify-published.mjs` 및 `.github/workflows/update-promotions.yml` 구현. schedule/manual, 기본 브랜치 한정, 권한/경합/실패 시 보존/Pages 확인 경로를 검토한다.
+
+### M3 — 실제 수집·소비 계약·분리 리뷰
+
+- [x] [Windows-pwsh] 실제 원문으로 최초 및 이전 피드 갱신 수집. `.tmp/promotions-evidence/`에 실자료와 결과 보존. 합성 테스트 자료는 테스트 파일/격리 임시 Git 저장소에만 둔다.
+- [x] [Windows-pwsh] 원래 런처 `parsePromotionFeed`에 실제 출력 통과. 4000901/4001078을 원문과 대조하고 실행 시점 활성/예정을 구분한다. 보관함 현재 일정이 없으면 없다고 보고한다.
+- [x] [Windows-pwsh] 변경 파일만 형식/문법/회귀 검사, `git diff --check`, 분리 리뷰 통과.
+- [ ] [사용자, 적용 승인 후] master 변경 적용, 수동 수집 실행, 공개 URL HTTP 200/실제 내용 확인. 로컬 검증과 별도 완료 게이트.
+
+## 런처 작업과 적용 조정
+
+원래 작업의 `scripts/promotions/` 6개 파일과 `.github/workflows/update-promotions.yml` 초안은 이 변경으로 대체해야 한다. 해당 작업의 소유자가 제거/제외한다. 소비 코드, URL, JSON schema 변경은 필요 없다. 본 작업은 원래 트리를 수정하지 않는다.
+
+`docs/work/`는 적용 승인 대기 동안 유지한다. 외부 wiki 경로는 현재 허용된 쓰기 루트 밖이며 노트 이관/아카이브는 실제 마무리 단계에 남긴다.
+
+## 리뷰 기록
+
+사전 분리 설계 검토: 보관함 시작 시각을 제외한 중복 판정, 수동 override 이후 중복, 첫 글과 staff 검사의 결합 보완이 필요하다. 확정 계약 내 수정으로 반영한다.
+
+### 사용자 후속 결정 — 공개 피드 만료 관리
+
+사용자: “당장 필요한 드롭스랑 창고 할인에대해서만 누적하면되고, 해당 스케줄러에서 만료된 일정은 제거하는등 관리만 되면 될 듯”. 초기 90일 과거 기록 보존 방침을 대체한다. `endsAt <= 수집 시각`인 일정은 제거하고 진행·예정만 유지한다. 발견 실패 때 정상 파일 보존 정책과 런처의 종료 즉시 로컬 판정은 유지한다. 계약의 이벤트 **최대 기간 90일**은 보관 기간과 다른 제한이므로 그대로다.
+
+### 분리 리뷰 1라운드 — 반려 후 수정
+
+반복 수집 시 두 결함을 재현했다. 비활성 원문 정보가 출력에서 사라지면 재공지 ID가 재등장하고, 초기 2페이지에서 실패한 원본은 이후 1페이지 탐색에서 다시 발견되지 않았다. 실패 회귀 검사 후 수정했다. 비활성 공식 ID 원문을 매 실행 재조회하며 그 원문 실패 시 발행을 중단한다. 각 게시판 3페이지 상한을 매 실행 유지한다. 스키마/의존성/외부 권한 확대는 없다.
+
+### 분리 리뷰 2라운드 — 통과
+
+`promotions_design_review`가 최종 코드, 두 반복 실행 회귀 수정, 사용자 만료 제거 요구, README, 검사 로그, 실수집 증거를 확인했다. 추가 차단 지적 없음. 로컬 구현·검증 완료 판정이며 공개 적용은 별도다.
+
+## 최종 로컬 결과
+
+- Node 24.18.0 / Windows PowerShell. 36개 테스트 통과, 실패·skip 0. 실제 원래 런처 TS 모듈의 계약 수용/거부 비교를 포함한다. TS 파일을 ESM으로 다시 해석한다는 Node 경고는 기존 모듈 설정에서 나온 것으로 제품/설정 파일을 수정하지 않았다.
+- 두 종류 파싱, PDT/PST/EDT/IANA 시간대, 연도 경계·존재하지 않거나 모호한 DST 시각 거부, 첫 원문 staff, canonical 원문 교체, 일정 중복/수동 우선/비활성 반복, 실패 파일 바이트 보존, 종료 경계 제거, Git 동시 변경·push 거부, 공개 404/오래된 JSON 재시도 검증을 통과했다.
+- actionlint 1.7.12로 새 workflow 검사 통과(shellcheck는 로컬 미설치로 비활성). 공식 릴리스 asset의 SHA256 digest를 검증한 실행 파일을 `.tmp/tools/`에서만 사용했다. Prettier 및 `git diff --check` 통과. 기존 dependency manifest/lockfile 변경 없음.
+- 실제 원문을 최초/재수집한 총 40개 응답을 `.tmp/promotions-evidence/sources/`에 저장했다. 두 실행의 일정이 같고 실제 런처 `parsePromotionFeed`로 각각 통과했다. 최종 `generatedAt`은 `2026-09-04T08:06:01.221Z`다.
+- `2026-09-04T08:06:20.874Z`(KST 17:06) 기준: [PoE1 예선 Drops](https://www.pathofexile.com/forum/view-thread/4000901) 진행 1건, UTC 9월 3일 21:00–9월 4일 21:00. [PoE2 Drops](https://www.pathofexile.com/forum/view-thread/4001078) 예정 1건, UTC 9월 4일 20:00–9월 11일 20:00. 종료 일정은 0건.
+- 현재/예정 보관함 할인은 탐색 범위에서 발견되지 않았다. 공식 과거 [3926103](https://www.pathofexile.com/forum/view-thread/3926103)의 양 게임 할인은 UTC 4월 3일 00:00–4월 7일 01:00, `derived-start`로 실제 파싱/계약 통과했으며 만료되어 공개 후보에는 없다. 과거 3934610의 다른 종료 문구는 지원하지 않아 경고 1건으로 남겼다.
+- 공개 URL은 같은 확인 시각 **HTTP 404**. GitHub workflow 실행/실제 push/master 머지/Pages 배포는 수행하지 않았다. 로컬 bare 저장소의 publish 테스트를 실제 GitHub 발행 증거로 사용하지 않는다.
+- 기존 사이트 파일과 테마/릴리스 workflow를 수정하지 않았다. 저장된 gh-pages 작업 트리도 clean을 유지한다. 원래 런처 작업 트리/사용자 프로필에 수정 또는 합성 데이터 주입 없음.
+
+증거: `.tmp/promotions-evidence/tests-final.log`, `live-summary.json`, `bootstrap.json`, `promotions.json`, `historical-stash-parsed.json`, 실패 재현 로그 및 공개 원문 응답. 최종 피드는 실자료 2건이며 합성 피드가 아니다.
+
+### 변경 파일
+
+- `.github/workflows/update-promotions.yml`: 6시간/수동/관련 push 실행, PR 읽기 전용 검사, 안전한 gh-pages 발행 및 Pages/공개 검증.
+- `scripts/promotions/collect.mjs`, `collector.mjs`, `contract.mjs`, `overrides.json`: 수집·파싱·스키마·운영 조정.
+- `scripts/promotions/publish.mjs`, `verify-published.mjs`: 발행 경합 보호와 공개 결과 확인.
+- `scripts/promotions/collect.test.mjs`, `collector.test.mjs`, `contract.test.mjs`, `publish.test.mjs`, `verify-published.test.mjs`: 회귀 검사.
+- `scripts/promotions/README.md`, 이 work 문서: 운영 절차·이관·검증·남은 승인.
+
+## 남은 적용과 원래 작업 깨우기
+
+현재 변경은 이 브랜치의 미커밋 14개 신규 파일이다. 구체적인 다음 단계는 커밋 → push/PR → 승인된 master 머지 → `Update Event Promotions` 첫 실행 → gh-pages JSON과 Pages build 및 공개 HTTP 200/내용 확인이다. master 머지는 기존 release-please도 실행한다. 릴리스 PR 머지는 별도 결정으로 남긴다.
+
+### 공개 적용 진행 지시
+
+push·master 머지·Pages 배포 세 단계까지 진행할지 명시적으로 확인한 뒤 사용자가 “모니터링하다가 검토까지 끝내면 작업 깨워”라고 지시했다. 이 응답에 따라 해당 적용을 진행하고 실제 공개 동작 검토 후 원래 작업을 깨운다. 릴리스 PR 머지나 원래 런처 트리 수정 권한은 확장하지 않는다. 별도 Codex 자동화도 만들지 않는다.
+
+사용자 후속 지시에 따라 Codex heartbeat/폴링 자동화는 만들지 않는다. **공개 실제 동작 확인을 마친 뒤** `mcp__codex_app__send_message_to_thread`로 `01a06a7d-20b7-7543-9dff-c7758cfd7e05`(local, GGG 일정 크롤링 계획 구상)를 직접 깨운다. 피드 URL/schema/generatedAt/진행·예정 목록, 적용 커밋, workflow run 및 공개 검증 증거, 중복 초안 제거 목록을 전달하고 “사용자 요청에 따라 필요한 연동 수정 또는 이미 호환되면 실제 피드로 숨김 Windows Electron QA와 캡처를 진행해 주세요”라고 요청한다. 현재는 공개 적용 승인 대기이므로 연동 QA 완료를 주장하거나 후속 QA를 시작시키지 않는다.

--- a/scripts/promotions/README.md
+++ b/scripts/promotions/README.md
@@ -1,0 +1,73 @@
+# GGG 이벤트 피드
+
+공식 GGG 공지에서 Twitch Drops와 보관함 할인을 읽어 런처용 `promotions.json`을 만든다. 수집 코드와 스케줄러는 **master**, 공개 결과는 **gh-pages 루트**에 둔다. 두 브랜치는 같은 GitHub 저장소에 있다.
+
+## 로컬 실행
+
+Node 24와 저장소에 이미 등록된 `node-html-parser`를 사용한다. Electron 실행이나 새 의존성은 필요 없다.
+
+```powershell
+npm.cmd ci --omit=dev --ignore-scripts --no-audit --no-fund
+node --test scripts/promotions/*.test.mjs
+node scripts/promotions/collect.mjs --output .tmp/promotions.json
+```
+
+`--output`이 이미 존재하면 이전 정상 피드로 읽는다. 다른 입력은 `--previous <파일>`로 지정한다. 이전 파일이 없으면 최초 수집이며, 잘못된 JSON은 오류로 중단한다. 완성된 피드의 검증이 끝난 뒤 임시 파일을 rename하여 출력 파일을 교체한다. **이 명령은 Git push나 Pages 배포를 하지 않는다.**
+
+수집기는 미커밋 런처 기능과 독립적으로 적용할 수 있게 `contract.mjs`를 사용한다. 계약 검사는 schema v1의 수용/거부 사례를 검증하며, `src/shared/promotions.ts`가 병합되면 실제 소비자와도 자동 비교한다. 다른 작업 트리의 실제 소비자를 읽기 전용으로 비교하려면:
+
+```powershell
+$env:PROMOTIONS_CONSUMER_MODULE = 'D:/project_poe2/POE2-unofficial-launcher/src/shared/promotions.ts'
+try { node --test scripts/promotions/*.test.mjs }
+finally { Remove-Item Env:PROMOTIONS_CONSUMER_MODULE }
+```
+
+소비자 파일이 없는 브랜치에서는 이 비교 한 건만 명시적으로 skip한다. 독립 계약 검사는 항상 실행한다. 지정한 파일이 없으면 실패한다.
+
+## 수집과 실패 처리
+
+- `/news/rss`와 `/forum/view-forum/news`, `/forum/view-forum/2211`의 **각 1–3페이지**를 매 실행 확인한다. 이전 실행에서 실패했던 2–3페이지 원문도 다시 발견하기 위한 고정 상한이다. 이전 미종료 원문과 비활성 공식 ID의 원문도 확인한다.
+- 요청은 직렬이며 500ms 간격, 요청당 15초와 2MiB, 전체 후보 60개로 제한한다. 무제한 과거 탐색이나 계정 로그인은 없다. 범위 밖의 오래된 미종료 공지를 모두 찾는다는 보장은 없다.
+- `/filter-account-type/staff` 응답의 첫 `.newsPost` 본문과 바로 뒤 작성자 정보의 staff 표시를 함께 확인한다. FAQ/다른 보상 섹션/사용자 댓글을 이벤트로 사용하지 않는다.
+- Drops의 `Start Time`/`End Time`, `from … until …`, 명시적인 시간 수와 종료 시각을 지원한다. 시청할 게임의 category/directory/stream 문구로 게임을 판정한다. 다른 게임에서도 보상을 쓴다는 FAQ는 게임 판정에 사용하지 않는다.
+- 보관함 할인은 `Stash Tab Sale ends at/on …`과 양 게임 적용 문구가 명시된 글을 지원한다. 시작은 RSS 또는 원문 게시 시각이며 `derived-start`다. 지원하지 않는 표현이나 불확실한 게임·기간은 경고로 남기고 추측하지 않는다.
+- 발견 요청 실패/챌린지 페이지/잘못된 입력/후보 초과는 전체 실행을 실패시킨다. 개별 원문 실패는 그 원문의 마지막 정상 일정을 유지하며 다른 원문은 갱신할 수 있다. 최초 실행에서 실패만 있고 검증한 일정도 없으면 발행하지 않는다.
+- 원문이 정상적으로 다시 파싱되면 해당 원문의 이전 섹션을 교체한다. 실패 시에는 이전 미종료 일정을 유지한다. **종료 시각이 수집 시각 이하인 일정은 매 수집에서 제거**하여 공개 JSON에는 진행·예정 일정만 유지한다. 200건을 넘는 출력은 발행하지 않는다. 발견 단계 자체가 실패하면 이전 공개 파일을 보존하므로 만료 정리는 다음 정상 실행에서 이루어진다. 런처의 로컬 종료 판정은 이 지연과 무관하다.
+
+## JSON 계약과 수동 조정
+
+공개 URL은 [promotions.json](https://nerdhead-lab.github.io/POE2-unofficial-launcher/promotions.json)이다. schema 변경이나 URL 변경은 소비 런처와 사전 동기화가 필요하다.
+
+- 최상위: `schemaVersion: 1`, UTC ISO `generatedAt`, `events` 배열(최대 200건).
+- 이벤트: `id`, `kind`(`twitch-drops`/`stash-sale`), `game`(`poe1`/`poe2`/`both`), UTC ISO `startsAt`/`endsAt`, 공식 forum thread `sourceUrl`, `precision`(`exact`/`derived-start`/`manual`). Drops에는 `both`를 허용하지 않는다.
+- ID는 `[a-z0-9:-]` 1–160자, 중복 불가. 종료는 시작보다 뒤이고 기간은 최대 90일. UTC 문자열은 초 또는 밀리초 3자리와 `Z`를 사용한다.
+- 동일 일정은 **종류 + 게임 + 시작 UTC epoch + 종료 UTC epoch**다. 같은 일정의 재공지는 하나로 합치고 가능한 경우 기존 ID를 유지한다. 기간이 달라지면 별도 일정으로 취급한다. 자동 ID는 스레드/섹션 기반이며 일반적인 기간 정정에서 유지된다.
+
+`overrides.json`의 `events`에는 공식 출처와 전체 필드를 가진 `precision: "manual"` 이벤트를 넣는다. 같은 ID를 교체하며 동일 일정의 자동 항목보다 우선한다. 수동 입력도 필터링 전에 계약을 검증한다. 원래 자동 일정을 취소하고 다른 ID로 정정하려면 자동 ID를 `disabledIds`에도 명시한다.
+
+`disabledIds`에 지정한 ID 및 현재 확인 가능한 같은 일정의 재공지들을 제외한다. `ggg-{thread}-…` ID는 이후 실행에도 그 공식 원문을 재조회하므로 피드에서 제거된 뒤에도 재공지 억제를 유지한다. 이 원문을 읽지 못하면 억제 규칙을 잃지 않도록 전체 발행을 중단한다. 수동 ID의 동일 일정 억제를 유지하려면 그 이벤트를 `events`에도 유지한다. 종료한 억제 규칙은 운영자가 정리해 원문 재조회를 줄일 수 있다.
+
+## GitHub Actions와 발행
+
+`.github/workflows/update-promotions.yml`은 UTC **00:17/06:17/12:17/18:17**(KST **09:17/15:17/21:17/03:17**)에 실행한다. GitHub schedule은 지연되거나 누락될 수 있으므로 정확한 시작·종료 판정은 런처가 로컬 시각으로 수행한다. 런처의 시작/절전 복귀/1시간 조회 계약은 유지한다. [GitHub schedule 문서](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#schedule)
+
+동일 workflow의 PR 실행은 읽기 권한의 테스트만 수행한다. 수집·발행은 원래 저장소 master의 schedule/수동 실행/관련 경로 push에서만 가능하다. 별도 중복 스케줄러는 필요 없다. 예약/수동 실행을 등록하려면 workflow가 기본 브랜치에 적용되어야 한다.
+
+승인 후 수동 실행은 GitHub Actions의 **Update Event Promotions → Run workflow → master**를 선택한다. 저장소의 GitHub CLI 토큰 스킬을 적용한 환경에서는 `gh workflow run update-promotions.yml --ref master`도 가능하다.
+
+발행 절차:
+
+1. 기존 Pages 설정이 `legacy`, source `gh-pages`, path `/`인지 확인한다.
+2. 별도 gh-pages checkout의 revision을 기록하고 기존 피드를 읽어 `.tmp/promotions-candidate.json`을 만든다.
+3. `publish.mjs`가 깨끗한 gh-pages checkout과 기준 revision을 확인하고 원격을 fetch한다. 수집 이후 원격 피드가 변경됐으면 실패한다. 다른 사이트 변경은 fast-forward로 보존한다.
+4. `promotions.json` **한 파일만** 커밋하고 일반 push한다. 경합·권한 오류는 실패로 보고하며 force push하지 않는다. 수집·검증 실패는 기존 원격 파일을 건드리지 않는다.
+5. `pages: write` 권한으로 [Pages build API](https://docs.github.com/en/rest/pages/pages#request-a-github-pages-build)를 요청한다. GITHUB_TOKEN push만으로 배포를 가정하지 않는다. 빌드 완료와 발행 커밋 포함 여부를 최대 5분 확인한다.
+6. `verify-published.mjs`가 공개 URL의 HTTP 200과 검증된 내용 일치를 최대 20회 확인한다. push 성공, build 요청 성공, 공개 내용 검증 성공은 서로 별도 단계다. 빌드나 CDN 확인이 실패해도 강제 롤백하지 않고 실패를 보고한다.
+
+`publish.mjs`는 실제 원격을 변경하는 명령이다. 운영자의 배포 승인 후 workflow에서만 실행한다. 테스트는 `.tmp` 아래의 격리된 로컬 bare 저장소에서만 실행하여 기존 사이트와 사용자 작업 트리를 보존한다.
+
+## 이관과 적용 순서
+
+현재 구현은 런처 작업의 수집기 초안을 이관한 것이다. 런처 작업 소유자는 그 작업 트리의 `scripts/promotions/` 및 `.github/workflows/update-promotions.yml` 초안을 제거/제외하고 이 변경을 사용해야 한다. `src/shared/promotions.ts`, `SUPPORT_URLS.PROMOTIONS_JSON`, 소비 서비스는 그대로 유지한다.
+
+로컬 검증 후 적용 승인 → master 대상 변경 병합 → 수동 workflow 실행 → 실제 공개 JSON 확인 → 원래 런처 작업에 완료 통보 순서다. master 머지는 기존 release-please를 실행하므로 머지 승인은 별도로 필요하다. 실제 피드로 런처의 숨김 Windows Electron QA와 캡처는 원래 작업에서 수행한다.

--- a/scripts/promotions/collect.mjs
+++ b/scripts/promotions/collect.mjs
@@ -1,0 +1,189 @@
+/* global fetch, AbortSignal, Buffer, process, URL, console */
+import { readFile, writeFile, rename, mkdir } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { setTimeout as delay } from "node:timers/promises";
+import { parsePromotionFeed } from "./contract.mjs";
+import {
+  canonicalSource,
+  parseArticle,
+  parseForum,
+  parseRss,
+  mergePromotions,
+} from "./collector.mjs";
+
+export async function fetchOfficial(url) {
+  const response = await fetch(url, {
+    headers: {
+      "User-Agent":
+        "PoE-Unofficial-Launcher-Promotions/1.0 (+https://github.com/NERDHEAD-lab/POE2-unofficial-launcher)",
+      Accept: "text/html, application/rss+xml",
+    },
+    signal: AbortSignal.timeout(15_000),
+    redirect: "error",
+  });
+  if (!response.ok) throw new Error(`HTTP ${response.status}`);
+  const reader = response.body.getReader();
+  const chunks = [];
+  let size = 0;
+  for (;;) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    size += value.byteLength;
+    if (size > 2 * 1024 * 1024) {
+      await reader.cancel();
+      throw new Error("Response too large");
+    }
+    chunks.push(Buffer.from(value));
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+export async function collect({
+  previous = null,
+  overrides,
+  fetchText = fetchOfficial,
+  pause = () => delay(500),
+  now = new Date(),
+}) {
+  if (previous) previous = parsePromotionFeed(previous);
+  // Validate controls before requests. Disabled official IDs retain their source
+  // as a candidate even after the published feed no longer contains the event.
+  mergePromotions(previous, [], overrides, now);
+  const disabledSources = new Set(
+    overrides.disabledIds.flatMap((id) => {
+      const match = /^ggg-(\d+)-/.exec(id);
+      return match
+        ? [`https://www.pathofexile.com/forum/view-thread/${match[1]}`]
+        : [];
+    }),
+  );
+  const candidates = new Map();
+  const discover = (items) => {
+    for (const item of items)
+      candidates.set(item.url, { ...candidates.get(item.url), ...item });
+  };
+  // Fail the run on discovery failure; an error/challenge page is not an empty feed.
+  discover(parseRss(await fetchText("https://www.pathofexile.com/news/rss")));
+  // Keep the bounded window on every run so an initially failed page-two source
+  // is retried even when other successful sources advance generatedAt.
+  const pages = 3;
+  for (const board of ["news", "2211"]) {
+    for (let page = 1; page <= pages; page++) {
+      await pause();
+      discover(
+        parseForum(
+          await fetchText(
+            `https://www.pathofexile.com/forum/view-forum/${board}${page === 1 ? "" : `/page/${page}`}`,
+          ),
+        ),
+      );
+    }
+  }
+  for (const event of previous?.events ?? []) {
+    if (Date.parse(event.endsAt) > now.getTime()) {
+      const url = canonicalSource(event.sourceUrl);
+      if (!candidates.has(url)) candidates.set(url, { url });
+    }
+  }
+  for (const url of disabledSources)
+    if (!candidates.has(url)) candidates.set(url, { url });
+  if (candidates.size > 60) throw new Error("Unexpected candidate volume");
+  const parsed = [];
+  const warnings = [];
+  for (const item of candidates.values()) {
+    const known =
+      previous?.events.filter(
+        (event) => canonicalSource(event.sourceUrl) === item.url,
+      ) ?? [];
+    if (
+      !disabledSources.has(item.url) &&
+      known.length &&
+      known.every((event) => Date.parse(event.endsAt) <= now.getTime())
+    )
+      continue;
+    await pause();
+    try {
+      parsed.push(
+        ...parseArticle(
+          await fetchText(`${item.url}/filter-account-type/staff`),
+          item.url,
+          item.publishedAt,
+        ),
+      );
+    } catch (error) {
+      if (disabledSources.has(item.url))
+        throw new Error(
+          `Cannot validate disabled source ${item.url}: ${error.message}`,
+        );
+      // A failed candidate keeps its last validated events; other sources may advance.
+      warnings.push(`${item.url}: ${error.message}`);
+    }
+  }
+  if (warnings.length && !parsed.length && !previous?.events.length)
+    throw new Error(`No validated promotions: ${warnings.join("; ")}`);
+  return { feed: mergePromotions(previous, parsed, overrides, now), warnings };
+}
+
+async function readJson(path, optional = false) {
+  try {
+    return JSON.parse(await readFile(path, "utf8"));
+  } catch (error) {
+    if (optional && error.code === "ENOENT") return null;
+    throw error;
+  }
+}
+
+export async function collectToFile({
+  output,
+  previousPath = output,
+  ...options
+}) {
+  const previous = await readJson(previousPath, true);
+  const overrides = await readJson(
+    new URL("./overrides.json", import.meta.url),
+  );
+  const result = await collect({ ...options, previous, overrides });
+  await mkdir(dirname(output), { recursive: true });
+  const temporary = `${output}.${process.pid}.tmp`;
+  await writeFile(temporary, `${JSON.stringify(result.feed, null, 2)}\n`);
+  await rename(temporary, output);
+  return result;
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const option = (key) => args[args.indexOf(key) + 1];
+  if (
+    !args.includes("--output") ||
+    ![2, 4].includes(args.length) ||
+    args.some((value, index) =>
+      index % 2 === 0
+        ? !["--output", "--previous"].includes(value)
+        : value.startsWith("--"),
+    ) ||
+    new Set(args.filter((_, index) => index % 2 === 0)).size !== args.length / 2
+  )
+    throw new Error(
+      "Usage: node scripts/promotions/collect.mjs --output <promotions.json> [--previous <promotions.json>]",
+    );
+  const output = resolve(option("--output"));
+  const { feed, warnings } = await collectToFile({
+    output,
+    previousPath: args.includes("--previous")
+      ? resolve(option("--previous"))
+      : output,
+  });
+  console.log(`Validated ${feed.events.length} events -> ${output}`);
+  for (const warning of warnings) console.warn(warning);
+}
+
+if (
+  process.argv[1] &&
+  resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+  main().catch((error) => {
+    console.error(error.message);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/promotions/collect.test.mjs
+++ b/scripts/promotions/collect.test.mjs
@@ -1,0 +1,234 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { collect, collectToFile } from "./collect.mjs";
+import {
+  mkdtemp,
+  mkdir,
+  readFile,
+  writeFile,
+  rm,
+  realpath,
+} from "node:fs/promises";
+import { resolve, join, sep } from "node:path";
+
+const previous = {
+  schemaVersion: 1,
+  generatedAt: "2026-09-04T00:00:00Z",
+  events: [
+    {
+      id: "ggg-1-stash",
+      kind: "stash-sale",
+      game: "both",
+      startsAt: "2026-09-04T00:00:00Z",
+      endsAt: "2026-09-08T00:00:00Z",
+      sourceUrl: "https://www.pathofexile.com/forum/view-thread/1",
+      precision: "derived-start",
+    },
+  ],
+};
+const options = {
+  previous,
+  overrides: { events: [], disabledIds: [] },
+  now: new Date("2026-09-04T01:00:00Z"),
+  pause: async () => {},
+};
+
+test("a discovery failure rejects before a replacement feed can be published", async () => {
+  await assert.rejects(
+    collect({ ...options, fetchText: async () => "<html>challenge</html>" }),
+  );
+  assert.equal(previous.events.length, 1);
+});
+
+test("failed discovery leaves previous output byte-for-byte intact", async (t) => {
+  await mkdir(".tmp", { recursive: true });
+  const parent = await realpath(resolve(".tmp"));
+  const dir = await mkdtemp(join(parent, "promotions-file-test-"));
+  t.after(async () => {
+    assert.ok((await realpath(dir)).startsWith(parent + sep));
+    await rm(dir, { recursive: true });
+  });
+  const output = join(dir, "promotions.json");
+  const original = JSON.stringify(previous);
+  await writeFile(output, original);
+  await assert.rejects(
+    collectToFile({
+      ...options,
+      output,
+      fetchText: async () => "<html>challenge</html>",
+    }),
+  );
+  assert.equal(await readFile(output, "utf8"), original);
+});
+
+const rss =
+  "<rss><channel><item><title>Build Showcase</title></item></channel></rss>";
+const emptyForum = '<table class="forumTable"></table>';
+const stash =
+  '<table><tr class="newsPost"><td><div class="content">Stash Tab Sale<br>The Stash Tab sale ends at Sep 8, 2026 9AM GMT+9<br>both Path of Exile 1 and 2</div></td></tr><tr class="newsPostInfo"><td><span class="staff"></span><span class="post_date">Sep 4, 2026, 9:00:00 AM</span></td></tr></table><script>window.momentTimezone = "Asia/Seoul";</script>';
+
+test("bootstrap finds page-two schedules with a hard three-page bound", async () => {
+  const calls = [];
+  const { feed } = await collect({
+    ...options,
+    previous: null,
+    fetchText: async (url) => {
+      calls.push(url);
+      if (url.endsWith("/rss")) return rss;
+      if (url.endsWith("/news/page/2"))
+        return '<table class="forumTable"><a href="/forum/view-thread/2">Stash Tab Sale</a></table>';
+      if (url.includes("view-forum")) return emptyForum;
+      return stash;
+    },
+  });
+  assert.equal(feed.events[0]?.kind, "stash-sale");
+  assert.equal(calls.filter((url) => url.includes("view-forum")).length, 6);
+  assert.ok(calls.every((url) => !url.endsWith("/page/4")));
+});
+
+test("fresh and stale feeds retain the same bounded discovery window", async () => {
+  for (const [generatedAt, expectedPages] of [
+    ["2026-09-04T00:00:00Z", 6],
+    ["2026-08-01T00:00:00Z", 6],
+  ]) {
+    const calls = [];
+    await collect({
+      ...options,
+      previous: { ...previous, generatedAt },
+      fetchText: async (url) => {
+        calls.push(url);
+        if (url.endsWith("/rss")) return rss;
+        if (url.includes("view-forum")) return emptyForum;
+        return stash;
+      },
+    });
+    assert.equal(
+      calls.filter((url) => url.includes("view-forum")).length,
+      expectedPages,
+    );
+  }
+});
+
+test("a failed page-two source is rediscovered on the next scheduled run", async () => {
+  let recovered = false;
+  const config = {
+    ...options,
+    previous: null,
+    fetchText: async (url) => {
+      if (url.endsWith("/rss")) return rss;
+      if (url.endsWith("/news"))
+        return '<table class="forumTable"><a href="/forum/view-thread/1">Stash Tab Sale</a></table>';
+      if (url.endsWith("/news/page/2"))
+        return '<table class="forumTable"><a href="/forum/view-thread/2">Stash Tab Sale</a></table>';
+      if (url.includes("view-forum")) return emptyForum;
+      if (url.includes("/view-thread/2/")) {
+        if (!recovered) throw new Error("HTTP 503");
+        return stash.replace(
+          "Sep 4, 2026, 9:00:00 AM",
+          "Sep 4, 2026, 10:00:00 AM",
+        );
+      }
+      return stash;
+    },
+  };
+  const first = await collect(config);
+  assert.equal(first.feed.events.length, 1);
+  recovered = true;
+  const second = await collect({
+    ...config,
+    previous: first.feed,
+    now: new Date("2026-09-04T07:00:00Z"),
+  });
+  assert.equal(second.feed.events.length, 2);
+});
+
+test("a failed bootstrap discovery page rejects the whole run", async () => {
+  await assert.rejects(
+    collect({
+      ...options,
+      previous: null,
+      fetchText: async (url) => {
+        if (url.endsWith("/rss")) return rss;
+        if (url.endsWith("/page/2")) throw new Error("HTTP 503");
+        return emptyForum;
+      },
+    }),
+    /503/,
+  );
+});
+
+test("a failed source is preserved while a different source advances", async () => {
+  const { feed, warnings } = await collect({
+    ...options,
+    fetchText: async (url) => {
+      if (url.endsWith("/rss")) return rss;
+      if (url.includes("view-forum"))
+        return '<table class="forumTable"><a href="/forum/view-thread/2">Stash Tab Sale</a></table>';
+      if (url.includes("/view-thread/1/")) throw new Error("HTTP 503");
+      return stash.replace(
+        "Sep 4, 2026, 9:00:00 AM",
+        "Sep 4, 2026, 10:00:00 AM",
+      );
+    },
+  });
+  assert.equal(feed.events.length, 2);
+  assert.deepEqual(
+    feed.events.find((event) => event.id === previous.events[0].id),
+    previous.events[0],
+  );
+  assert.equal(warnings.length, 1);
+});
+
+test("failed active source preserves last known events and reports the source", async () => {
+  const { feed, warnings } = await collect({
+    ...options,
+    fetchText: async (url) => {
+      if (url.endsWith("/rss"))
+        return "<rss><channel><item><title>Build Showcase</title></item></channel></rss>";
+      if (url.includes("view-forum"))
+        return '<table class="forumTable"></table>';
+      throw new Error("HTTP 503");
+    },
+  });
+  assert.deepEqual(feed.events, previous.events);
+  assert.equal(warnings.length, 1);
+});
+
+test("disabled official source is rechecked so a repost stays disabled on later runs", async () => {
+  const calls = [];
+  const config = {
+    ...options,
+    previous: null,
+    overrides: { events: [], disabledIds: ["ggg-1-stash"] },
+    fetchText: async (url) => {
+      calls.push(url);
+      if (url.endsWith("/rss")) return rss;
+      if (url.includes("view-forum"))
+        return '<table class="forumTable"><a href="/forum/view-thread/2">Stash Tab Sale</a></table>';
+      return stash;
+    },
+  };
+  const first = await collect(config);
+  const second = await collect({ ...config, previous: first.feed });
+  assert.equal(first.feed.events.length, 0);
+  assert.equal(second.feed.events.length, 0);
+  assert.equal(
+    calls.filter((url) => url.includes("/view-thread/1/")).length,
+    2,
+  );
+});
+
+test("an unavailable disabled source cannot silently re-enable its reposts", async () => {
+  await assert.rejects(
+    collect({
+      ...options,
+      overrides: { events: [], disabledIds: ["ggg-1-stash"] },
+      fetchText: async (url) => {
+        if (url.endsWith("/rss")) return rss;
+        if (url.includes("view-forum")) return emptyForum;
+        throw new Error("HTTP 503");
+      },
+    }),
+    /disabled source/i,
+  );
+});

--- a/scripts/promotions/collector.mjs
+++ b/scripts/promotions/collector.mjs
@@ -1,0 +1,367 @@
+import { createHash } from "node:crypto";
+import { parse } from "node-html-parser";
+import { parsePromotionFeed, scheduleKey } from "./contract.mjs";
+
+const candidate = /\btwitch\s+drops?\b|\bstash(?:\s+tab)?\s+sale\b/i;
+const text = (html) =>
+  parse(`<div>${html.replace(/<!\[CDATA\[([\s\S]*?)\]\]>/g, "$1")}</div>`).text;
+export function canonicalSource(url) {
+  const match =
+    /^https:\/\/www\.pathofexile\.com\/forum\/view-thread\/(\d+)(?:\/filter-account-type\/staff)?$/.exec(
+      url,
+    );
+  if (!match) throw new Error("Not an official GGG announcement URL");
+  return `https://www.pathofexile.com/forum/view-thread/${match[1]}`;
+}
+
+export function parseRss(xml) {
+  if (!/<rss\b/i.test(xml) || !/<channel\b/i.test(xml) || !/<item>/i.test(xml))
+    throw new Error("Invalid GGG RSS response");
+  return [...xml.matchAll(/<item>([\s\S]*?)<\/item>/gi)].flatMap(([, item]) => {
+    const field = (tag) =>
+      text(
+        new RegExp(`<${tag}>([\\s\\S]*?)<\\/${tag}>`, "i").exec(item)?.[1] ??
+          "",
+      ).trim();
+    if (!candidate.test(`${field("title")} ${field("description")}`)) return [];
+    const published = Date.parse(field("pubDate"));
+    if (!Number.isFinite(published))
+      throw new Error("RSS publication time missing");
+    return [
+      {
+        url: canonicalSource(field("link")),
+        publishedAt: new Date(published).toISOString(),
+      },
+    ];
+  });
+}
+
+export function parseForum(html) {
+  const root = parse(html);
+  if (!root.querySelector(".forumTable"))
+    throw new Error("Invalid GGG forum response");
+  return root
+    .querySelectorAll('a[href^="/forum/view-thread/"]')
+    .flatMap((link) => {
+      if (!candidate.test(link.text)) return [];
+      const path = /^\/forum\/view-thread\/\d+/.exec(
+        link.getAttribute("href"),
+      )?.[0];
+      return path
+        ? [{ url: canonicalSource(`https://www.pathofexile.com${path}`) }]
+        : [];
+    });
+}
+
+const months = [
+  "jan",
+  "feb",
+  "mar",
+  "apr",
+  "may",
+  "jun",
+  "jul",
+  "aug",
+  "sep",
+  "oct",
+  "nov",
+  "dec",
+];
+const datePattern =
+  /\b(Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|Jun(?:e)?|Jul(?:y)?|Aug(?:ust)?|Sep(?:t(?:ember)?)?|Oct(?:ober)?|Nov(?:ember)?|Dec(?:ember)?)\s+(\d{1,2})(?:st|nd|rd|th)?(?:,?\s+(20\d\d))?,?\s+(\d{1,2})(?::(\d\d))?(?::(\d\d))?\s*(AM|PM)\s*(?:\(?\s*(PDT|PST|EDT|EST|UTC|GMT(?:[+-]\d{1,2}(?::\d\d)?)?)\)?)?/i;
+
+function offsetMinutes(zone, instant) {
+  const fixed = { PDT: -420, PST: -480, EDT: -240, EST: -300, UTC: 0, GMT: 0 };
+  if (zone in fixed) return fixed[zone];
+  const label = zone.startsWith("GMT")
+    ? zone
+    : new Intl.DateTimeFormat("en", {
+        timeZone: zone,
+        timeZoneName: "longOffset",
+      })
+        .formatToParts(new Date(instant))
+        .find((x) => x.type === "timeZoneName").value;
+  if (label === "GMT") return 0;
+  const match = /^GMT([+-])(\d{1,2})(?::(\d\d))?$/.exec(label);
+  if (!match || Number(match[2]) > 14 || Number(match[3] ?? 0) > 59)
+    throw new Error("Unknown source timezone");
+  return (
+    (match[1] === "+" ? 1 : -1) *
+    (Number(match[2]) * 60 + Number(match[3] ?? 0))
+  );
+}
+
+function calendarTime(value, reference, fallbackZone) {
+  const match = datePattern.exec(value);
+  if (!match) throw new Error("Missing explicit date");
+  const [
+    ,
+    month,
+    day,
+    year,
+    hours,
+    minutes = "0",
+    seconds = "0",
+    meridiem,
+    literalZone,
+  ] = match;
+  const zone = literalZone?.toUpperCase() ?? fallbackZone;
+  if (
+    !zone ||
+    +hours < 1 ||
+    +hours > 12 ||
+    +minutes > 59 ||
+    +seconds > 59 ||
+    +day < 1 ||
+    +day > 31
+  )
+    throw new Error("Incomplete source date");
+  const monthNumber = months.indexOf(month.slice(0, 3).toLowerCase());
+  let yearNumber = year ? Number(year) : new Date(reference).getUTCFullYear();
+  // Announcements near New Year can refer to the following January.
+  if (!year && new Date(reference).getUTCMonth() === 11 && monthNumber === 0)
+    yearNumber++;
+  const wall = Date.UTC(
+    yearNumber,
+    monthNumber,
+    +day,
+    (+hours % 12) + (meridiem.toUpperCase() === "PM" ? 12 : 0),
+    +minutes,
+    +seconds,
+  );
+  if (new Date(wall).getUTCMonth() !== monthNumber)
+    throw new Error("Invalid calendar date");
+  let instant = wall;
+  for (let i = 0; i < 3; i++)
+    instant = wall - offsetMinutes(zone, instant) * 60_000;
+  if (instant + offsetMinutes(zone, instant) * 60_000 !== wall)
+    throw new Error("Nonexistent local source date");
+  if (
+    !["PDT", "PST", "EDT", "EST", "UTC"].includes(zone) &&
+    !zone.startsWith("GMT")
+  ) {
+    for (const delta of [-3600_000, 3600_000]) {
+      if (
+        instant + delta + offsetMinutes(zone, instant + delta) * 60_000 ===
+        wall
+      )
+        throw new Error("Ambiguous local source date");
+    }
+  }
+  return new Date(instant).toISOString();
+}
+
+function twitchGame(section) {
+  const one = /Path of Exile(?:\s+1)?\s+(?:category|directory|stream)/i.test(
+    section,
+  );
+  const two = /Path of Exile\s+2\s+(?:category|directory|stream)/i.test(
+    section,
+  );
+  if (one === two) throw new Error("Ambiguous Twitch game category");
+  return one ? "poe1" : "poe2";
+}
+
+export function parseArticle(html, sourceUrl, publishedAt) {
+  sourceUrl = canonicalSource(sourceUrl);
+  const root = parse(html);
+  const post = root.querySelector(".newsPost");
+  const content = post?.querySelector(".content");
+  const info = post?.nextElementSibling;
+  if (
+    !content ||
+    !info?.classList.contains("newsPostInfo") ||
+    !info.querySelector(".staff")
+  )
+    throw new Error("Original GGG staff post not found");
+  const zone = /window\.momentTimezone\s*=\s*['"]([^'"]+)['"]/.exec(html)?.[1];
+  const published =
+    publishedAt ??
+    calendarTime(
+      info.querySelector(".post_date")?.text ?? "",
+      Date.now(),
+      zone,
+    );
+  for (const node of content.querySelectorAll(
+    ".forum-faq, .forum-faq-show-all, script, style",
+  ))
+    node.remove();
+  const body = text(
+    content.innerHTML
+      .replace(
+        /<h([1-6])[^>]*>([\s\S]*?)<\/h\1>/gi,
+        (_, level, heading) => `\n@@${level}:${text(heading)}\n`,
+      )
+      .replace(/<br\s*\/?>/gi, "\n"),
+  );
+  const thread = /\d+$/.exec(sourceUrl)[0];
+  const events = [];
+  const add = (kind, game, startsAt, endsAt, section, precision = "exact") => {
+    if (Math.abs(Date.parse(startsAt) - Date.parse(published)) > 60 * 86400_000)
+      throw new Error("Event too far from publication");
+    const suffix =
+      kind === "stash-sale"
+        ? "stash"
+        : `twitch-${createHash("sha256").update(section.toLowerCase().trim()).digest("hex").slice(0, 10)}`;
+    events.push({
+      id: `ggg-${thread}-${suffix}`,
+      kind,
+      game,
+      startsAt,
+      endsAt,
+      sourceUrl,
+      precision,
+    });
+  };
+
+  if (/stash(?:\s+tab)?\s+sale/i.test(body)) {
+    const ending =
+      /stash(?:\s+tab)?\s+sale\s+ends?\s+(?:at|on)\s+([^\n]+)/i.exec(body)?.[1];
+    if (!ending) throw new Error("Stash sale end missing");
+    const game = /both Path of Exile\s+1\s+and\s+2/i.test(body) ? "both" : null;
+    if (!game) throw new Error("Stash sale game scope missing");
+    add(
+      "stash-sale",
+      game,
+      published,
+      calendarTime(ending, published, zone),
+      "stash",
+      "derived-start",
+    );
+  }
+
+  if (/twitch\s+drops?/i.test(body)) {
+    // Keep section headings so Support-a-Streamer and quest ranges cannot become drops.
+    const chunks = body.split(/(?=\n@@[1-6]:)/);
+    let excluded = false;
+    let heading = "drops";
+    for (const chunk of chunks) {
+      const title = /^\s*@@[1-6]:([^\n]+)/.exec(chunk)?.[1];
+      if (title) {
+        heading = title;
+        if (/support a streamer|discord|quest|how do|faq/i.test(title))
+          excluded = true;
+        else if (/twitch|drops?|week\s*\d/i.test(title)) excluded = false;
+      }
+      if (excluded) continue;
+      const labelled = [
+        ...chunk.matchAll(
+          /Start Time:\s*([^\n]+)[\s\S]*?End Time:\s*([^\n]+)/gi,
+        ),
+      ];
+      for (const [index, match] of labelled.entries()) {
+        const starts = calendarTime(match[1], published);
+        add(
+          "twitch-drops",
+          twitchGame(chunk),
+          starts,
+          calendarTime(match[2], starts),
+          `${heading}:${index}`,
+        );
+      }
+      if (labelled.length) continue;
+      const range =
+        /Drops?\s+will\s+be\s+enabled\s+from\s+(.+?)\s+until\s+([^\n]+)/i.exec(
+          chunk,
+        );
+      if (range) {
+        const starts = calendarTime(range[1], published);
+        add(
+          "twitch-drops",
+          twitchGame(chunk),
+          starts,
+          calendarTime(range[2], starts),
+          heading,
+        );
+        continue;
+      }
+      const duration =
+        /Twitch Drops?\s+will\s+be\s+available\s+for\s+(\d+)\s+hours/i.exec(
+          chunk,
+        );
+      const ending = /Twitch Drops?\s+ends?\s+at\s+([^\n]+)/i.exec(chunk);
+      if (duration && ending && +duration[1] <= 168) {
+        // These posts supply an explicit local date with UTC offset after "or".
+        const end = calendarTime(ending[1], published, zone);
+        add(
+          "twitch-drops",
+          twitchGame(chunk),
+          new Date(Date.parse(end) - +duration[1] * 3600_000).toISOString(),
+          end,
+          heading,
+        );
+      }
+    }
+    if (!events.some((x) => x.kind === "twitch-drops"))
+      throw new Error("No supported Twitch date range");
+  }
+  if (!events.length) throw new Error("No supported promotion");
+  return parsePromotionFeed({
+    schemaVersion: 1,
+    generatedAt: new Date().toISOString(),
+    events,
+  }).events;
+}
+
+export function mergePromotions(previous, parsed, overrides, now = new Date()) {
+  if (
+    !overrides ||
+    !Array.isArray(overrides.events) ||
+    !Array.isArray(overrides.disabledIds) ||
+    !overrides.disabledIds.every((x) => typeof x === "string")
+  )
+    throw new Error("Invalid overrides");
+  const validate = (events) =>
+    parsePromotionFeed({
+      schemaVersion: 1,
+      generatedAt: now.toISOString(),
+      events,
+    }).events;
+  parsed = validate(parsed);
+  const manual = validate(overrides.events);
+  if (manual.some((event) => event.precision !== "manual"))
+    throw new Error("Overrides require manual precision");
+  const old = previous ? parsePromotionFeed(previous).events : [];
+  const byId = new Map(old.map((event) => [event.id, event]));
+  // A successfully reparsed source replaces all its sections (including deleted weeks).
+  for (const source of new Set(
+    parsed.map((x) => canonicalSource(x.sourceUrl)),
+  )) {
+    for (const [id, event] of byId)
+      if (canonicalSource(event.sourceUrl) === source) byId.delete(id);
+  }
+  for (const event of parsed) byId.set(event.id, event);
+  for (const event of manual) byId.set(event.id, event);
+  const disabled = new Set(overrides.disabledIds);
+  const disabledSchedules = new Set(
+    [...old, ...parsed, ...manual]
+      .filter((event) => disabled.has(event.id))
+      .map(scheduleKey),
+  );
+  const oldSchedules = new Map(old.map((event) => [scheduleKey(event), event]));
+  const campaigns = new Map();
+  for (const event of byId.values()) {
+    const signature = scheduleKey(event);
+    if (disabled.has(event.id) || disabledSchedules.has(signature)) continue;
+    const earlier = campaigns.get(signature);
+    if (!earlier || event.precision === "manual")
+      campaigns.set(signature, event);
+  }
+  // Keep an old ID for an unchanged reposted schedule, unless that ID now names
+  // a corrected schedule. Manual IDs are deliberately authoritative.
+  const result = [...campaigns.entries()].map(([key, event]) => {
+    const prior = oldSchedules.get(key);
+    return prior &&
+      event.precision !== "manual" &&
+      (!byId.has(prior.id) || scheduleKey(byId.get(prior.id)) === key)
+      ? { ...event, id: prior.id }
+      : event;
+  });
+  return parsePromotionFeed({
+    schemaVersion: 1,
+    generatedAt: now.toISOString(),
+    events: result
+      .filter((event) => Date.parse(event.endsAt) > now.getTime())
+      .sort((a, b) => a.startsAt.localeCompare(b.startsAt)),
+  });
+}

--- a/scripts/promotions/collector.test.mjs
+++ b/scripts/promotions/collector.test.mjs
@@ -1,0 +1,291 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { parseArticle, parseRss, mergePromotions } from "./collector.mjs";
+
+// Minimal structural fixtures from the GGG staff posts named below; times are facts.
+const article = (content, published = "Jul 24, 2026, 6:25:44 AM") =>
+  `<table><tr class="newsPost"><td><div class="content">${content}</div></td></tr><tr class="newsPostInfo"><td><span class="staff"></span><span class="post_date">${published}</span></td></tr></table><script>window.momentTimezone = 'Asia/Seoul';</script>`;
+const source = (id) => `https://www.pathofexile.com/forum/view-thread/${id}`;
+
+test("RSS decodes CDATA descriptions and ignores unrelated posts", () => {
+  const result = parseRss(
+    `<rss><channel><item><title>News</title><link>${source(1)}</link><description><![CDATA[<p>Stash Tab Sale</p>]]></description><pubDate>Thu, 03 Sep 2026 03:00:00 +0000</pubDate></item><item><title>Build Showcase</title></item></channel></rss>`,
+  );
+  assert.equal(result.length, 1);
+  assert.equal(result[0].url, source(1));
+  assert.throws(() => parseRss("<html>Checking your browser</html>"));
+});
+
+test("3987475 uses PDT and excludes Support a Streamer and cross-game FAQ", () => {
+  const html = article(
+    `<h1>Twitch Drops</h1><h3>Nautical Explorer Back Attachment</h3><strong>Start Time: July 24th 1:00 PM PDT</strong><br><strong>End Time: August 1st 4:59 AM PDT</strong><br>Path of Exile 1 category<h1>Support a Streamer</h1>Start Time: July 25th 1:00 PM PDT<br>End Time: August 2nd 1:00 PM PDT<div class="forum-faq">Path of Exile 2 category</div>`,
+  );
+  const [event] = parseArticle(html, source(3987475));
+  assert.equal(event.game, "poe1");
+  assert.equal(event.startsAt, "2026-07-24T20:00:00.000Z");
+  assert.equal(event.endsAt, "2026-08-01T11:59:00.000Z");
+  assert.equal(parseArticle(html, source(3987475)).length, 1);
+});
+
+test("separate weeks stay separate and retain IDs when a period is corrected", () => {
+  const html = article(
+    `<h1>Twitch Drops</h1><h2>Week 1</h2>Start Time: July 24th 1PM PDT<br>End Time: July 31st 1PM PDT<br>Path of Exile 2 category<h2>Week 2</h2>Start Time: July 31st 1PM PDT<br>End Time: August 7th 1PM PDT<br>Path of Exile 2 category`,
+  );
+  const events = parseArticle(html, source(2));
+  assert.equal(events.length, 2);
+  assert.notEqual(events[0].id, events[1].id);
+  assert.deepEqual(
+    parseArticle(html.replace("August 7th", "August 8th"), source(2)).map(
+      (x) => x.id,
+    ),
+    events.map((x) => x.id),
+  );
+});
+
+test("4000901 derives start only from an explicit 24-hour duration", () => {
+  const html = article(
+    `Twitch Drops will be available for 24 hours once the race begins. Path of Exile 1 stream. Twitch Drops end at 2PM PDT on September 4, or Sep 05, 2026 6:00 AM (GMT+9) in your local time.`,
+    "Sep 3, 2026, 12:00:00 PM",
+  );
+  const [event] = parseArticle(html, source(4000901));
+  assert.equal(event.startsAt, "2026-09-03T21:00:00.000Z");
+  assert.equal(event.endsAt, "2026-09-04T21:00:00.000Z");
+});
+
+test("4001078 reads the drops section without confusing realm/patch times", () => {
+  const html = article(
+    `<h1>Launch Information</h1>Sep 05, 2026 3:00 AM (GMT+9)<h1>New Twitch Drops</h1>Path of Exile 2 Directory<br>Drops will be enabled from September 4th 1PM PDT until September 11th 1PM PDT, or Sep 05, 2026 5:00 AM (GMT+9) until Sep 12, 2026 5:00 AM (GMT+9) in your local time.`,
+    "Sep 4, 2026, 7:30:00 AM",
+  );
+  const [event] = parseArticle(html, source(4001078));
+  assert.equal(event.game, "poe2");
+  assert.equal(event.startsAt, "2026-09-04T20:00:00.000Z");
+  assert.equal(event.endsAt, "2026-09-11T20:00:00.000Z");
+});
+
+test("3926103 derives stash start from publication in declared source timezone", () => {
+  const html = article(
+    `Stash Tab Sale<br>The Stash Tab sale ends at <strong>Apr 07, 2026 10:00 AM (GMT+9)</strong><br>both Path of Exile 1 and 2`,
+    "Apr 3, 2026, 9:00:00 AM",
+  );
+  const [event] = parseArticle(html, source(3926103));
+  assert.equal(event.game, "both");
+  assert.equal(event.precision, "derived-start");
+  assert.equal(event.startsAt, "2026-04-03T00:00:00.000Z");
+  assert.equal(event.endsAt, "2026-04-07T01:00:00.000Z");
+  assert.throws(() =>
+    parseArticle(
+      html.replace("window.momentTimezone", "unknown"),
+      source(3926103),
+    ),
+  );
+});
+
+test("unknown game, missing boundaries and non-staff HTML cannot publish", () => {
+  assert.throws(() =>
+    parseArticle(
+      article(
+        "Twitch Drops Start Time: July 24th 1PM PDT<br>End Time: July 31st 1PM PDT",
+      ),
+      source(3),
+    ),
+  );
+  assert.throws(() =>
+    parseArticle(article("Twitch Drops Path of Exile 2 category"), source(3)),
+  );
+  assert.throws(() => parseArticle("<html>Just a moment</html>", source(3)));
+});
+
+test("the same sale from an Eastern-time source yields identical UTC bounds", () => {
+  const html = article(
+    "Stash Tab Sale<br>The Stash Tab sale ends at Apr 06, 2026 9:00 PM (EDT)<br>both Path of Exile 1 and 2",
+    "Apr 2, 2026, 8:00:00 PM",
+  ).replace("Asia/Seoul", "America/New_York");
+  const [event] = parseArticle(html, source(3926103));
+  assert.equal(event.startsAt, "2026-04-03T00:00:00.000Z");
+  assert.equal(event.endsAt, "2026-04-07T01:00:00.000Z");
+});
+
+test("overrides win; disabled IDs stay removed; reposts do not duplicate campaigns", () => {
+  const now = new Date("2026-09-04T02:00:00Z");
+  const base = {
+    id: "ggg-1-stash",
+    kind: "stash-sale",
+    game: "both",
+    startsAt: "2026-09-04T00:00:00Z",
+    endsAt: "2026-09-08T00:00:00Z",
+    sourceUrl: source(1),
+    precision: "derived-start",
+  };
+  const previous = {
+    schemaVersion: 1,
+    generatedAt: "2026-09-04T00:00:00Z",
+    events: [base],
+  };
+  const repost = {
+    ...base,
+    id: "ggg-2-stash",
+    sourceUrl: source(2),
+    startsAt: "2026-09-04T00:00:00.000Z",
+  };
+  const result = mergePromotions(
+    previous,
+    [repost],
+    { events: [], disabledIds: [] },
+    now,
+  );
+  assert.equal(result.events.length, 1);
+  assert.equal(result.events[0].id, base.id);
+  assert.equal(
+    mergePromotions(previous, [], { events: [], disabledIds: [base.id] }, now)
+      .events.length,
+    0,
+  );
+  assert.equal(
+    mergePromotions(
+      previous,
+      [],
+      {
+        events: [
+          { ...base, precision: "manual", endsAt: "2026-09-09T00:00:00Z" },
+        ],
+        disabledIds: [],
+      },
+      now,
+    ).events[0].endsAt,
+    "2026-09-09T00:00:00Z",
+  );
+});
+
+test("a staff reply cannot authenticate a non-staff original post", () => {
+  const html =
+    article(
+      "Twitch Drops Start Time: July 24th 1PM PDT<br>End Time: July 31st 1PM PDT<br>Path of Exile 1 category",
+    ).replace('<span class="staff"></span>', "") +
+    '<tr class="newsPostInfo"><td><span class="staff"></span></td></tr>';
+  assert.throws(() => parseArticle(html, source(4)), /staff/i);
+});
+
+const sale = {
+  id: "ggg-1-stash",
+  kind: "stash-sale",
+  game: "both",
+  startsAt: "2026-09-04T00:00:00Z",
+  endsAt: "2026-09-08T00:00:00Z",
+  sourceUrl: source(1),
+  precision: "derived-start",
+};
+const previousFeed = (events) => ({
+  schemaVersion: 1,
+  generatedAt: "2026-09-04T00:00:00Z",
+  events,
+});
+const now = new Date("2026-09-04T01:00:00Z");
+const overrides = { events: [], disabledIds: [] };
+
+test("different stash starts are different schedules", () => {
+  const result = mergePromotions(
+    previousFeed([sale]),
+    [
+      {
+        ...sale,
+        id: "ggg-2-stash",
+        sourceUrl: source(2),
+        startsAt: "2026-09-04T01:00:00Z",
+      },
+    ],
+    overrides,
+    now,
+  );
+  assert.equal(result.events.length, 2);
+});
+
+test("canonical source replacement removes deleted sections", () => {
+  const old = [
+    sale,
+    { ...sale, id: "deleted", startsAt: "2026-09-05T00:00:00Z" },
+  ].map((event) => ({
+    ...event,
+    sourceUrl: `${source(1)}/filter-account-type/staff`,
+  }));
+  assert.deepEqual(
+    mergePromotions(previousFeed(old), [sale], overrides, now).events,
+    [sale],
+  );
+});
+
+test("manual schedules take precedence and cannot duplicate automatic schedules", () => {
+  const manual = { ...sale, id: "manual-copy", precision: "manual" };
+  assert.deepEqual(
+    mergePromotions(
+      previousFeed([sale]),
+      [],
+      { ...overrides, events: [manual] },
+      now,
+    ).events,
+    [manual],
+  );
+});
+
+test("a disabled prior ID cannot return via a duplicate repost", () => {
+  const repost = { ...sale, id: "repost", sourceUrl: source(2) };
+  assert.equal(
+    mergePromotions(
+      previousFeed([sale]),
+      [repost],
+      { ...overrides, disabledIds: [sale.id] },
+      now,
+    ).events.length,
+    0,
+  );
+});
+
+test("invalid or non-manual overrides fail before expiry/disabled filtering", () => {
+  for (const event of [{ ...sale, endsAt: "invalid" }, sale]) {
+    assert.throws(() =>
+      mergePromotions(
+        null,
+        [],
+        { events: [event], disabledIds: [event.id] },
+        now,
+      ),
+    );
+  }
+});
+
+test("ended schedules are removed at the exact boundary; active and upcoming remain", () => {
+  const expired = {
+    ...sale,
+    id: "old",
+    startsAt: "2026-09-03T00:00:00Z",
+    endsAt: "2026-09-04T01:00:00Z",
+  };
+  const upcoming = {
+    ...sale,
+    id: "upcoming",
+    startsAt: "2026-09-05T00:00:00Z",
+  };
+  assert.deepEqual(
+    mergePromotions(previousFeed([expired, sale, upcoming]), [], overrides, now)
+      .events,
+    [sale, upcoming],
+  );
+});
+
+test("winter PST, year rollover and DST-invalid dates are handled explicitly", () => {
+  const body =
+    "Twitch Drops Start Time: December 31st 11PM PST<br>End Time: January 1st 1AM PST<br>Path of Exile 1 category";
+  const [event] = parseArticle(
+    article(body, "Dec 30, 2026, 9:00:00 AM"),
+    source(5),
+  );
+  assert.equal(event.startsAt, "2027-01-01T07:00:00.000Z");
+  assert.equal(event.endsAt, "2027-01-01T09:00:00.000Z");
+  for (const date of ["Mar 8, 2026, 2:30:00 AM", "Nov 1, 2026, 1:30:00 AM"]) {
+    const html = article(
+      "Stash Tab Sale<br>The Stash Tab sale ends at Nov 2, 2026 9PM EST<br>both Path of Exile 1 and 2",
+      date,
+    ).replace("Asia/Seoul", "America/New_York");
+    assert.throws(() => parseArticle(html, source(6)), /local source date/);
+  }
+});

--- a/scripts/promotions/contract.mjs
+++ b/scripts/promotions/contract.mjs
@@ -1,0 +1,68 @@
+// schemaVersion 1 consumer contract, mirrored from src/shared/promotions.ts.
+// Keep this collector deployable before the launcher feature is merged.
+export const scheduleKey = (event) =>
+  `${event.kind}:${event.game}:${Date.parse(event.startsAt)}:${Date.parse(event.endsAt)}`;
+
+function record(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? value
+    : {};
+}
+
+export function isUtcInstant(value) {
+  if (
+    typeof value !== "string" ||
+    !/^\d{4}-\d\d-\d\dT\d\d:\d\d:\d\d(?:\.\d{3})?Z$/.test(value)
+  )
+    return false;
+  const time = Date.parse(value);
+  return (
+    Number.isFinite(time) &&
+    new Date(time).toISOString() === value.replace(/(?<=:\d\d)Z$/, ".000Z")
+  );
+}
+
+export function parsePromotionFeed(value) {
+  const feed = record(value);
+  if (
+    feed.schemaVersion !== 1 ||
+    !isUtcInstant(feed.generatedAt) ||
+    !Array.isArray(feed.events) ||
+    feed.events.length > 200
+  ) {
+    throw new Error("Invalid promotion feed");
+  }
+  const ids = new Set();
+  const events = feed.events.map((entry) => {
+    const item = record(entry);
+    if (
+      typeof item.id !== "string" ||
+      !/^[a-z0-9:-]{1,160}$/.test(item.id) ||
+      ids.has(item.id) ||
+      !["twitch-drops", "stash-sale"].includes(item.kind) ||
+      !["poe1", "poe2", "both"].includes(item.game) ||
+      (item.kind === "twitch-drops" && item.game === "both") ||
+      !["exact", "derived-start", "manual"].includes(item.precision) ||
+      !isUtcInstant(item.startsAt) ||
+      !isUtcInstant(item.endsAt) ||
+      Date.parse(item.endsAt) <= Date.parse(item.startsAt) ||
+      Date.parse(item.endsAt) - Date.parse(item.startsAt) > 90 * 86400_000 ||
+      typeof item.sourceUrl !== "string" ||
+      !/^https:\/\/www\.pathofexile\.com\/forum\/view-thread\/\d+(?:\/filter-account-type\/staff)?$/.test(
+        item.sourceUrl,
+      )
+    )
+      throw new Error("Invalid promotion event");
+    ids.add(item.id);
+    return {
+      id: item.id,
+      kind: item.kind,
+      game: item.game,
+      startsAt: item.startsAt,
+      endsAt: item.endsAt,
+      sourceUrl: item.sourceUrl,
+      precision: item.precision,
+    };
+  });
+  return { schemaVersion: 1, generatedAt: feed.generatedAt, events };
+}

--- a/scripts/promotions/contract.test.mjs
+++ b/scripts/promotions/contract.test.mjs
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { parsePromotionFeed } from "./contract.mjs";
+
+const event = {
+  id: "ggg-4000901-twitch-471bcf3ba0",
+  kind: "twitch-drops",
+  game: "poe1",
+  startsAt: "2026-09-03T21:00:00Z",
+  endsAt: "2026-09-04T21:00:00.000Z",
+  sourceUrl: "https://www.pathofexile.com/forum/view-thread/4000901",
+  precision: "exact",
+};
+const feed = {
+  schemaVersion: 1,
+  generatedAt: "2026-09-04T08:00:00Z",
+  events: [event],
+};
+const invalid = [
+  null,
+  {},
+  [],
+  { ...feed, schemaVersion: 2 },
+  { ...feed, generatedAt: "2026-02-30T00:00:00Z" },
+  { ...feed, events: [event, event] },
+  { ...feed, events: Array(201).fill(event) },
+  ...[
+    { id: "" },
+    { id: "x".repeat(161) },
+    { id: "Uppercase" },
+    { kind: "unknown" },
+    { game: "both" },
+    { game: "poe3" },
+    { precision: "guessed" },
+    { startsAt: "2026-09-03T21:00:00+00:00" },
+    { endsAt: "2026-02-30T21:00:00Z" },
+    { endsAt: event.startsAt },
+    { endsAt: "2027-09-04T21:00:00Z" },
+    { sourceUrl: "https://example.com/forum/view-thread/1" },
+    { sourceUrl: event.sourceUrl + "?x=1" },
+  ].map((change) => ({ ...feed, events: [{ ...event, ...change }] })),
+];
+const valid = [
+  feed,
+  { ...feed, events: [] },
+  { ...feed, events: [{ ...event, game: "poe2", precision: "manual" }] },
+  {
+    ...feed,
+    events: [
+      {
+        ...event,
+        kind: "stash-sale",
+        game: "both",
+        precision: "derived-start",
+        sourceUrl: event.sourceUrl + "/filter-account-type/staff",
+      },
+    ],
+  },
+];
+
+test("schema v1 accepts supported payloads and rejects malformed events", () => {
+  for (const input of valid) assert.deepEqual(parsePromotionFeed(input), input);
+  for (const input of invalid) assert.throws(() => parsePromotionFeed(input));
+});
+
+test("validator matches the actual launcher consumer when available", async (t) => {
+  const path = resolve(
+    process.env.PROMOTIONS_CONSUMER_MODULE ?? "src/shared/promotions.ts",
+  );
+  if (!existsSync(path)) {
+    if (process.env.PROMOTIONS_CONSUMER_MODULE)
+      throw new Error("Explicit consumer module missing");
+    t.skip(
+      "Launcher feature not merged yet; pass PROMOTIONS_CONSUMER_MODULE for cross-worktree comparison",
+    );
+    return;
+  }
+  const consumer = await import(pathToFileURL(path).href);
+  for (const input of valid)
+    assert.deepEqual(
+      parsePromotionFeed(input),
+      consumer.parsePromotionFeed(input),
+    );
+  for (const input of invalid)
+    assert.throws(() => consumer.parsePromotionFeed(input));
+});

--- a/scripts/promotions/overrides.json
+++ b/scripts/promotions/overrides.json
@@ -1,0 +1,4 @@
+{
+  "events": [],
+  "disabledIds": []
+}

--- a/scripts/promotions/publish.mjs
+++ b/scripts/promotions/publish.mjs
@@ -1,0 +1,76 @@
+import { execFileSync } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { parsePromotionFeed } from "./contract.mjs";
+
+// Explicit publishing command. collect.mjs never calls this module.
+export function publishFeed({ pages, input, revision }) {
+  const feed = parsePromotionFeed(JSON.parse(readFileSync(input, "utf8")));
+  if (!/^[a-f0-9]{40}$/.test(revision ?? ""))
+    throw new Error("Expected collection revision SHA");
+  const git = (...args) =>
+    execFileSync("git", args, {
+      cwd: pages,
+      encoding: "utf8",
+      windowsHide: true,
+      stdio: ["ignore", "pipe", "pipe"],
+    }).trim();
+  if (git("branch", "--show-current") !== "gh-pages")
+    throw new Error("Expected gh-pages checkout");
+  if (git("status", "--porcelain", "--untracked-files=all"))
+    throw new Error("Pages checkout must be clean");
+  if (git("rev-parse", "HEAD") !== revision)
+    throw new Error("Collection revision no longer matches checkout");
+  git("fetch", "origin", "gh-pages");
+  if (
+    git(
+      "diff",
+      "--name-only",
+      revision,
+      "origin/gh-pages",
+      "--",
+      "promotions.json",
+    )
+  )
+    throw new Error(
+      "Remote promotions.json changed during collection; collect again",
+    );
+  git("merge", "--ff-only", "origin/gh-pages");
+  writeFileSync(
+    join(pages, "promotions.json"),
+    `${JSON.stringify(feed, null, 2)}\n`,
+  );
+  git("add", "--", "promotions.json");
+  const changed = git("diff", "--cached", "--name-only");
+  if (!changed) return { changed: false, revision: git("rev-parse", "HEAD") };
+  if (changed !== "promotions.json")
+    throw new Error("Unexpected staged Pages changes");
+  git("config", "user.name", "github-actions[bot]");
+  git("config", "user.email", "github-actions[bot]@users.noreply.github.com");
+  git("commit", "-m", "chore: update event promotions");
+  // A competing push is a hard failure; never force-push or merge JSON after collection.
+  git("push", "origin", "HEAD:gh-pages");
+  return { changed: true, revision: git("rev-parse", "HEAD") };
+}
+
+if (
+  process.argv[1] &&
+  resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+  try {
+    const [pages, input, revision, ...extra] = process.argv.slice(2);
+    if (!pages || !input || !revision || extra.length)
+      throw new Error(
+        "Usage: node scripts/promotions/publish.mjs <pages-checkout> <candidate.json> <collection-revision>",
+      );
+    console.log(
+      JSON.stringify(
+        publishFeed({ pages: resolve(pages), input: resolve(input), revision }),
+      ),
+    );
+  } catch (error) {
+    console.error(error.message);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/promotions/publish.test.mjs
+++ b/scripts/promotions/publish.test.mjs
@@ -1,0 +1,131 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { execFileSync } from "node:child_process";
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  readFileSync,
+  rmSync,
+  realpathSync,
+} from "node:fs";
+import { join, resolve, sep } from "node:path";
+import { publishFeed } from "./publish.mjs";
+
+const feed = {
+  schemaVersion: 1,
+  generatedAt: "2026-09-04T08:00:00Z",
+  events: [],
+};
+const git = (cwd, ...args) =>
+  execFileSync("git", args, {
+    cwd,
+    encoding: "utf8",
+    windowsHide: true,
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+function repo(t, initialFeed = false) {
+  const parent = resolve(".tmp");
+  mkdirSync(parent, { recursive: true });
+  const root = mkdtempSync(join(parent, "promotions-git-test-"));
+  t.after(() => {
+    assert.ok(realpathSync(root).startsWith(realpathSync(parent) + sep));
+    rmSync(root, { recursive: true, force: true });
+  });
+  const origin = join(root, "origin.git"),
+    pages = join(root, "pages"),
+    other = join(root, "other");
+  git(root, "init", "--bare", origin);
+  git(root, "clone", origin, pages);
+  git(pages, "switch", "-c", "gh-pages");
+  git(pages, "config", "user.name", "Test");
+  git(pages, "config", "user.email", "test@example.invalid");
+  writeFileSync(join(pages, "index.html"), "original site");
+  if (initialFeed)
+    writeFileSync(join(pages, "promotions.json"), JSON.stringify(feed));
+  git(pages, "add", ".");
+  git(pages, "commit", "-m", "initial");
+  git(pages, "push", "origin", "gh-pages");
+  git(root, "clone", "--branch", "gh-pages", origin, other);
+  git(other, "config", "user.name", "Test");
+  git(other, "config", "user.email", "test@example.invalid");
+  const revision = git(pages, "rev-parse", "HEAD");
+  const input = join(root, "candidate.json");
+  writeFileSync(
+    input,
+    JSON.stringify({ ...feed, generatedAt: "2026-09-04T09:00:00Z" }),
+  );
+  return { root, origin, pages, other, revision, input };
+}
+const remoteWrite = (r, file, value) => {
+  writeFileSync(join(r.other, file), value);
+  git(r.other, "add", file);
+  git(r.other, "commit", "-m", "concurrent update");
+  git(r.other, "push", "origin", "gh-pages");
+};
+
+test("initial publication writes only promotions.json and identical repeat is a no-op", (t) => {
+  const r = repo(t);
+  assert.equal(publishFeed(r).changed, true);
+  assert.equal(
+    git(r.pages, "diff", "--name-only", r.revision, "HEAD"),
+    "promotions.json",
+  );
+  assert.equal(
+    readFileSync(join(r.pages, "index.html"), "utf8"),
+    "original site",
+  );
+  assert.equal(
+    git(r.origin, "rev-parse", "gh-pages"),
+    git(r.pages, "rev-parse", "HEAD"),
+  );
+  assert.equal(
+    publishFeed({ ...r, revision: git(r.pages, "rev-parse", "HEAD") }).changed,
+    false,
+  );
+});
+
+test("concurrent site changes survive in the published branch", (t) => {
+  const r = repo(t);
+  remoteWrite(r, "themes.json", '{"theme":"preserve me"}');
+  publishFeed(r);
+  assert.equal(
+    git(r.origin, "show", "gh-pages:themes.json"),
+    '{"theme":"preserve me"}',
+  );
+  assert.equal(
+    git(r.pages, "diff", "--name-only", "HEAD^", "HEAD"),
+    "promotions.json",
+  );
+});
+
+test("a concurrent feed edit aborts instead of merging stale JSON", (t) => {
+  const r = repo(t, true);
+  const replacement = JSON.stringify({
+    ...feed,
+    generatedAt: "2026-09-04T10:00:00Z",
+  });
+  remoteWrite(r, "promotions.json", replacement);
+  assert.throws(() => publishFeed(r), /changed during collection/);
+  assert.equal(git(r.origin, "show", "gh-pages:promotions.json"), replacement);
+});
+
+test("invalid JSON and dirty checkout cannot modify the remote", (t) => {
+  const r = repo(t, true);
+  writeFileSync(r.input, '{"schemaVersion":2}');
+  assert.throws(() => publishFeed(r), /Invalid promotion feed/);
+  assert.equal(git(r.origin, "rev-parse", "gh-pages"), r.revision);
+  writeFileSync(r.input, JSON.stringify(feed));
+  writeFileSync(join(r.pages, "unknown.txt"), "preserve");
+  assert.throws(() => publishFeed(r), /clean/);
+  assert.equal(git(r.origin, "rev-parse", "gh-pages"), r.revision);
+});
+
+test("failed push is reported without overwriting the remote feed", (t) => {
+  const r = repo(t, true);
+  writeFileSync(join(r.origin, "hooks", "pre-receive"), "#!/bin/sh\nexit 1\n", {
+    mode: 0o755,
+  });
+  assert.throws(() => publishFeed(r), /push/);
+  assert.equal(git(r.origin, "rev-parse", "gh-pages"), r.revision);
+});

--- a/scripts/promotions/verify-published.mjs
+++ b/scripts/promotions/verify-published.mjs
@@ -1,0 +1,58 @@
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { setTimeout as delay } from "node:timers/promises";
+import { parsePromotionFeed } from "./contract.mjs";
+
+export const PUBLIC_URL =
+  "https://nerdhead-lab.github.io/POE2-unofficial-launcher/promotions.json";
+
+export async function verifyPublished(
+  expected,
+  {
+    attempts = 20,
+    fetchResponse = () =>
+      fetch(PUBLIC_URL, {
+        headers: { Accept: "application/json", "Cache-Control": "no-cache" },
+        redirect: "error",
+        signal: AbortSignal.timeout(15_000),
+      }),
+    pause = () => delay(15_000),
+  } = {},
+) {
+  const wanted = JSON.stringify(parsePromotionFeed(expected));
+  let failure = "No response";
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    try {
+      const response = await fetchResponse();
+      if (response.status !== 200) throw new Error(`HTTP ${response.status}`);
+      const body = await response.text();
+      if (Buffer.byteLength(body) > 256 * 1024)
+        throw new Error("Public feed too large");
+      if (JSON.stringify(parsePromotionFeed(JSON.parse(body))) !== wanted)
+        throw new Error("Public feed differs from collected feed");
+      return;
+    } catch (error) {
+      failure = error.message;
+    }
+    if (attempt + 1 < attempts) await pause();
+  }
+  throw new Error(`Public promotions.json not verified: ${failure}`);
+}
+
+if (
+  process.argv[1] &&
+  resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+  try {
+    if (process.argv.length !== 3)
+      throw new Error(
+        "Usage: node scripts/promotions/verify-published.mjs <candidate.json>",
+      );
+    await verifyPublished(JSON.parse(await readFile(process.argv[2], "utf8")));
+    console.log(`HTTP 200 and validated contents match: ${PUBLIC_URL}`);
+  } catch (error) {
+    console.error(error.message);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/promotions/verify-published.test.mjs
+++ b/scripts/promotions/verify-published.test.mjs
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { verifyPublished } from "./verify-published.mjs";
+
+const expected = {
+  schemaVersion: 1,
+  generatedAt: "2026-09-04T08:00:00Z",
+  events: [],
+};
+test("public verification waits through 404 and stale JSON until exact validated content arrives", async () => {
+  const responses = [
+    new Response("", { status: 404 }),
+    Response.json({ ...expected, generatedAt: "2026-09-03T08:00:00Z" }),
+    Response.json(expected),
+  ];
+  let calls = 0;
+  await verifyPublished(expected, {
+    fetchResponse: async () => responses[calls++],
+    pause: async () => {},
+  });
+  assert.equal(calls, 3);
+});
+test("invalid or unchanged public responses fail within the retry bound", async () => {
+  let calls = 0;
+  await assert.rejects(
+    verifyPublished(expected, {
+      attempts: 2,
+      fetchResponse: async () => {
+        calls++;
+        return Response.json({ schemaVersion: 2 });
+      },
+      pause: async () => {},
+    }),
+    /not verified/,
+  );
+  assert.equal(calls, 2);
+});


### PR DESCRIPTION
## Summary

공식 GGG 공지에서 트위치 드롭스와 보관함 할인 일정을 수집하고, 6시간마다 `gh-pages/promotions.json`을 갱신하는 단일 Actions workflow를 추가합니다. 진행·예정 일정만 유지하며 종료된 일정은 다음 정상 수집에서 제거합니다.

발견 실패 시 기존 피드를 보존하고, 원문별 실패·재공지 중복·수동 제외를 처리합니다. 발행 중 다른 사이트 변경은 보존하고 피드 경합은 중단하며, Pages 빌드와 공개 HTTP 200/내용 일치까지 확인합니다. 로컬 회귀 검사 36개, 실제 GGG 수집 및 런처 JSON 계약 대조, 분리 리뷰를 통과했습니다.

## Motivation

런처가 GGG를 직접 크롤링하지 않고 공통 JSON을 소비하도록 수집 책임을 중앙화합니다. 기존 schemaVersion 1과 소비 URL, 사이트·테마·릴리스 자동화를 유지하며, 미커밋 런처 기능과 독립적으로 수집기를 적용할 수 있게 합니다.
