### PR TITLE
chore: 공식 상점 API 기반 보관함 할인 수집 및 예상 일정 유지

### DIFF
--- a/.github/workflows/update-promotions.yml
+++ b/.github/workflows/update-promotions.yml
@@ -70,7 +70,7 @@ jobs:
         id: base
         working-directory: pages
         run: echo "revision=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-      - name: Collect official GGG events
+      - name: Collect official Twitch drops and shop sale observations
         run: node scripts/promotions/collect.mjs --previous pages/promotions.json --output .tmp/promotions-candidate.json
       - name: Publish only the validated feed
         env:

--- a/scripts/promotions/README.md
+++ b/scripts/promotions/README.md
@@ -1,6 +1,6 @@
 # GGG 이벤트 피드
 
-공식 GGG 공지에서 Twitch Drops와 보관함 할인을 읽어 런처용 `promotions.json`을 만든다. 수집 코드와 스케줄러는 **master**, 공개 결과는 **gh-pages 루트**에 둔다. 두 브랜치는 같은 GitHub 저장소에 있다.
+공식 GGG 공지에서 Twitch Drops를, 공식 상점 API에서 보관함 할인을 읽어 런처용 `promotions.json`을 만든다. 수집 코드와 스케줄러는 **master**, 공개 결과는 **gh-pages 루트**에 둔다. 두 브랜치는 같은 GitHub 저장소에 있다.
 
 ## 로컬 실행
 
@@ -22,7 +22,7 @@ try { node --test scripts/promotions/*.test.mjs }
 finally { Remove-Item Env:PROMOTIONS_CONSUMER_MODULE }
 ```
 
-소비자 파일이 없는 브랜치에서는 이 비교 한 건만 명시적으로 skip한다. 독립 계약 검사는 항상 실행한다. 지정한 파일이 없으면 실패한다.
+소비자 파일이 없는 브랜치에서는 이 비교 한 건만 명시적으로 skip한다. 독립 계약 검사는 항상 실행한다. 지정한 파일이 없으면 실패한다. 소비자가 확장자 없는 TypeScript import를 사용하면 해당 작업의 esbuild로 `.tmp`에 번들한 `.mjs` 경로를 지정한다. `fixtures/stash-sales-contract.json`의 수동/확정/실패/만료 샘플과 잘못된 입력을 양쪽 검증기에 대조한다. 이전 schema 1 검증기와의 드롭스 호환성은 별도 고정 fixture로 확인한다.
 
 ## 수집과 실패 처리
 
@@ -30,28 +30,55 @@ finally { Remove-Item Env:PROMOTIONS_CONSUMER_MODULE }
 - 요청은 직렬이며 500ms 간격, 요청당 15초와 2MiB, 전체 후보 60개로 제한한다. 무제한 과거 탐색이나 계정 로그인은 없다. 범위 밖의 오래된 미종료 공지를 모두 찾는다는 보장은 없다.
 - `/filter-account-type/staff` 응답의 첫 `.newsPost` 본문과 바로 뒤 작성자 정보의 staff 표시를 함께 확인한다. FAQ/다른 보상 섹션/사용자 댓글을 이벤트로 사용하지 않는다.
 - Drops의 `Start Time`/`End Time`, `from … until …`, 명시적인 시간 수와 종료 시각을 지원한다. 시청할 게임의 category/directory/stream 문구로 게임을 판정한다. 다른 게임에서도 보상을 쓴다는 FAQ는 게임 판정에 사용하지 않는다.
-- 보관함 할인은 `Stash Tab Sale ends at/on …`과 양 게임 적용 문구가 명시된 글을 지원한다. 시작은 RSS 또는 원문 게시 시각이며 `derived-start`다. 지원하지 않는 표현이나 불확실한 게임·기간은 경고로 남기고 추측하지 않는다.
-- 발견 요청 실패/챌린지 페이지/잘못된 입력/후보 초과는 전체 실행을 실패시킨다. 개별 원문 실패는 그 원문의 마지막 정상 일정을 유지하며 다른 원문은 갱신할 수 있다. 최초 실행에서 실패만 있고 검증한 일정도 없으면 발행하지 않는다.
-- 원문이 정상적으로 다시 파싱되면 해당 원문의 이전 섹션을 교체한다. 실패 시에는 이전 미종료 일정을 유지한다. **종료 시각이 수집 시각 이하인 일정은 매 수집에서 제거**하여 공개 JSON에는 진행·예정 일정만 유지한다. 200건을 넘는 출력은 발행하지 않는다. 발견 단계 자체가 실패하면 이전 공개 파일을 보존하므로 만료 정리는 다음 정상 실행에서 이루어진다. 런처의 로컬 종료 판정은 이 지연과 무관하다.
+- 정기 RSS/포럼 수집은 **Twitch Drops만** 처리한다. 보관함 공지 파서는 제거했으며, 기존 피드의 legacy `stash-sale` 이벤트도 산출 `events`에서 제거한다. 지원하지 않는 드롭스 표현은 추측하지 않는다.
+- 발견 요청 실패/챌린지/후보 초과는 드롭스 수집 부분만 실패시킨다. 기존 검증 드롭스를 유지하고 상점 수집을 계속한다. 개별 원문 실패는 그 원문의 마지막 정상 일정을 유지하며 다른 원문은 갱신할 수 있다. 상점 실패도 드롭스 갱신을 막지 않는다. 최초 실행의 원격 요청이 모두 실패해도 `unavailable` 관측과 출처가 명시된 수동 기준만 만들며 API 확정을 만들지 않는다.
+- 원문이 정상적으로 다시 파싱되면 해당 원문의 이전 섹션을 교체한다. **종료 시각이 수집 완료 시각 이하인 일정은 매 수집에서 제거**한다. 잘못된 이전 JSON/계약/수동 설정과 200건 초과 출력은 전체 교체를 막는다. 런처도 로컬 시각으로 종료를 판정한다.
+
+### 상점 API와 관측
+
+| 서비스/게임 | 정확한 공식 URL                                                               | 관측 방식                                                |
+| ----------- | ----------------------------------------------------------------------------- | -------------------------------------------------------- |
+| GGG PoE2    | `https://pathofexile2.com/api/shop-microtransactions?game=poe2`               | 개인 보관함 태그, `cost < baseCost`, `special.start/end` |
+| Kakao PoE2  | `https://poe2.kakaogames.com/api/shop-microtransactions?game=poe2`            | 위와 동일                                                |
+| GGG PoE1    | `https://www.pathofexile.com/api/shop-microtransaction-categories/stash-tabs` | 식별된 개인 상품, `onSpecial`, `cost < originalCost`     |
+| Kakao PoE1  | `https://poe.kakaogames.com/api/shop-microtransaction-categories/stash-tabs`  | 위와 동일                                                |
+
+PoE2 태그는 `StashTabs` 또는 `PoE2StashTabs` **정확히 일치**해야 한다. 변형 상품은 자신의 태그가 없을 때만 부모 태그를 사용한다. 길드 상품, 무기 효과, 상시 묶음할인 `discount`는 제외한다. 동일 기간의 상품 ID를 모으며 서로 다른 할인 기간이 섞이거나 응답 구조가 손상되면 해당 관측을 실패 처리한다. 전체 상품에 기간이 있다는 가정이나 다른 상품의 기간 복사는 하지 않는다.
+
+2026-09-04 사전조사에서 PoE1 category API에는 가격/할인 여부만 있고 기간이 없었다. `game=poe`는 400, `game=poe1`은 503이라 PoE2 API의 PoE1 지원으로 간주하지 않는다. PoE1은 확인된 개인 상품 ID 목록만 사용하며 새 상품은 별도 확인 후 목록에 추가한다. 정상 정가는 `ok + null`, 할인 중이지만 기간 없음은 `period-unavailable + null`이다. 403/503/HTML/불완전한 목록은 `unavailable`이며 정상 할인 없음과 구분한다. 로그인이나 차단 우회는 하지 않는다.
+
+각 성공 관측의 `checkedAt`은 응답 완료 시각이다. 실패하면 이전 성공 시각과 아직 끝나지 않은 확정 기간을 보존한다. 이력이 없으면 실패 시도 시각을 쓰고 확정 기간은 `null`이다. 만료된 확정 기간은 실패 중에도 제거하되 마지막 기준 기록은 남긴다.
 
 ## JSON 계약과 수동 조정
 
 공개 URL은 [promotions.json](https://nerdhead-lab.github.io/POE2-unofficial-launcher/promotions.json)이다. schema 변경이나 URL 변경은 소비 런처와 사전 동기화가 필요하다.
 
-- 최상위: `schemaVersion: 1`, UTC ISO `generatedAt`, `events` 배열(최대 200건).
+- 최상위: `schemaVersion: 1`, UTC ISO `generatedAt`, `events` 배열(최대 200건), optional `stashSales`. 이전 소비자는 추가 필드를 무시하고 드롭스를 계속 읽는다.
 - 이벤트: `id`, `kind`(`twitch-drops`/`stash-sale`), `game`(`poe1`/`poe2`/`both`), UTC ISO `startsAt`/`endsAt`, 공식 forum thread `sourceUrl`, `precision`(`exact`/`derived-start`/`manual`). Drops에는 `both`를 허용하지 않는다.
 - ID는 `[a-z0-9:-]` 1–160자, 중복 불가. 종료는 시작보다 뒤이고 기간은 최대 90일. UTC 문자열은 초 또는 밀리초 3자리와 `Z`를 사용한다.
 - 동일 일정은 **종류 + 게임 + 시작 UTC epoch + 종료 UTC epoch**다. 같은 일정의 재공지는 하나로 합치고 가능한 경우 기존 ID를 유지한다. 기간이 달라지면 별도 일정으로 취급한다. 자동 ID는 스레드/섹션 기반이며 일반적인 기간 정정에서 유지된다.
 
-`overrides.json`의 `events`에는 공식 출처와 전체 필드를 가진 `precision: "manual"` 이벤트를 넣는다. 같은 ID를 교체하며 동일 일정의 자동 항목보다 우선한다. 수동 입력도 필터링 전에 계약을 검증한다. 원래 자동 일정을 취소하고 다른 ID로 정정하려면 자동 ID를 `disabledIds`에도 명시한다.
+`overrides.json`의 `events`에는 공식 출처와 전체 필드를 가진 `precision: "manual"` **드롭스** 이벤트를 넣는다. 같은 ID를 교체하며 동일 일정의 자동 항목보다 우선한다. 수동 입력도 필터링 전에 계약을 검증한다. 원래 자동 일정을 취소하고 다른 ID로 정정하려면 자동 ID를 `disabledIds`에도 명시한다.
 
-`disabledIds`에 지정한 ID 및 현재 확인 가능한 같은 일정의 재공지들을 제외한다. `ggg-{thread}-…` ID는 이후 실행에도 그 공식 원문을 재조회하므로 피드에서 제거된 뒤에도 재공지 억제를 유지한다. 이 원문을 읽지 못하면 억제 규칙을 잃지 않도록 전체 발행을 중단한다. 수동 ID의 동일 일정 억제를 유지하려면 그 이벤트를 `events`에도 유지한다. 종료한 억제 규칙은 운영자가 정리해 원문 재조회를 줄일 수 있다.
+`disabledIds`에 지정한 ID 및 현재 확인 가능한 같은 일정의 재공지들을 제외한다. `ggg-{thread}-…` ID는 이후 실행에도 그 공식 원문을 재조회하므로 피드에서 제거된 뒤에도 재공지 억제를 유지한다. 이 원문을 읽지 못하면 신규 드롭스를 채택하지 않고 이전 검증 드롭스에 기존 제어를 적용한다. 상점 갱신은 계속한다. 수동 ID의 동일 일정 억제를 유지하려면 그 이벤트를 `events`에도 유지한다.
+
+### 보관함 계약과 수동 기준
+
+`stashSales`는 `version: 1`, 정확히 네 개의 `observations`, nullable `anchor`, nullable `nextEstimate`다. 관측은 서비스/게임/정확한 API URL/상태/확인 시각과 nullable `confirmedPeriod`를 갖는다. 확정 기간에는 UTC 시작·종료·실제 관측 시각 및 상품 ID(최대 100개)가 있다. 같은 UTC 기간이어도 API 관측의 서비스/게임 범위는 보존한다.
+
+`anchor.origin: "api"`는 실제 개인 보관함 할인 API에서 관측한 기간이다. 시작이 가장 최근인 기간을 선택하며 시작이 같으면 기존 기준을 유지한다. 표시 일정의 만료 정리와 별도로 **같은 promotions.json 안에 영구 보존**한다.
+
+`stash-seed.json`은 [8월 캘린더](https://poe.kakaogames.com/forum/view-thread/3991174)와 [8월 21일 공지](https://poe.kakaogames.com/forum/view-thread/3998528)를 근거로 한 일회 수동 초기값이다. `origin: "manual-announcement"`, KST 날짜 **8/21~8/25**, 범위 **Kakao PoE1/PoE2**로 저장한다. 공지 게시 시각을 확정 시작으로 사용하지 않는다. 기존 기준이 없을 때만 적용하고 API 기준을 덮어쓰지 않는다. 수동 기준도 이후 실행에서 보존한다.
+
+`nextEstimate`는 기준의 KST 시작·종료 날짜 각각에 **21일을 한 번만** 더한 날짜다. 최초 예상은 **9/11~9/15**이며 종료 날짜 다음 날 00:00 KST부터 `null`이다. 예측을 기준으로 다음 21일을 다시 계산하지 않는다. 실제 API 확인이 생기면 기준을 교체해 그 기간의 다음 예상만 만든다. 예상은 `events`와 분리되어 **툴팁에만 표시하며 확정 알림/활성 판정에 사용하지 않는다**. 서비스별 확정은 각 API 관측 범위만 사용한다.
 
 ## GitHub Actions와 발행
 
 `.github/workflows/update-promotions.yml`은 UTC **00:17/06:17/12:17/18:17**(KST **09:17/15:17/21:17/03:17**)에 실행한다. GitHub schedule은 지연되거나 누락될 수 있으므로 정확한 시작·종료 판정은 런처가 로컬 시각으로 수행한다. 런처의 시작/절전 복귀/1시간 조회 계약은 유지한다. [GitHub schedule 문서](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#schedule)
 
 동일 workflow의 PR 실행은 읽기 권한의 테스트만 수행한다. 수집·발행은 원래 저장소 master의 schedule/수동 실행/관련 경로 push에서만 가능하다. 별도 중복 스케줄러는 필요 없다. 예약/수동 실행을 등록하려면 workflow가 기본 브랜치에 적용되어야 한다.
+
+수집 단계는 `GITHUB_STEP_SUMMARY`에 네 소스의 상태/마지막 확인 시각/분류한 상품 수/할인 상품 ID/확정 기간을 기록한다. 실패 시 캐시 확정은 `Cached API confirmation`, 이번 성공은 `API confirmed`로 표시한다. 수동 기준과 날짜 예측은 별도 줄로 표시하므로 수동 표시를 API 감지 성공으로 오인하지 않는다.
 
 승인 후 수동 실행은 GitHub Actions의 **Update Event Promotions → Run workflow → master**를 선택한다. 저장소의 GitHub CLI 토큰 스킬을 적용한 환경에서는 `gh workflow run update-promotions.yml --ref master`도 가능하다.
 
@@ -68,6 +95,6 @@ finally { Remove-Item Env:PROMOTIONS_CONSUMER_MODULE }
 
 ## 이관과 적용 순서
 
-현재 구현은 런처 작업의 수집기 초안을 이관한 것이다. 런처 작업 소유자는 그 작업 트리의 `scripts/promotions/` 및 `.github/workflows/update-promotions.yml` 초안을 제거/제외하고 이 변경을 사용해야 한다. `src/shared/promotions.ts`, `SUPPORT_URLS.PROMOTIONS_JSON`, 소비 서비스는 그대로 유지한다.
+소비 런처는 별도 작업에서 같은 계약을 구현한다. 공개 URL은 추가하지 않는다. 기존 master 수집기는 unknown `stashSales`를 제거하므로 **새 수집기 배포 전 promotions.json에 수동 입력만 해두는 방식은 영속적이지 않다**. 이 수집기의 검토·머지·배포 후 통합 피드에 수동 기준을 등록한다.
 
 로컬 검증 후 적용 승인 → master 대상 변경 병합 → 수동 workflow 실행 → 실제 공개 JSON 확인 → 원래 런처 작업에 완료 통보 순서다. master 머지는 기존 release-please를 실행하므로 머지 승인은 별도로 필요하다. 실제 피드로 런처의 숨김 Windows Electron QA와 캡처는 원래 작업에서 수행한다.

--- a/scripts/promotions/collect.mjs
+++ b/scripts/promotions/collect.mjs
@@ -1,9 +1,16 @@
 /* global fetch, AbortSignal, Buffer, process, URL, console */
-import { readFile, writeFile, rename, mkdir } from "node:fs/promises";
+import {
+  readFile,
+  writeFile,
+  rename,
+  mkdir,
+  appendFile,
+} from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { setTimeout as delay } from "node:timers/promises";
 import { parsePromotionFeed } from "./contract.mjs";
+import { collectStashSales, collectionSummary } from "./stash-sales.mjs";
 import {
   canonicalSource,
   parseArticle,
@@ -17,7 +24,7 @@ export async function fetchOfficial(url) {
     headers: {
       "User-Agent":
         "PoE-Unofficial-Launcher-Promotions/1.0 (+https://github.com/NERDHEAD-lab/POE2-unofficial-launcher)",
-      Accept: "text/html, application/rss+xml",
+      Accept: "application/json, text/html, application/rss+xml",
     },
     signal: AbortSignal.timeout(15_000),
     redirect: "error",
@@ -44,9 +51,51 @@ export async function collect({
   overrides,
   fetchText = fetchOfficial,
   pause = () => delay(500),
-  now = new Date(),
+  now,
+  clock = now ? () => now : () => new Date(),
 }) {
+  now ??= clock();
   if (previous) previous = parsePromotionFeed(previous);
+  // Input corruption still fails before writing. Source failures are independent.
+  const fallback = mergePromotions(previous, [], overrides, now);
+  let drops;
+  try {
+    drops = await collectDrops({ previous, overrides, fetchText, pause, now });
+  } catch (error) {
+    drops = {
+      feed: fallback,
+      warnings: [`Drops collection unavailable: ${error.message}`],
+    };
+  }
+  const shop = await collectStashSales({
+    previous: previous?.stashSales,
+    fetchText,
+    pause,
+    clock,
+  });
+  const completedAt = clock();
+  const feed = parsePromotionFeed({
+    ...drops.feed,
+    generatedAt: completedAt.toISOString(),
+    events: drops.feed.events.filter(
+      (event) => Date.parse(event.endsAt) > completedAt.getTime(),
+    ),
+    stashSales: shop.stashSales,
+  });
+  const warnings = [...drops.warnings, ...shop.warnings];
+  return {
+    feed,
+    warnings,
+    summary: collectionSummary(feed, shop.reports, warnings),
+  };
+}
+
+async function collectDrops({ previous, overrides, fetchText, pause, now }) {
+  if (previous)
+    previous = {
+      ...previous,
+      events: previous.events.filter((event) => event.kind === "twitch-drops"),
+    };
   // Validate controls before requests. Disabled official IDs retain their source
   // as a candidate even after the published feed no longer contains the event.
   mergePromotions(previous, [], overrides, now);
@@ -63,7 +112,7 @@ export async function collect({
     for (const item of items)
       candidates.set(item.url, { ...candidates.get(item.url), ...item });
   };
-  // Fail the run on discovery failure; an error/challenge page is not an empty feed.
+  // Fail this source on discovery failure; an error page is not an empty feed.
   discover(parseRss(await fetchText("https://www.pathofexile.com/news/rss")));
   // Keep the bounded window on every run so an initially failed page-two source
   // is retried even when other successful sources advance generatedAt.
@@ -168,13 +217,16 @@ async function main() {
       "Usage: node scripts/promotions/collect.mjs --output <promotions.json> [--previous <promotions.json>]",
     );
   const output = resolve(option("--output"));
-  const { feed, warnings } = await collectToFile({
+  const { feed, warnings, summary } = await collectToFile({
     output,
     previousPath: args.includes("--previous")
       ? resolve(option("--previous"))
       : output,
   });
   console.log(`Validated ${feed.events.length} events -> ${output}`);
+  console.log(summary);
+  if (process.env.GITHUB_STEP_SUMMARY)
+    await appendFile(process.env.GITHUB_STEP_SUMMARY, summary);
   for (const warning of warnings) console.warn(warning);
 }
 

--- a/scripts/promotions/collect.test.mjs
+++ b/scripts/promotions/collect.test.mjs
@@ -16,16 +16,44 @@ const previous = {
   generatedAt: "2026-09-04T00:00:00Z",
   events: [
     {
-      id: "ggg-1-stash",
-      kind: "stash-sale",
-      game: "both",
+      id: "ggg-1-twitch-370116f319",
+      kind: "twitch-drops",
+      game: "poe2",
       startsAt: "2026-09-04T00:00:00Z",
       endsAt: "2026-09-08T00:00:00Z",
       sourceUrl: "https://www.pathofexile.com/forum/view-thread/1",
-      precision: "derived-start",
+      precision: "exact",
     },
   ],
 };
+const shopReply = (url) =>
+  JSON.stringify(
+    url.includes("categories")
+      ? {
+          items: [
+            {
+              id: "CurrencyTab",
+              guild: false,
+              cost: 75,
+              originalCost: 75,
+              onSpecial: false,
+            },
+          ],
+          total: 1,
+        }
+      : {
+          data: [
+            {
+              id: "CurrencyTab",
+              guild: false,
+              tags: ["StashTabs"],
+              cost: 75,
+              baseCost: 75,
+            },
+          ],
+          meta: {},
+        },
+  );
 const options = {
   previous,
   overrides: { events: [], disabledIds: [] },
@@ -33,14 +61,20 @@ const options = {
   pause: async () => {},
 };
 
-test("a discovery failure rejects before a replacement feed can be published", async () => {
-  await assert.rejects(
-    collect({ ...options, fetchText: async () => "<html>challenge</html>" }),
+test("failed discovery preserves existing drops and reports all shop sources unavailable", async () => {
+  const result = await collect({
+    ...options,
+    fetchText: async () => "<html>challenge</html>",
+  });
+  assert.deepEqual(result.feed.events, previous.events);
+  assert.ok(
+    result.feed.stashSales.observations.every(
+      (x) => x.status === "unavailable",
+    ),
   );
-  assert.equal(previous.events.length, 1);
 });
 
-test("failed discovery leaves previous output byte-for-byte intact", async (t) => {
+test("invalid previous input leaves previous output byte-for-byte intact", async (t) => {
   await mkdir(".tmp", { recursive: true });
   const parent = await realpath(resolve(".tmp"));
   const dir = await mkdtemp(join(parent, "promotions-file-test-"));
@@ -49,7 +83,7 @@ test("failed discovery leaves previous output byte-for-byte intact", async (t) =
     await rm(dir, { recursive: true });
   });
   const output = join(dir, "promotions.json");
-  const original = JSON.stringify(previous);
+  const original = JSON.stringify({ ...previous, schemaVersion: 2 });
   await writeFile(output, original);
   await assert.rejects(
     collectToFile({
@@ -64,8 +98,8 @@ test("failed discovery leaves previous output byte-for-byte intact", async (t) =
 const rss =
   "<rss><channel><item><title>Build Showcase</title></item></channel></rss>";
 const emptyForum = '<table class="forumTable"></table>';
-const stash =
-  '<table><tr class="newsPost"><td><div class="content">Stash Tab Sale<br>The Stash Tab sale ends at Sep 8, 2026 9AM GMT+9<br>both Path of Exile 1 and 2</div></td></tr><tr class="newsPostInfo"><td><span class="staff"></span><span class="post_date">Sep 4, 2026, 9:00:00 AM</span></td></tr></table><script>window.momentTimezone = "Asia/Seoul";</script>';
+const drop =
+  '<table><tr class="newsPost"><td><div class="content">Twitch Drops<br>Start Time: Sep 4, 2026 12AM UTC<br>End Time: Sep 8, 2026 12AM UTC<br>Path of Exile 2 category</div></td></tr><tr class="newsPostInfo"><td><span class="staff"></span><span class="post_date">Sep 4, 2026, 9:00:00 AM</span></td></tr></table><script>window.momentTimezone = "Asia/Seoul";</script>';
 
 test("bootstrap finds page-two schedules with a hard three-page bound", async () => {
   const calls = [];
@@ -73,15 +107,16 @@ test("bootstrap finds page-two schedules with a hard three-page bound", async ()
     ...options,
     previous: null,
     fetchText: async (url) => {
+      if (url.includes("/api/")) return shopReply(url);
       calls.push(url);
       if (url.endsWith("/rss")) return rss;
       if (url.endsWith("/news/page/2"))
-        return '<table class="forumTable"><a href="/forum/view-thread/2">Stash Tab Sale</a></table>';
+        return '<table class="forumTable"><a href="/forum/view-thread/2">Twitch Drops</a></table>';
       if (url.includes("view-forum")) return emptyForum;
-      return stash;
+      return drop;
     },
   });
-  assert.equal(feed.events[0]?.kind, "stash-sale");
+  assert.equal(feed.events[0]?.kind, "twitch-drops");
   assert.equal(calls.filter((url) => url.includes("view-forum")).length, 6);
   assert.ok(calls.every((url) => !url.endsWith("/page/4")));
 });
@@ -96,10 +131,11 @@ test("fresh and stale feeds retain the same bounded discovery window", async () 
       ...options,
       previous: { ...previous, generatedAt },
       fetchText: async (url) => {
+        if (url.includes("/api/")) return shopReply(url);
         calls.push(url);
         if (url.endsWith("/rss")) return rss;
         if (url.includes("view-forum")) return emptyForum;
-        return stash;
+        return drop;
       },
     });
     assert.equal(
@@ -115,20 +151,18 @@ test("a failed page-two source is rediscovered on the next scheduled run", async
     ...options,
     previous: null,
     fetchText: async (url) => {
+      if (url.includes("/api/")) return shopReply(url);
       if (url.endsWith("/rss")) return rss;
       if (url.endsWith("/news"))
-        return '<table class="forumTable"><a href="/forum/view-thread/1">Stash Tab Sale</a></table>';
+        return '<table class="forumTable"><a href="/forum/view-thread/1">Twitch Drops</a></table>';
       if (url.endsWith("/news/page/2"))
-        return '<table class="forumTable"><a href="/forum/view-thread/2">Stash Tab Sale</a></table>';
+        return '<table class="forumTable"><a href="/forum/view-thread/2">Twitch Drops</a></table>';
       if (url.includes("view-forum")) return emptyForum;
       if (url.includes("/view-thread/2/")) {
         if (!recovered) throw new Error("HTTP 503");
-        return stash.replace(
-          "Sep 4, 2026, 9:00:00 AM",
-          "Sep 4, 2026, 10:00:00 AM",
-        );
+        return drop.replace("Sep 4, 2026 12AM UTC", "Sep 4, 2026 1AM UTC");
       }
-      return stash;
+      return drop;
     },
   };
   const first = await collect(config);
@@ -142,33 +176,34 @@ test("a failed page-two source is rediscovered on the next scheduled run", async
   assert.equal(second.feed.events.length, 2);
 });
 
-test("a failed bootstrap discovery page rejects the whole run", async () => {
-  await assert.rejects(
-    collect({
-      ...options,
-      previous: null,
-      fetchText: async (url) => {
-        if (url.endsWith("/rss")) return rss;
-        if (url.endsWith("/page/2")) throw new Error("HTTP 503");
-        return emptyForum;
-      },
-    }),
-    /503/,
+test("a failed bootstrap discovery page still allows successful shop observations", async () => {
+  const result = await collect({
+    ...options,
+    previous: null,
+    fetchText: async (url) => {
+      if (url.includes("/api/")) return shopReply(url);
+      if (url.endsWith("/rss")) return rss;
+      if (url.endsWith("/page/2")) throw new Error("HTTP 503");
+      return emptyForum;
+    },
+  });
+  assert.deepEqual(result.feed.events, []);
+  assert.ok(
+    result.feed.stashSales.observations.every((x) => x.status === "ok"),
   );
+  assert.ok(result.warnings.some((x) => x.includes("503")));
 });
 
 test("a failed source is preserved while a different source advances", async () => {
   const { feed, warnings } = await collect({
     ...options,
     fetchText: async (url) => {
+      if (url.includes("/api/")) return shopReply(url);
       if (url.endsWith("/rss")) return rss;
       if (url.includes("view-forum"))
-        return '<table class="forumTable"><a href="/forum/view-thread/2">Stash Tab Sale</a></table>';
+        return '<table class="forumTable"><a href="/forum/view-thread/2">Twitch Drops</a></table>';
       if (url.includes("/view-thread/1/")) throw new Error("HTTP 503");
-      return stash.replace(
-        "Sep 4, 2026, 9:00:00 AM",
-        "Sep 4, 2026, 10:00:00 AM",
-      );
+      return drop.replace("Sep 4, 2026 12AM UTC", "Sep 4, 2026 1AM UTC");
     },
   });
   assert.equal(feed.events.length, 2);
@@ -183,6 +218,7 @@ test("failed active source preserves last known events and reports the source", 
   const { feed, warnings } = await collect({
     ...options,
     fetchText: async (url) => {
+      if (url.includes("/api/")) return shopReply(url);
       if (url.endsWith("/rss"))
         return "<rss><channel><item><title>Build Showcase</title></item></channel></rss>";
       if (url.includes("view-forum"))
@@ -199,13 +235,14 @@ test("disabled official source is rechecked so a repost stays disabled on later 
   const config = {
     ...options,
     previous: null,
-    overrides: { events: [], disabledIds: ["ggg-1-stash"] },
+    overrides: { events: [], disabledIds: ["ggg-1-twitch-370116f319"] },
     fetchText: async (url) => {
+      if (url.includes("/api/")) return shopReply(url);
       calls.push(url);
       if (url.endsWith("/rss")) return rss;
       if (url.includes("view-forum"))
-        return '<table class="forumTable"><a href="/forum/view-thread/2">Stash Tab Sale</a></table>';
-      return stash;
+        return '<table class="forumTable"><a href="/forum/view-thread/2">Twitch Drops</a></table>';
+      return drop;
     },
   };
   const first = await collect(config);
@@ -219,16 +256,57 @@ test("disabled official source is rechecked so a repost stays disabled on later 
 });
 
 test("an unavailable disabled source cannot silently re-enable its reposts", async () => {
-  await assert.rejects(
-    collect({
-      ...options,
-      overrides: { events: [], disabledIds: ["ggg-1-stash"] },
-      fetchText: async (url) => {
-        if (url.endsWith("/rss")) return rss;
-        if (url.includes("view-forum")) return emptyForum;
-        throw new Error("HTTP 503");
-      },
-    }),
-    /disabled source/i,
+  const result = await collect({
+    ...options,
+    overrides: { events: [], disabledIds: ["ggg-1-twitch-370116f319"] },
+    fetchText: async (url) => {
+      if (url.includes("/api/")) return shopReply(url);
+      if (url.endsWith("/rss")) return rss;
+      if (url.includes("view-forum")) return emptyForum;
+      throw new Error("HTTP 503");
+    },
+  });
+  assert.deepEqual(result.feed.events, []);
+  assert.ok(result.warnings.some((x) => /disabled source/i.test(x)));
+});
+
+test("legacy stash events and stash-only forum announcements do not enter the drops feed", async () => {
+  const result = await collect({
+    ...options,
+    previous: {
+      ...previous,
+      events: [{ ...previous.events[0], kind: "stash-sale", game: "both" }],
+    },
+    fetchText: async (url) => {
+      if (url.includes("/api/")) return shopReply(url);
+      if (url.endsWith("/rss"))
+        return "<rss><channel><item><title>Stash Tab Sale</title></item></channel></rss>";
+      if (url.includes("view-forum"))
+        return '<table class="forumTable"><a href="/forum/view-thread/2">Stash Tab Sale</a></table>';
+      throw new Error("Stash-only source must not be fetched");
+    },
+  });
+  assert.deepEqual(result.feed.events, []);
+  assert.deepEqual(result.warnings, []);
+});
+
+test("unavailable shop APIs cannot block newly discovered drops", async () => {
+  const result = await collect({
+    ...options,
+    previous: null,
+    fetchText: async (url) => {
+      if (url.includes("/api/")) throw new Error("HTTP 403");
+      if (url.endsWith("/rss")) return rss;
+      if (url.includes("view-forum"))
+        return '<table class="forumTable"><a href="/forum/view-thread/2">Twitch Drops</a></table>';
+      return drop;
+    },
+  });
+  assert.equal(result.feed.events.length, 1);
+  assert.equal(result.feed.events[0].kind, "twitch-drops");
+  assert.ok(
+    result.feed.stashSales.observations.every(
+      (x) => x.status === "unavailable",
+    ),
   );
 });

--- a/scripts/promotions/collector.mjs
+++ b/scripts/promotions/collector.mjs
@@ -2,7 +2,7 @@ import { createHash } from "node:crypto";
 import { parse } from "node-html-parser";
 import { parsePromotionFeed, scheduleKey } from "./contract.mjs";
 
-const candidate = /\btwitch\s+drops?\b|\bstash(?:\s+tab)?\s+sale\b/i;
+const candidate = /\btwitch\s+drops?\b/i;
 const text = (html) =>
   parse(`<div>${html.replace(/<!\[CDATA\[([\s\S]*?)\]\]>/g, "$1")}</div>`).text;
 export function canonicalSource(url) {
@@ -199,10 +199,7 @@ export function parseArticle(html, sourceUrl, publishedAt) {
   const add = (kind, game, startsAt, endsAt, section, precision = "exact") => {
     if (Math.abs(Date.parse(startsAt) - Date.parse(published)) > 60 * 86400_000)
       throw new Error("Event too far from publication");
-    const suffix =
-      kind === "stash-sale"
-        ? "stash"
-        : `twitch-${createHash("sha256").update(section.toLowerCase().trim()).digest("hex").slice(0, 10)}`;
+    const suffix = `twitch-${createHash("sha256").update(section.toLowerCase().trim()).digest("hex").slice(0, 10)}`;
     events.push({
       id: `ggg-${thread}-${suffix}`,
       kind,
@@ -213,22 +210,6 @@ export function parseArticle(html, sourceUrl, publishedAt) {
       precision,
     });
   };
-
-  if (/stash(?:\s+tab)?\s+sale/i.test(body)) {
-    const ending =
-      /stash(?:\s+tab)?\s+sale\s+ends?\s+(?:at|on)\s+([^\n]+)/i.exec(body)?.[1];
-    if (!ending) throw new Error("Stash sale end missing");
-    const game = /both Path of Exile\s+1\s+and\s+2/i.test(body) ? "both" : null;
-    if (!game) throw new Error("Stash sale game scope missing");
-    add(
-      "stash-sale",
-      game,
-      published,
-      calendarTime(ending, published, zone),
-      "stash",
-      "derived-start",
-    );
-  }
 
   if (/twitch\s+drops?/i.test(body)) {
     // Keep section headings so Support-a-Streamer and quest ranges cannot become drops.
@@ -361,6 +342,7 @@ export function mergePromotions(previous, parsed, overrides, now = new Date()) {
     schemaVersion: 1,
     generatedAt: now.toISOString(),
     events: result
+      .filter((event) => event.kind === "twitch-drops")
       .filter((event) => Date.parse(event.endsAt) > now.getTime())
       .sort((a, b) => a.startsAt.localeCompare(b.startsAt)),
   });

--- a/scripts/promotions/collector.test.mjs
+++ b/scripts/promotions/collector.test.mjs
@@ -9,7 +9,7 @@ const source = (id) => `https://www.pathofexile.com/forum/view-thread/${id}`;
 
 test("RSS decodes CDATA descriptions and ignores unrelated posts", () => {
   const result = parseRss(
-    `<rss><channel><item><title>News</title><link>${source(1)}</link><description><![CDATA[<p>Stash Tab Sale</p>]]></description><pubDate>Thu, 03 Sep 2026 03:00:00 +0000</pubDate></item><item><title>Build Showcase</title></item></channel></rss>`,
+    `<rss><channel><item><title>News</title><link>${source(1)}</link><description><![CDATA[<p>Twitch Drops</p>]]></description><pubDate>Thu, 03 Sep 2026 03:00:00 +0000</pubDate></item><item><title>Build Showcase</title></item></channel></rss>`,
   );
   assert.equal(result.length, 1);
   assert.equal(result[0].url, source(1));
@@ -63,22 +63,12 @@ test("4001078 reads the drops section without confusing realm/patch times", () =
   assert.equal(event.endsAt, "2026-09-11T20:00:00.000Z");
 });
 
-test("3926103 derives stash start from publication in declared source timezone", () => {
+test("historical stash announcements are no longer parsed into promotion events", () => {
   const html = article(
     `Stash Tab Sale<br>The Stash Tab sale ends at <strong>Apr 07, 2026 10:00 AM (GMT+9)</strong><br>both Path of Exile 1 and 2`,
     "Apr 3, 2026, 9:00:00 AM",
   );
-  const [event] = parseArticle(html, source(3926103));
-  assert.equal(event.game, "both");
-  assert.equal(event.precision, "derived-start");
-  assert.equal(event.startsAt, "2026-04-03T00:00:00.000Z");
-  assert.equal(event.endsAt, "2026-04-07T01:00:00.000Z");
-  assert.throws(() =>
-    parseArticle(
-      html.replace("window.momentTimezone", "unknown"),
-      source(3926103),
-    ),
-  );
+  assert.throws(() => parseArticle(html, source(3926103)), /No supported/);
 });
 
 test("unknown game, missing boundaries and non-staff HTML cannot publish", () => {
@@ -96,9 +86,9 @@ test("unknown game, missing boundaries and non-staff HTML cannot publish", () =>
   assert.throws(() => parseArticle("<html>Just a moment</html>", source(3)));
 });
 
-test("the same sale from an Eastern-time source yields identical UTC bounds", () => {
+test("Eastern-time drops produce precise UTC bounds", () => {
   const html = article(
-    "Stash Tab Sale<br>The Stash Tab sale ends at Apr 06, 2026 9:00 PM (EDT)<br>both Path of Exile 1 and 2",
+    "Twitch Drops<br>Start Time: Apr 2, 2026 8PM EDT<br>End Time: Apr 6, 2026 9PM EDT<br>Path of Exile 2 category",
     "Apr 2, 2026, 8:00:00 PM",
   ).replace("Asia/Seoul", "America/New_York");
   const [event] = parseArticle(html, source(3926103));
@@ -109,13 +99,13 @@ test("the same sale from an Eastern-time source yields identical UTC bounds", ()
 test("overrides win; disabled IDs stay removed; reposts do not duplicate campaigns", () => {
   const now = new Date("2026-09-04T02:00:00Z");
   const base = {
-    id: "ggg-1-stash",
-    kind: "stash-sale",
-    game: "both",
+    id: "ggg-1-twitch",
+    kind: "twitch-drops",
+    game: "poe2",
     startsAt: "2026-09-04T00:00:00Z",
     endsAt: "2026-09-08T00:00:00Z",
     sourceUrl: source(1),
-    precision: "derived-start",
+    precision: "exact",
   };
   const previous = {
     schemaVersion: 1,
@@ -124,7 +114,7 @@ test("overrides win; disabled IDs stay removed; reposts do not duplicate campaig
   };
   const repost = {
     ...base,
-    id: "ggg-2-stash",
+    id: "ggg-2-twitch",
     sourceUrl: source(2),
     startsAt: "2026-09-04T00:00:00.000Z",
   };
@@ -167,13 +157,13 @@ test("a staff reply cannot authenticate a non-staff original post", () => {
 });
 
 const sale = {
-  id: "ggg-1-stash",
-  kind: "stash-sale",
-  game: "both",
+  id: "ggg-1-twitch",
+  kind: "twitch-drops",
+  game: "poe2",
   startsAt: "2026-09-04T00:00:00Z",
   endsAt: "2026-09-08T00:00:00Z",
   sourceUrl: source(1),
-  precision: "derived-start",
+  precision: "exact",
 };
 const previousFeed = (events) => ({
   schemaVersion: 1,
@@ -183,13 +173,13 @@ const previousFeed = (events) => ({
 const now = new Date("2026-09-04T01:00:00Z");
 const overrides = { events: [], disabledIds: [] };
 
-test("different stash starts are different schedules", () => {
+test("different drops starts are different schedules", () => {
   const result = mergePromotions(
     previousFeed([sale]),
     [
       {
         ...sale,
-        id: "ggg-2-stash",
+        id: "ggg-2-twitch",
         sourceUrl: source(2),
         startsAt: "2026-09-04T01:00:00Z",
       },

--- a/scripts/promotions/contract.mjs
+++ b/scripts/promotions/contract.mjs
@@ -64,5 +64,226 @@ export function parsePromotionFeed(value) {
       precision: item.precision,
     };
   });
-  return { schemaVersion: 1, generatedAt: feed.generatedAt, events };
+  return {
+    schemaVersion: 1,
+    generatedAt: feed.generatedAt,
+    events,
+    ...("stashSales" in feed
+      ? { stashSales: parseStashSales(feed.stashSales) }
+      : {}),
+  };
+}
+
+export const SHOP_SOURCES = [
+  {
+    service: "ggg",
+    game: "poe1",
+    sourceUrl:
+      "https://www.pathofexile.com/api/shop-microtransaction-categories/stash-tabs",
+  },
+  {
+    service: "ggg",
+    game: "poe2",
+    sourceUrl: "https://pathofexile2.com/api/shop-microtransactions?game=poe2",
+  },
+  {
+    service: "kakao",
+    game: "poe1",
+    sourceUrl:
+      "https://poe.kakaogames.com/api/shop-microtransaction-categories/stash-tabs",
+  },
+  {
+    service: "kakao",
+    game: "poe2",
+    sourceUrl:
+      "https://poe2.kakaogames.com/api/shop-microtransactions?game=poe2",
+  },
+];
+
+function requireStash(condition) {
+  if (!condition) throw new Error("Invalid stash sales section");
+}
+
+function scopeOf(value, withSource = false) {
+  const item = record(value);
+  const source = SHOP_SOURCES.find(
+    (x) => x.service === item.service && x.game === item.game,
+  );
+  requireStash(source && (!withSource || source.sourceUrl === item.sourceUrl));
+  return withSource
+    ? { ...source }
+    : { service: source.service, game: source.game };
+}
+
+function utcPeriod(value) {
+  const item = record(value);
+  const duration = Date.parse(item.endsAt) - Date.parse(item.startsAt);
+  requireStash(
+    isUtcInstant(item.startsAt) &&
+      isUtcInstant(item.endsAt) &&
+      duration > 0 &&
+      duration <= 90 * 86400_000 &&
+      isUtcInstant(item.observedAt),
+  );
+  return {
+    startsAt: item.startsAt,
+    endsAt: item.endsAt,
+    observedAt: item.observedAt,
+  };
+}
+
+export function isCalendarDate(value) {
+  return (
+    typeof value === "string" &&
+    /^\d{4}-\d\d-\d\d$/.test(value) &&
+    Number.isFinite(Date.parse(value + "T00:00:00Z")) &&
+    new Date(value + "T00:00:00Z").toISOString().slice(0, 10) === value
+  );
+}
+
+function datePeriod(value) {
+  const item = record(value);
+  const duration = Date.parse(item.endDate) - Date.parse(item.startDate);
+  requireStash(
+    isCalendarDate(item.startDate) &&
+      isCalendarDate(item.endDate) &&
+      duration >= 0 &&
+      duration <= 90 * 86400_000 &&
+      item.timeZone === "Asia/Seoul",
+  );
+  return {
+    startDate: item.startDate,
+    endDate: item.endDate,
+    timeZone: "Asia/Seoul",
+  };
+}
+
+function announcementUrl(value) {
+  return (
+    typeof value === "string" &&
+    /^https:\/\/(?:www\.pathofexile\.com|poe\.kakaogames\.com|poe2\.kakaogames\.com)\/forum\/view-thread\/\d+$/.test(
+      value,
+    )
+  );
+}
+
+function uniqueStrings(value, limit, valid) {
+  requireStash(
+    Array.isArray(value) &&
+      value.length > 0 &&
+      value.length <= limit &&
+      new Set(value).size === value.length &&
+      value.every(valid),
+  );
+  return [...value];
+}
+
+export function parseStashSales(value) {
+  const item = record(value);
+  requireStash(
+    item.version === 1 &&
+      Array.isArray(item.observations) &&
+      item.observations.length === 4,
+  );
+  const scopes = new Set();
+  const observations = item.observations.map((value) => {
+    const observation = record(value);
+    const source = scopeOf(observation, true);
+    const key = `${source.service}:${source.game}`;
+    requireStash(
+      !scopes.has(key) &&
+        isUtcInstant(observation.checkedAt) &&
+        ["ok", "unavailable", "period-unavailable"].includes(
+          observation.status,
+        ),
+    );
+    scopes.add(key);
+    const confirmedPeriod =
+      observation.confirmedPeriod === null
+        ? null
+        : {
+            ...utcPeriod(observation.confirmedPeriod),
+            productIds: uniqueStrings(
+              record(observation.confirmedPeriod).productIds,
+              100,
+              (id) =>
+                typeof id === "string" && /^[A-Za-z0-9_-]{1,160}$/.test(id),
+            ),
+          };
+    requireStash(
+      observation.status !== "period-unavailable" || confirmedPeriod === null,
+    );
+    requireStash(
+      !confirmedPeriod ||
+        Date.parse(confirmedPeriod.observedAt) <=
+          Date.parse(observation.checkedAt),
+    );
+    return {
+      ...source,
+      checkedAt: observation.checkedAt,
+      status: observation.status,
+      confirmedPeriod,
+    };
+  });
+  let anchor = null;
+  if (item.anchor !== null) {
+    const value = record(item.anchor);
+    requireStash(["api", "manual-announcement"].includes(value.origin));
+    if (value.origin === "api") {
+      anchor = { origin: "api", ...scopeOf(value, true), ...utcPeriod(value) };
+    } else {
+      const sourceUrls = uniqueStrings(value.sourceUrls, 4, announcementUrl);
+      requireStash(
+        Array.isArray(value.scope) &&
+          value.scope.length > 0 &&
+          value.scope.length <= 4,
+      );
+      const scope = value.scope.map((x) => scopeOf(x));
+      requireStash(
+        new Set(scope.map((x) => `${x.service}:${x.game}`)).size ===
+          scope.length,
+      );
+      anchor = {
+        origin: "manual-announcement",
+        ...datePeriod(value),
+        sourceUrls,
+        scope,
+      };
+    }
+  }
+  let nextEstimate = null;
+  if (item.nextEstimate !== null) {
+    const estimate = record(item.nextEstimate);
+    requireStash(
+      anchor &&
+        estimate.intervalDays === 21 &&
+        estimate.basisOrigin === anchor.origin &&
+        (anchor.origin === "api"
+          ? estimate.basisSourceUrl === anchor.sourceUrl
+          : anchor.sourceUrls.includes(estimate.basisSourceUrl)),
+    );
+    const kstDate = (utc) =>
+      new Date(Date.parse(utc) + 9 * 3600_000).toISOString().slice(0, 10);
+    const plus21 = (date) =>
+      new Date(Date.parse(`${date}T00:00:00Z`) + 21 * 86400_000)
+        .toISOString()
+        .slice(0, 10);
+    requireStash(
+      estimate.startDate ===
+        plus21(
+          anchor.origin === "api" ? kstDate(anchor.startsAt) : anchor.startDate,
+        ) &&
+        estimate.endDate ===
+          plus21(
+            anchor.origin === "api" ? kstDate(anchor.endsAt) : anchor.endDate,
+          ),
+    );
+    nextEstimate = {
+      ...datePeriod(estimate),
+      intervalDays: 21,
+      basisOrigin: estimate.basisOrigin,
+      basisSourceUrl: estimate.basisSourceUrl,
+    };
+  }
+  return { version: 1, observations, anchor, nextEstimate };
 }

--- a/scripts/promotions/contract.test.mjs
+++ b/scripts/promotions/contract.test.mjs
@@ -4,6 +4,8 @@ import { existsSync } from "node:fs";
 import { resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import { parsePromotionFeed } from "./contract.mjs";
+import samples from "./fixtures/stash-sales-contract.json" with { type: "json" };
+import { parsePromotionFeed as parseLegacy } from "./fixtures/legacy-contract-v1.mjs";
 
 const event = {
   id: "ggg-4000901-twitch-471bcf3ba0",
@@ -66,6 +68,133 @@ test("schema v1 accepts supported payloads and rejects malformed events", () => 
   for (const input of invalid) assert.throws(() => parsePromotionFeed(input));
 });
 
+test("optional stash section round-trips the shared manual/API/failure/expiry samples", () => {
+  for (const sample of Object.values(samples))
+    assert.deepEqual(parsePromotionFeed(sample), sample);
+});
+
+test("the pre-extension consumer keeps reading drops from the extended feed", () => {
+  for (const sample of Object.values(samples)) {
+    const extended = { ...sample, events: [event] };
+    assert.deepEqual(parseLegacy(extended), {
+      schemaVersion: 1,
+      generatedAt: sample.generatedAt,
+      events: [event],
+    });
+  }
+});
+
+const changeStash = (change) => {
+  const value = structuredClone(samples.confirmed);
+  change(value.stashSales);
+  return value;
+};
+const badStash = [
+  null,
+  {},
+  { ...samples.manual.stashSales, version: 2 },
+  ...[
+    (s) => {
+      s.observations = [];
+    },
+    (s) => {
+      s.observations[0] = s.observations[1];
+    },
+    (s) => {
+      s.observations[1].sourceUrl += "&lang=en";
+    },
+    (s) => {
+      s.observations[1].game = "poe1";
+    },
+    (s) => {
+      s.observations[1].status = "guessed";
+    },
+    (s) => {
+      s.observations[1].checkedAt = "2026-02-30T00:00:00Z";
+    },
+    (s) => {
+      delete s.observations[0].confirmedPeriod;
+    },
+    (s) => {
+      s.observations[1].confirmedPeriod.productIds = [];
+    },
+    (s) => {
+      s.observations[1].confirmedPeriod.productIds = [
+        "CurrencyTab",
+        "CurrencyTab",
+      ];
+    },
+    (s) => {
+      s.observations[1].confirmedPeriod.productIds = Array.from(
+        { length: 101 },
+        (_, i) => `Tab${i}`,
+      );
+    },
+    (s) => {
+      s.observations[1].confirmedPeriod.observedAt = "2026-09-11T02:00:00Z";
+    },
+    (s) => {
+      s.observations[1].confirmedPeriod.endsAt =
+        s.observations[1].confirmedPeriod.startsAt;
+    },
+    (s) => {
+      s.anchor.sourceUrl = "https://example.com";
+    },
+    (s) => {
+      s.anchor.origin = "manual";
+    },
+    (s) => {
+      s.nextEstimate.intervalDays = 42;
+    },
+    (s) => {
+      s.nextEstimate.startDate = "2026-02-30";
+    },
+    (s) => {
+      s.nextEstimate.startDate = "2026-10-03";
+    },
+    (s) => {
+      s.nextEstimate.timeZone = "UTC";
+    },
+    (s) => {
+      s.nextEstimate.basisOrigin = "estimated";
+    },
+    (s) => {
+      s.nextEstimate.basisSourceUrl = "https://example.com";
+    },
+  ].map((change) => changeStash(change).stashSales),
+];
+
+test("stash source scopes and precise or date-only fields fail closed", () => {
+  for (const stashSales of badStash)
+    assert.throws(() => parsePromotionFeed({ ...feed, stashSales }));
+  for (const change of [
+    (s) => {
+      s.anchor.startDate = "2026-02-30";
+    },
+    (s) => {
+      s.anchor.scope = [{ service: "kakao", game: "both" }];
+    },
+    (s) => {
+      s.anchor.sourceUrls = ["https://example.com"];
+    },
+    (s) => {
+      s.anchor.sourceUrls = Array.from(
+        { length: 5 },
+        (_, i) => `https://poe.kakaogames.com/forum/view-thread/${i}`,
+      );
+    },
+    (s) => {
+      s.anchor.sourceUrls = [
+        "https://poe.kakaogames.com/forum/view-thread/3998528/filter-account-type/staff",
+      ];
+    },
+  ]) {
+    const sample = structuredClone(samples.manual);
+    change(sample.stashSales);
+    assert.throws(() => parsePromotionFeed(sample));
+  }
+});
+
 test("validator matches the actual launcher consumer when available", async (t) => {
   const path = resolve(
     process.env.PROMOTIONS_CONSUMER_MODULE ?? "src/shared/promotions.ts",
@@ -79,11 +208,13 @@ test("validator matches the actual launcher consumer when available", async (t) 
     return;
   }
   const consumer = await import(pathToFileURL(path).href);
-  for (const input of valid)
+  for (const input of [...valid, ...Object.values(samples)])
     assert.deepEqual(
       parsePromotionFeed(input),
       consumer.parsePromotionFeed(input),
     );
   for (const input of invalid)
     assert.throws(() => consumer.parsePromotionFeed(input));
+  for (const stashSales of badStash)
+    assert.throws(() => consumer.parsePromotionFeed({ ...feed, stashSales }));
 });

--- a/scripts/promotions/fixtures/legacy-contract-v1.mjs
+++ b/scripts/promotions/fixtures/legacy-contract-v1.mjs
@@ -1,0 +1,69 @@
+// Frozen pre-stash-section consumer mirror from afba18e5; compatibility fixture only.
+// schemaVersion 1 consumer contract, mirrored from src/shared/promotions.ts.
+// Keep this collector deployable before the launcher feature is merged.
+export const scheduleKey = (event) =>
+  `${event.kind}:${event.game}:${Date.parse(event.startsAt)}:${Date.parse(event.endsAt)}`;
+
+function record(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? value
+    : {};
+}
+
+export function isUtcInstant(value) {
+  if (
+    typeof value !== "string" ||
+    !/^\d{4}-\d\d-\d\dT\d\d:\d\d:\d\d(?:\.\d{3})?Z$/.test(value)
+  )
+    return false;
+  const time = Date.parse(value);
+  return (
+    Number.isFinite(time) &&
+    new Date(time).toISOString() === value.replace(/(?<=:\d\d)Z$/, ".000Z")
+  );
+}
+
+export function parsePromotionFeed(value) {
+  const feed = record(value);
+  if (
+    feed.schemaVersion !== 1 ||
+    !isUtcInstant(feed.generatedAt) ||
+    !Array.isArray(feed.events) ||
+    feed.events.length > 200
+  ) {
+    throw new Error("Invalid promotion feed");
+  }
+  const ids = new Set();
+  const events = feed.events.map((entry) => {
+    const item = record(entry);
+    if (
+      typeof item.id !== "string" ||
+      !/^[a-z0-9:-]{1,160}$/.test(item.id) ||
+      ids.has(item.id) ||
+      !["twitch-drops", "stash-sale"].includes(item.kind) ||
+      !["poe1", "poe2", "both"].includes(item.game) ||
+      (item.kind === "twitch-drops" && item.game === "both") ||
+      !["exact", "derived-start", "manual"].includes(item.precision) ||
+      !isUtcInstant(item.startsAt) ||
+      !isUtcInstant(item.endsAt) ||
+      Date.parse(item.endsAt) <= Date.parse(item.startsAt) ||
+      Date.parse(item.endsAt) - Date.parse(item.startsAt) > 90 * 86400_000 ||
+      typeof item.sourceUrl !== "string" ||
+      !/^https:\/\/www\.pathofexile\.com\/forum\/view-thread\/\d+(?:\/filter-account-type\/staff)?$/.test(
+        item.sourceUrl,
+      )
+    )
+      throw new Error("Invalid promotion event");
+    ids.add(item.id);
+    return {
+      id: item.id,
+      kind: item.kind,
+      game: item.game,
+      startsAt: item.startsAt,
+      endsAt: item.endsAt,
+      sourceUrl: item.sourceUrl,
+      precision: item.precision,
+    };
+  });
+  return { schemaVersion: 1, generatedAt: feed.generatedAt, events };
+}

--- a/scripts/promotions/fixtures/stash-sales-contract.json
+++ b/scripts/promotions/fixtures/stash-sales-contract.json
@@ -1,0 +1,252 @@
+{
+  "manual": {
+    "schemaVersion": 1,
+    "generatedAt": "2026-09-04T10:00:00.000Z",
+    "events": [],
+    "stashSales": {
+      "version": 1,
+      "observations": [
+        {
+          "service": "ggg",
+          "game": "poe1",
+          "sourceUrl": "https://www.pathofexile.com/api/shop-microtransaction-categories/stash-tabs",
+          "checkedAt": "2026-09-04T10:00:00.000Z",
+          "status": "unavailable",
+          "confirmedPeriod": null
+        },
+        {
+          "service": "ggg",
+          "game": "poe2",
+          "sourceUrl": "https://pathofexile2.com/api/shop-microtransactions?game=poe2",
+          "checkedAt": "2026-09-04T10:00:00.000Z",
+          "status": "ok",
+          "confirmedPeriod": null
+        },
+        {
+          "service": "kakao",
+          "game": "poe1",
+          "sourceUrl": "https://poe.kakaogames.com/api/shop-microtransaction-categories/stash-tabs",
+          "checkedAt": "2026-09-04T10:00:00.000Z",
+          "status": "ok",
+          "confirmedPeriod": null
+        },
+        {
+          "service": "kakao",
+          "game": "poe2",
+          "sourceUrl": "https://poe2.kakaogames.com/api/shop-microtransactions?game=poe2",
+          "checkedAt": "2026-09-04T10:00:00.000Z",
+          "status": "ok",
+          "confirmedPeriod": null
+        }
+      ],
+      "anchor": {
+        "origin": "manual-announcement",
+        "startDate": "2026-08-21",
+        "endDate": "2026-08-25",
+        "timeZone": "Asia/Seoul",
+        "sourceUrls": [
+          "https://poe.kakaogames.com/forum/view-thread/3991174",
+          "https://poe.kakaogames.com/forum/view-thread/3998528"
+        ],
+        "scope": [
+          {
+            "service": "kakao",
+            "game": "poe1"
+          },
+          {
+            "service": "kakao",
+            "game": "poe2"
+          }
+        ]
+      },
+      "nextEstimate": {
+        "startDate": "2026-09-11",
+        "endDate": "2026-09-15",
+        "timeZone": "Asia/Seoul",
+        "intervalDays": 21,
+        "basisOrigin": "manual-announcement",
+        "basisSourceUrl": "https://poe.kakaogames.com/forum/view-thread/3998528"
+      }
+    }
+  },
+  "confirmed": {
+    "schemaVersion": 1,
+    "generatedAt": "2026-09-11T01:00:00.000Z",
+    "events": [],
+    "stashSales": {
+      "version": 1,
+      "observations": [
+        {
+          "service": "ggg",
+          "game": "poe1",
+          "sourceUrl": "https://www.pathofexile.com/api/shop-microtransaction-categories/stash-tabs",
+          "checkedAt": "2026-09-11T01:00:00.000Z",
+          "status": "unavailable",
+          "confirmedPeriod": null
+        },
+        {
+          "service": "ggg",
+          "game": "poe2",
+          "sourceUrl": "https://pathofexile2.com/api/shop-microtransactions?game=poe2",
+          "checkedAt": "2026-09-11T01:00:00.000Z",
+          "status": "ok",
+          "confirmedPeriod": {
+            "startsAt": "2026-09-11T00:00:01.000Z",
+            "endsAt": "2026-09-15T00:00:00.000Z",
+            "observedAt": "2026-09-11T01:00:00.000Z",
+            "productIds": ["CurrencyTab", "PremiumStashTab"]
+          }
+        },
+        {
+          "service": "kakao",
+          "game": "poe1",
+          "sourceUrl": "https://poe.kakaogames.com/api/shop-microtransaction-categories/stash-tabs",
+          "checkedAt": "2026-09-11T01:00:00.000Z",
+          "status": "ok",
+          "confirmedPeriod": null
+        },
+        {
+          "service": "kakao",
+          "game": "poe2",
+          "sourceUrl": "https://poe2.kakaogames.com/api/shop-microtransactions?game=poe2",
+          "checkedAt": "2026-09-11T01:00:00.000Z",
+          "status": "ok",
+          "confirmedPeriod": null
+        }
+      ],
+      "anchor": {
+        "origin": "api",
+        "service": "ggg",
+        "game": "poe2",
+        "sourceUrl": "https://pathofexile2.com/api/shop-microtransactions?game=poe2",
+        "startsAt": "2026-09-11T00:00:01.000Z",
+        "endsAt": "2026-09-15T00:00:00.000Z",
+        "observedAt": "2026-09-11T01:00:00.000Z"
+      },
+      "nextEstimate": {
+        "startDate": "2026-10-02",
+        "endDate": "2026-10-06",
+        "timeZone": "Asia/Seoul",
+        "intervalDays": 21,
+        "basisOrigin": "api",
+        "basisSourceUrl": "https://pathofexile2.com/api/shop-microtransactions?game=poe2"
+      }
+    }
+  },
+  "unavailable": {
+    "schemaVersion": 1,
+    "generatedAt": "2026-09-11T07:00:00.000Z",
+    "events": [],
+    "stashSales": {
+      "version": 1,
+      "observations": [
+        {
+          "service": "ggg",
+          "game": "poe1",
+          "sourceUrl": "https://www.pathofexile.com/api/shop-microtransaction-categories/stash-tabs",
+          "checkedAt": "2026-09-11T01:00:00.000Z",
+          "status": "unavailable",
+          "confirmedPeriod": null
+        },
+        {
+          "service": "ggg",
+          "game": "poe2",
+          "sourceUrl": "https://pathofexile2.com/api/shop-microtransactions?game=poe2",
+          "checkedAt": "2026-09-11T01:00:00.000Z",
+          "status": "unavailable",
+          "confirmedPeriod": {
+            "startsAt": "2026-09-11T00:00:01.000Z",
+            "endsAt": "2026-09-15T00:00:00.000Z",
+            "observedAt": "2026-09-11T01:00:00.000Z",
+            "productIds": ["CurrencyTab", "PremiumStashTab"]
+          }
+        },
+        {
+          "service": "kakao",
+          "game": "poe1",
+          "sourceUrl": "https://poe.kakaogames.com/api/shop-microtransaction-categories/stash-tabs",
+          "checkedAt": "2026-09-11T01:00:00.000Z",
+          "status": "ok",
+          "confirmedPeriod": null
+        },
+        {
+          "service": "kakao",
+          "game": "poe2",
+          "sourceUrl": "https://poe2.kakaogames.com/api/shop-microtransactions?game=poe2",
+          "checkedAt": "2026-09-11T01:00:00.000Z",
+          "status": "ok",
+          "confirmedPeriod": null
+        }
+      ],
+      "anchor": {
+        "origin": "api",
+        "service": "ggg",
+        "game": "poe2",
+        "sourceUrl": "https://pathofexile2.com/api/shop-microtransactions?game=poe2",
+        "startsAt": "2026-09-11T00:00:01.000Z",
+        "endsAt": "2026-09-15T00:00:00.000Z",
+        "observedAt": "2026-09-11T01:00:00.000Z"
+      },
+      "nextEstimate": {
+        "startDate": "2026-10-02",
+        "endDate": "2026-10-06",
+        "timeZone": "Asia/Seoul",
+        "intervalDays": 21,
+        "basisOrigin": "api",
+        "basisSourceUrl": "https://pathofexile2.com/api/shop-microtransactions?game=poe2"
+      }
+    }
+  },
+  "expired": {
+    "schemaVersion": 1,
+    "generatedAt": "2026-10-06T15:00:00.000Z",
+    "events": [],
+    "stashSales": {
+      "version": 1,
+      "observations": [
+        {
+          "service": "ggg",
+          "game": "poe1",
+          "sourceUrl": "https://www.pathofexile.com/api/shop-microtransaction-categories/stash-tabs",
+          "checkedAt": "2026-09-11T01:00:00.000Z",
+          "status": "unavailable",
+          "confirmedPeriod": null
+        },
+        {
+          "service": "ggg",
+          "game": "poe2",
+          "sourceUrl": "https://pathofexile2.com/api/shop-microtransactions?game=poe2",
+          "checkedAt": "2026-09-11T01:00:00.000Z",
+          "status": "ok",
+          "confirmedPeriod": null
+        },
+        {
+          "service": "kakao",
+          "game": "poe1",
+          "sourceUrl": "https://poe.kakaogames.com/api/shop-microtransaction-categories/stash-tabs",
+          "checkedAt": "2026-09-11T01:00:00.000Z",
+          "status": "ok",
+          "confirmedPeriod": null
+        },
+        {
+          "service": "kakao",
+          "game": "poe2",
+          "sourceUrl": "https://poe2.kakaogames.com/api/shop-microtransactions?game=poe2",
+          "checkedAt": "2026-09-11T01:00:00.000Z",
+          "status": "ok",
+          "confirmedPeriod": null
+        }
+      ],
+      "anchor": {
+        "origin": "api",
+        "service": "ggg",
+        "game": "poe2",
+        "sourceUrl": "https://pathofexile2.com/api/shop-microtransactions?game=poe2",
+        "startsAt": "2026-09-11T00:00:01.000Z",
+        "endsAt": "2026-09-15T00:00:00.000Z",
+        "observedAt": "2026-09-11T01:00:00.000Z"
+      },
+      "nextEstimate": null
+    }
+  }
+}

--- a/scripts/promotions/publish.test.mjs
+++ b/scripts/promotions/publish.test.mjs
@@ -11,11 +11,13 @@ import {
 } from "node:fs";
 import { join, resolve, sep } from "node:path";
 import { publishFeed } from "./publish.mjs";
+import samples from "./fixtures/stash-sales-contract.json" with { type: "json" };
 
 const feed = {
   schemaVersion: 1,
   generatedAt: "2026-09-04T08:00:00Z",
   events: [],
+  stashSales: samples.manual.stashSales,
 };
 const git = (cwd, ...args) =>
   execFileSync("git", args, {
@@ -78,6 +80,10 @@ test("initial publication writes only promotions.json and identical repeat is a 
   assert.equal(
     git(r.origin, "rev-parse", "gh-pages"),
     git(r.pages, "rev-parse", "HEAD"),
+  );
+  assert.deepEqual(
+    JSON.parse(git(r.origin, "show", "gh-pages:promotions.json")).stashSales,
+    feed.stashSales,
   );
   assert.equal(
     publishFeed({ ...r, revision: git(r.pages, "rev-parse", "HEAD") }).changed,

--- a/scripts/promotions/stash-sales.mjs
+++ b/scripts/promotions/stash-sales.mjs
@@ -1,0 +1,316 @@
+import { SHOP_SOURCES, isCalendarDate, parseStashSales } from "./contract.mjs";
+import manualSeed from "./stash-seed.json" with { type: "json" };
+
+const DAY = 86400_000;
+// The legacy category API has no tags. Only independently identified personal
+// products may establish a sale; generic bundle "discount" is not a special.
+const POE1_PERSONAL_IDS = new Set([
+  "UpgradeToPremiumStashTab",
+  "PremiumStashTab",
+  "StashTab",
+  "TradeStashTab",
+  "StashTabBundle",
+  "TradeStashTabBundle",
+  "PremiumStashTabBundle",
+  "CurrencyTab",
+  "FragmentTab",
+  "GemTab",
+  "MapTab",
+  "FlaskTab",
+  "UniqueTab",
+  "PremiumQuadTab",
+  "BreachTab",
+  "DeliriumTab",
+  "EssenceTab",
+  "DivinationTab",
+  "BlightTab",
+  "MetamorphTab",
+  "DelveTab",
+]);
+const check = (condition, message) => {
+  if (!condition) throw new Error(message);
+};
+
+function apiTime(value) {
+  const match =
+    typeof value === "string" &&
+    /^(\d{4}-\d\d-\d\d)T(\d\d):(\d\d):(\d\d)(?:\.\d{3})?(Z|[+-](\d\d):(\d\d))$/.exec(
+      value,
+    );
+  check(
+    match &&
+      isCalendarDate(match[1]) &&
+      +match[2] < 24 &&
+      +match[3] < 60 &&
+      +match[4] < 60 &&
+      (!match[6] ||
+        (+match[6] <= 14 &&
+          +match[7] < 60 &&
+          (+match[6] !== 14 || +match[7] === 0))),
+    "Invalid API timestamp",
+  );
+  const time = Date.parse(value);
+  check(Number.isFinite(time), "Invalid API timestamp");
+  return new Date(time).toISOString();
+}
+
+function inspectShop(source, payload, now) {
+  const items = source.game === "poe2" ? payload?.data : payload?.items;
+  check(
+    Array.isArray(items) && items.length > 0 && items.length <= 5000,
+    "Invalid shop catalog",
+  );
+  if (source.game === "poe1")
+    check(payload.total === items.length, "Incomplete PoE1 category catalog");
+  const rows = items.flatMap((item) => {
+    check(
+      item && typeof item === "object" && !Array.isArray(item),
+      "Invalid shop product",
+    );
+    if (source.game === "poe2")
+      check(
+        Array.isArray(item.tags) &&
+          item.tags.every((tag) => typeof tag === "string"),
+        "Invalid product tags",
+      );
+    check(
+      item.variants === undefined || Array.isArray(item.variants),
+      "Invalid variants",
+    );
+    return [
+      item,
+      ...(item.variants ?? []).map((variant) => {
+        check(
+          variant && typeof variant === "object" && !Array.isArray(variant),
+          "Invalid variant",
+        );
+        check(
+          variant.tags === undefined ||
+            (Array.isArray(variant.tags) &&
+              variant.tags.every((tag) => typeof tag === "string")),
+          "Invalid variant tags",
+        );
+        return {
+          ...variant,
+          tags: variant.tags ?? item.tags,
+          guild: variant.guild ?? item.guild,
+        };
+      }),
+    ];
+  });
+  const personal = rows.filter(
+    (item) =>
+      item.guild !== true &&
+      (source.game === "poe2"
+        ? Array.isArray(item.tags) &&
+          item.tags.some(
+            (tag) => tag === "StashTabs" || tag === "PoE2StashTabs",
+          ) &&
+          !item.tags.some(
+            (tag) => tag === "GuildStashTabs" || tag === "PoE2GuildStashTabs",
+          )
+        : POE1_PERSONAL_IDS.has(item.id)),
+  );
+  check(
+    personal.length > 0 && personal.length <= 200,
+    "No identifiable personal stash products",
+  );
+  const periods = new Map();
+  let missingPeriod = false;
+  const discountedIds = [];
+  for (const item of personal) {
+    const baseCost = source.game === "poe2" ? item.baseCost : item.originalCost;
+    check(
+      typeof item.id === "string" &&
+        /^[A-Za-z0-9_-]{1,160}$/.test(item.id) &&
+        typeof item.cost === "number" &&
+        Number.isFinite(item.cost) &&
+        item.cost >= 0 &&
+        typeof baseCost === "number" &&
+        Number.isFinite(baseCost) &&
+        baseCost >= item.cost,
+      "Invalid personal stash price",
+    );
+    if (source.game === "poe1")
+      check(typeof item.onSpecial === "boolean", "Missing legacy special flag");
+    const discounted =
+      item.cost < baseCost && (source.game !== "poe1" || item.onSpecial);
+    if (!discounted && !(source.game === "poe1" && item.onSpecial)) continue;
+    if (discounted) discountedIds.push(item.id);
+    if (!item.special) {
+      missingPeriod = true;
+      continue;
+    }
+    if (!discounted) continue;
+    const startsAt = apiTime(item.special.start);
+    const endsAt = apiTime(item.special.end);
+    const start = Date.parse(startsAt),
+      end = Date.parse(endsAt);
+    check(
+      end > start &&
+        end - start <= 90 * DAY &&
+        start <= now.getTime() &&
+        now.getTime() < end,
+      "Inconsistent current sale period",
+    );
+    const key = `${startsAt}:${endsAt}`;
+    const period = periods.get(key) ?? {
+      startsAt,
+      endsAt,
+      observedAt: now.toISOString(),
+      productIds: [],
+    };
+    period.productIds.push(item.id);
+    periods.set(key, period);
+  }
+  check(periods.size <= 1, "Conflicting personal stash sale periods");
+  // Do not combine exact prices with an unrelated or incomplete period.
+  check(
+    !(missingPeriod && periods.size),
+    "Incomplete personal stash sale periods",
+  );
+  const confirmedPeriod = [...periods.values()][0] ?? null;
+  if (confirmedPeriod) {
+    confirmedPeriod.productIds = [
+      ...new Set(confirmedPeriod.productIds),
+    ].sort();
+    check(
+      confirmedPeriod.productIds.length <= 100,
+      "Too many confirmed stash products",
+    );
+  }
+  return {
+    observation: {
+      ...source,
+      checkedAt: now.toISOString(),
+      status: missingPeriod ? "period-unavailable" : "ok",
+      confirmedPeriod,
+    },
+    personalCount: personal.length,
+    discountedIds: [...new Set(discountedIds)].sort(),
+  };
+}
+
+const seoulDate = (utc) =>
+  new Date(Date.parse(utc) + 9 * 3600_000).toISOString().slice(0, 10);
+const addDays = (date, days) =>
+  new Date(Date.parse(date + "T00:00:00Z") + days * DAY)
+    .toISOString()
+    .slice(0, 10);
+
+function estimate(anchor, now) {
+  if (!anchor) return null;
+  const startDate = addDays(
+    anchor.origin === "api" ? seoulDate(anchor.startsAt) : anchor.startDate,
+    21,
+  );
+  const endDate = addDays(
+    anchor.origin === "api" ? seoulDate(anchor.endsAt) : anchor.endDate,
+    21,
+  );
+  const expiresAt = Date.parse(addDays(endDate, 1) + "T00:00:00+09:00");
+  if (now.getTime() >= expiresAt) return null;
+  return {
+    startDate,
+    endDate,
+    timeZone: "Asia/Seoul",
+    intervalDays: 21,
+    basisOrigin: anchor.origin,
+    basisSourceUrl:
+      anchor.origin === "api" ? anchor.sourceUrl : anchor.sourceUrls.at(-1),
+  };
+}
+
+export async function collectStashSales({ previous, fetchText, pause, clock }) {
+  const observations = [],
+    reports = [],
+    warnings = [];
+  let anchor = previous?.anchor ?? structuredClone(manualSeed);
+  for (const source of SHOP_SOURCES) {
+    await pause();
+    const prior = previous?.observations.find(
+      (x) => x.service === source.service && x.game === source.game,
+    );
+    try {
+      const payload = JSON.parse(await fetchText(source.sourceUrl));
+      const result = inspectShop(source, payload, clock());
+      observations.push(result.observation);
+      reports.push(result);
+      const period = result.observation.confirmedPeriod;
+      if (
+        period &&
+        (anchor?.origin !== "api" ||
+          Date.parse(period.startsAt) > Date.parse(anchor.startsAt))
+      ) {
+        anchor = {
+          origin: "api",
+          ...source,
+          startsAt: period.startsAt,
+          endsAt: period.endsAt,
+          observedAt: period.observedAt,
+        };
+      }
+    } catch (error) {
+      const now = clock();
+      const observation = {
+        ...source,
+        checkedAt: prior?.checkedAt ?? now.toISOString(),
+        status: "unavailable",
+        confirmedPeriod:
+          prior?.confirmedPeriod &&
+          Date.parse(prior.confirmedPeriod.endsAt) > now.getTime()
+            ? prior.confirmedPeriod
+            : null,
+      };
+      observations.push(observation);
+      reports.push({ observation, personalCount: null, discountedIds: null });
+      warnings.push(`${source.sourceUrl}: ${error.message}`);
+    }
+  }
+  const now = clock();
+  for (const observation of observations)
+    if (
+      observation.confirmedPeriod &&
+      Date.parse(observation.confirmedPeriod.endsAt) <= now.getTime()
+    )
+      observation.confirmedPeriod = null;
+  const stashSales = parseStashSales({
+    version: 1,
+    observations,
+    anchor,
+    nextEstimate: estimate(anchor, now),
+  });
+  return { stashSales, reports, warnings };
+}
+
+export function collectionSummary(feed, reports, warnings) {
+  const stash = feed.stashSales;
+  const rows = reports.map(
+    ({ observation: o, personalCount, discountedIds }) => {
+      const p = o.confirmedPeriod;
+      const evidence = p
+        ? `${o.status === "ok" ? "API confirmed" : "Cached API confirmation"}: ${p.startsAt} - ${p.endsAt}; ${p.productIds.join(", ")}`
+        : "No confirmed period";
+      return `| ${o.service} ${o.game} | ${o.status} | ${o.checkedAt} | ${personalCount ?? "unavailable"} | ${discountedIds?.join(", ") || "-"} | ${evidence} |`;
+    },
+  );
+  return [
+    "## Promotion collection",
+    `Generated: ${feed.generatedAt}; Twitch drops: ${feed.events.length}`,
+    "",
+    "| Source | Status | Last successful check (first failure: attempt) | Personal products | Discounted product IDs | Evidence |",
+    "| --- | --- | --- | --- | --- | --- |",
+    ...rows,
+    "",
+    `Anchor: ${stash.anchor?.origin ?? "none"}; ${stash.anchor?.sourceUrl ?? stash.anchor?.sourceUrls.join(", ") ?? "-"}`,
+    `Date-only estimate (never an API confirmation): ${stash.nextEstimate ? `${stash.nextEstimate.startDate} - ${stash.nextEstimate.endDate} Asia/Seoul; +21 days once` : "none"}`,
+    ...(warnings.length
+      ? [
+          "",
+          "Warnings:",
+          ...warnings.map((warning) => `- ${warning.replace(/[\r\n|]/g, " ")}`),
+        ]
+      : []),
+    "",
+  ].join("\n");
+}

--- a/scripts/promotions/stash-sales.test.mjs
+++ b/scripts/promotions/stash-sales.test.mjs
@@ -1,0 +1,394 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { collect } from "./collect.mjs";
+import { SHOP_SOURCES } from "./contract.mjs";
+import samples from "./fixtures/stash-sales-contract.json" with { type: "json" };
+
+const now = new Date("2026-09-11T01:00:00.000Z");
+const special = {
+  start: "2026-09-11T00:00:01+00:00",
+  end: "2026-09-15T00:00:00+00:00",
+};
+const tab = (change = {}) => ({
+  id: "CurrencyTab",
+  tags: ["StashTabs", "PoE2StashTabs"],
+  guild: false,
+  cost: 75,
+  baseCost: 75,
+  special: null,
+  ...change,
+});
+const oldTab = (change = {}) => ({
+  id: "CurrencyTab",
+  guild: false,
+  cost: 75,
+  originalCost: 75,
+  onSpecial: false,
+  ...change,
+});
+const defaults = (source) =>
+  source.game === "poe1"
+    ? { items: [oldTab()], total: 1 }
+    : { data: [tab()], meta: {} };
+
+async function run({ previous = null, at = now, payload, fail, clock } = {}) {
+  return collect({
+    previous,
+    overrides: { events: [], disabledIds: [] },
+    now: at,
+    clock,
+    pause: async () => {},
+    fetchText: async (url) => {
+      const source = SHOP_SOURCES.find((source) => source.sourceUrl === url);
+      if (fail?.(url, source)) throw new Error("HTTP 503");
+      if (source) return JSON.stringify(payload?.(source) ?? defaults(source));
+      if (url.endsWith("/rss"))
+        return "<rss><channel><item><title>Build Showcase</title></item></channel></rss>";
+      return '<table class="forumTable"></table>';
+    },
+  });
+}
+const observation = (result, service = "ggg", game = "poe2") =>
+  result.feed.stashSales?.observations.find(
+    (x) => x.service === service && x.game === game,
+  );
+const apiRun = (products, other = {}) =>
+  run({
+    ...other,
+    payload: (s) =>
+      s.game === "poe2" ? { data: products, meta: {} } : defaults(s),
+  });
+
+test("full-price catalogs seed the announced dates without claiming API confirmation", async () => {
+  const result = await run({ at: new Date(samples.manual.generatedAt) });
+  assert.deepEqual(
+    result.feed.stashSales?.anchor,
+    samples.manual.stashSales.anchor,
+  );
+  assert.deepEqual(
+    result.feed.stashSales.nextEstimate,
+    samples.manual.stashSales.nextEstimate,
+  );
+  assert.equal(result.feed.stashSales.observations.length, 4);
+  assert.ok(
+    result.feed.stashSales.observations.every(
+      (x) => x.status === "ok" && x.confirmedPeriod === null,
+    ),
+  );
+  assert.deepEqual(result.feed.events, []);
+});
+
+test("only discounted personal stash products contribute exact normalized API periods", async () => {
+  const result = await apiRun([
+    tab({ cost: 60, special }),
+    tab({ id: "PremiumStashTab", cost: 30, baseCost: 40, special }),
+    tab({ id: "WeaponEffect", tags: ["WeaponEffects"], cost: 10, special }),
+    tab({
+      id: "GuildCurrencyTab",
+      tags: ["GuildStashTabs", "PoE2GuildStashTabs"],
+      guild: true,
+      cost: 10,
+      special,
+    }),
+    tab({ id: "StashTabBundle", cost: 150, baseCost: 150, discount: 30 }),
+  ]);
+  assert.deepEqual(
+    observation(result)?.confirmedPeriod,
+    samples.confirmed.stashSales.observations[1].confirmedPeriod,
+  );
+  assert.deepEqual(
+    result.feed.stashSales.anchor,
+    samples.confirmed.stashSales.anchor,
+  );
+  assert.deepEqual(
+    result.feed.stashSales.nextEstimate,
+    samples.confirmed.stashSales.nextEstimate,
+  );
+  assert.deepEqual(result.feed.events, []);
+});
+
+test("a discounted variant inherits a missing tag list but never overwrites its own tags", async () => {
+  const result = await apiRun([
+    tab({
+      variants: [
+        { id: "VariantTab", cost: 50, baseCost: 75, special },
+        {
+          id: "NotATab",
+          tags: ["WeaponEffects"],
+          cost: 50,
+          baseCost: 75,
+          special,
+        },
+      ],
+    }),
+  ]);
+  assert.deepEqual(observation(result)?.confirmedPeriod?.productIds, [
+    "VariantTab",
+  ]);
+});
+
+test("unrelated specials and bundle discounts do not establish an API anchor", async () => {
+  const result = await apiRun([
+    tab({ id: "StashTabBundle", discount: 30 }),
+    tab({ id: "WeaponEffect", tags: ["WeaponEffects"], cost: 10, special }),
+  ]);
+  assert.equal(observation(result)?.status, "ok");
+  assert.equal(observation(result)?.confirmedPeriod, null);
+  assert.equal(result.feed.stashSales.anchor.origin, "manual-announcement");
+});
+
+test("PoE1 price-only sale reports unavailable period; regular bundle savings are not a sale", async () => {
+  const result = await run({
+    payload: (s) =>
+      s.game === "poe1"
+        ? { items: [oldTab({ cost: 60, onSpecial: true })], total: 1 }
+        : defaults(s),
+  });
+  assert.equal(
+    observation(result, "kakao", "poe1")?.status,
+    "period-unavailable",
+  );
+  assert.equal(observation(result, "kakao", "poe1")?.confirmedPeriod, null);
+  const bundle = await run({
+    payload: (s) =>
+      s.game === "poe1"
+        ? {
+            items: [
+              oldTab({
+                id: "StashTabBundle",
+                cost: 150,
+                originalCost: 150,
+                discount: 30,
+              }),
+            ],
+            total: 1,
+          }
+        : defaults(s),
+  });
+  assert.equal(observation(bundle, "kakao", "poe1")?.status, "ok");
+});
+
+test("a later PoE1 API period can confirm only its identified discounted personal tabs", async () => {
+  const result = await run({
+    payload: (s) =>
+      s.game === "poe1"
+        ? {
+            items: [
+              oldTab({ cost: 60, onSpecial: true, special }),
+              oldTab({
+                id: "WeaponEffect",
+                cost: 10,
+                onSpecial: true,
+                special,
+              }),
+            ],
+            total: 2,
+          }
+        : defaults(s),
+  });
+  assert.deepEqual(
+    observation(result, "kakao", "poe1")?.confirmedPeriod?.productIds,
+    ["CurrencyTab"],
+  );
+});
+
+test("request failures preserve the last successful time and unexpired confirmed evidence", async () => {
+  const result = await run({
+    previous: samples.confirmed,
+    at: new Date(samples.unavailable.generatedAt),
+    fail: (_url, s) => s?.service === "ggg" && s.game === "poe2",
+  });
+  assert.deepEqual(
+    observation(result),
+    samples.unavailable.stashSales.observations[1],
+  );
+  assert.deepEqual(
+    result.feed.stashSales.anchor,
+    samples.confirmed.stashSales.anchor,
+  );
+});
+
+test("cache expires at end even on failure while the API anchor stays durable", async () => {
+  const result = await run({
+    previous: samples.confirmed,
+    at: new Date("2026-09-15T00:00:00Z"),
+    fail: (_url, s) => !!s,
+  });
+  assert.equal(observation(result)?.confirmedPeriod, null);
+  assert.equal(observation(result)?.status, "unavailable");
+  assert.deepEqual(
+    result.feed.stashSales.anchor,
+    samples.confirmed.stashSales.anchor,
+  );
+});
+
+test("successful full-price observation clears cached current sale without losing the anchor", async () => {
+  const result = await run({ previous: samples.confirmed });
+  assert.equal(observation(result)?.confirmedPeriod, null);
+  assert.equal(observation(result)?.status, "ok");
+  assert.deepEqual(
+    result.feed.stashSales.anchor,
+    samples.confirmed.stashSales.anchor,
+  );
+});
+
+test("empty, malformed, incomplete and ambiguous catalogs never become successful no-sale observations", async () => {
+  const broken = [
+    { data: [] },
+    {},
+    { data: [tab({ cost: "60", special })] },
+    {
+      data: [
+        tab(),
+        tab({ id: "PremiumStashTab", tags: null, cost: 60, special }),
+      ],
+    },
+    {
+      data: [
+        tab(),
+        tab({ id: "PremiumStashTab", tags: "StashTabs", cost: 60, special }),
+      ],
+    },
+    {
+      data: [
+        tab({
+          variants: [
+            { id: "VariantTab", tags: null, cost: 60, baseCost: 75, special },
+          ],
+        }),
+      ],
+    },
+    {
+      data: [
+        tab({
+          cost: 60,
+          special: { ...special, start: "2026-02-30T00:00:00Z" },
+        }),
+      ],
+    },
+    { data: [tab({ cost: 60, special: { ...special, end: special.start } })] },
+    {
+      data: [
+        tab({ cost: 60, special }),
+        tab({
+          id: "PremiumStashTab",
+          cost: 20,
+          special: { ...special, end: "2026-09-16T00:00:00Z" },
+        }),
+      ],
+    },
+  ];
+  for (const payload of broken) {
+    const result = await run({
+      previous: samples.confirmed,
+      payload: (s) => (s.game === "poe2" ? payload : defaults(s)),
+    });
+    assert.equal(observation(result)?.status, "unavailable");
+    assert.deepEqual(
+      observation(result)?.confirmedPeriod,
+      samples.confirmed.stashSales.observations[1].confirmedPeriod,
+    );
+  }
+});
+
+test("an equal-start API observation does not swap the persisted anchor between services", async () => {
+  const prior = structuredClone(samples.confirmed);
+  prior.stashSales.anchor.service = "kakao";
+  prior.stashSales.anchor.sourceUrl = SHOP_SOURCES[3].sourceUrl;
+  prior.stashSales.nextEstimate.basisSourceUrl = SHOP_SOURCES[3].sourceUrl;
+  const result = await apiRun([tab({ cost: 60, special })], {
+    previous: prior,
+  });
+  assert.deepEqual(result.feed.stashSales?.anchor, prior.stashSales.anchor);
+});
+
+test("a newer observed sale replaces the manual basis and generates only its next period", async () => {
+  const result = await apiRun([tab({ cost: 60, special })], {
+    previous: samples.manual,
+  });
+  assert.equal(result.feed.stashSales?.anchor.origin, "api");
+  assert.equal(result.feed.stashSales?.nextEstimate.startDate, "2026-10-02");
+});
+
+test("estimates stop after the end date in Seoul and never roll forward without confirmation", async () => {
+  const justBefore = await run({
+    previous: samples.manual,
+    at: new Date("2026-09-15T14:59:59Z"),
+  });
+  assert.equal(justBefore.feed.stashSales?.nextEstimate?.endDate, "2026-09-15");
+  const atEnd = await run({
+    previous: justBefore.feed,
+    at: new Date("2026-09-15T15:00:00Z"),
+  });
+  assert.equal(atEnd.feed.stashSales?.nextEstimate, null);
+  const later = await run({
+    previous: atEnd.feed,
+    at: new Date("2026-12-01T00:00:00Z"),
+  });
+  assert.equal(later.feed.stashSales?.nextEstimate, null);
+  assert.deepEqual(
+    later.feed.stashSales?.anchor,
+    samples.manual.stashSales.anchor,
+  );
+});
+
+test("API UTC dates are converted to Seoul before the one-time calendar shift", async () => {
+  const previous = structuredClone(samples.confirmed);
+  Object.assign(previous.stashSales.anchor, {
+    startsAt: "2026-12-18T20:00:00Z",
+    endsAt: "2026-12-22T20:00:00Z",
+    observedAt: "2026-12-19T00:00:00Z",
+  });
+  previous.stashSales.nextEstimate = null;
+  const result = await run({ previous, at: new Date("2026-12-23T00:00:00Z") });
+  assert.equal(result.feed.stashSales?.nextEstimate?.startDate, "2027-01-09");
+  assert.equal(result.feed.stashSales?.nextEstimate?.endDate, "2027-01-13");
+});
+
+test("RSS failure cannot block actual API confirmation or erase known drops", async () => {
+  const drop = {
+    id: "existing-drop",
+    kind: "twitch-drops",
+    game: "poe2",
+    startsAt: "2026-09-11T00:00:00Z",
+    endsAt: "2026-09-12T00:00:00Z",
+    sourceUrl: "https://www.pathofexile.com/forum/view-thread/1",
+    precision: "exact",
+  };
+  const result = await apiRun([tab({ cost: 60, special })], {
+    previous: { ...samples.manual, events: [drop] },
+    fail: (url) => url.endsWith("/rss"),
+  });
+  assert.deepEqual(result.feed.events, [drop]);
+  assert.equal(result.feed.stashSales?.anchor.origin, "api");
+  assert.ok(result.warnings.some((x) => x.includes("503")));
+});
+
+test("the run summary distinguishes a manual prediction from actual API observations", async () => {
+  const manual = await run();
+  assert.match(manual.summary ?? "", /manual-announcement/);
+  assert.match(manual.summary ?? "", /2026-09-11/);
+  const confirmed = await apiRun([tab({ cost: 60, special })]);
+  assert.match(confirmed.summary ?? "", /CurrencyTab/);
+  assert.match(confirmed.summary ?? "", /2026-09-11T00:00:01.000Z/);
+  assert.match(confirmed.summary ?? "", /API confirmed/);
+});
+
+test("checkedAt and observedAt reflect each completed API request instead of the run start", async () => {
+  let time = now.getTime();
+  const result = await run({
+    clock: () => new Date(time),
+    payload: (source) => {
+      time += 60_000;
+      return source.game === "poe2"
+        ? { data: [tab({ cost: 60, special })], meta: {} }
+        : defaults(source);
+    },
+  });
+  assert.equal(observation(result)?.checkedAt, "2026-09-11T01:02:00.000Z");
+  assert.equal(
+    observation(result)?.confirmedPeriod?.observedAt,
+    "2026-09-11T01:02:00.000Z",
+  );
+  assert.equal(result.feed.generatedAt, "2026-09-11T01:04:00.000Z");
+});

--- a/scripts/promotions/stash-seed.json
+++ b/scripts/promotions/stash-seed.json
@@ -1,0 +1,14 @@
+{
+  "origin": "manual-announcement",
+  "startDate": "2026-08-21",
+  "endDate": "2026-08-25",
+  "timeZone": "Asia/Seoul",
+  "sourceUrls": [
+    "https://poe.kakaogames.com/forum/view-thread/3991174",
+    "https://poe.kakaogames.com/forum/view-thread/3998528"
+  ],
+  "scope": [
+    { "service": "kakao", "game": "poe1" },
+    { "service": "kakao", "game": "poe2" }
+  ]
+}

--- a/scripts/promotions/verify-published.test.mjs
+++ b/scripts/promotions/verify-published.test.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { verifyPublished } from "./verify-published.mjs";
+import samples from "./fixtures/stash-sales-contract.json" with { type: "json" };
 
 const expected = {
   schemaVersion: 1,
@@ -34,4 +35,16 @@ test("invalid or unchanged public responses fail within the retry bound", async 
     /not verified/,
   );
   assert.equal(calls, 2);
+});
+
+test("public verification rejects a feed whose legacy publisher stripped the stash anchor", async () => {
+  const { stashSales: _stash, ...stripped } = samples.manual;
+  await assert.rejects(
+    verifyPublished(samples.manual, {
+      attempts: 1,
+      fetchResponse: async () => Response.json(stripped),
+      pause: async () => {},
+    }),
+    /not verified/,
+  );
 });


### PR DESCRIPTION
## Summary

공식 상점 API의 개인 보관함 가격과 기간을 수집하고, RSS/포럼 수집은 Twitch Drops로 제한합니다. 통합 `promotions.json`의 optional `stashSales`에 서비스별 관측, 마지막 기준, 한 번의 21일 예상을 보존합니다.

8월 21~25일 공식 캘린더·공지의 날짜를 수동 초기 기준으로 사용하며, 실제 API 확인이 생기면 해당 기간을 우선합니다. 만료된 표시 일정은 제거하고 기준은 유지합니다. 수집 실패와 정상 할인 없음을 구분하며 Actions 요약에 수동 예상과 실제 관측 결과를 별도로 남깁니다.

## Motivation

보관함 공지의 게시 시각을 실제 할인 시작으로 오인하지 않고, 할인이 없는 기간에도 다음 예상의 근거가 사라지지 않도록 합니다. 드롭스와 상점 요청을 독립적으로 처리하고 기존 schema 1 소비자의 드롭스 호환성을 유지합니다.
