### PR TITLE
feat: 트위치 드롭스와 보관함 할인 일정·알림을 확인할 수 있도록 추가

### DIFF
--- a/.github/workflows/check-promotions.yml
+++ b/.github/workflows/check-promotions.yml
@@ -1,0 +1,32 @@
+name: Check Event Promotions
+
+on:
+  pull_request:
+    paths:
+      - "scripts/promotions/**"
+      - "src/shared/promotions.ts"
+      - "src/shared/stash-sales.ts"
+      - ".github/workflows/check-promotions.yml"
+      - ".github/workflows/update-promotions.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: event-promotions-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "24"
+          cache: npm
+      - run: npm ci --omit=dev --ignore-scripts --no-audit --no-fund
+      - run: node --test scripts/promotions/*.test.mjs

--- a/.github/workflows/update-promotions.yml
+++ b/.github/workflows/update-promotions.yml
@@ -9,18 +9,14 @@ on:
     paths:
       - "scripts/promotions/**"
       - "src/shared/promotions.ts"
-      - ".github/workflows/update-promotions.yml"
-  pull_request:
-    paths:
-      - "scripts/promotions/**"
-      - "src/shared/promotions.ts"
+      - "src/shared/stash-sales.ts"
       - ".github/workflows/update-promotions.yml"
 
 permissions:
   contents: read
 
 concurrency:
-  group: event-promotions-${{ github.event_name == 'pull_request' && github.event.pull_request.number || 'publisher' }}
+  group: event-promotions-publisher
   cancel-in-progress: false
 
 jobs:

--- a/scripts/promotions/README.md
+++ b/scripts/promotions/README.md
@@ -76,7 +76,7 @@ PoE2 태그는 `StashTabs` 또는 `PoE2StashTabs` **정확히 일치**해야 한
 
 `.github/workflows/update-promotions.yml`은 UTC **00:17/06:17/12:17/18:17**(KST **09:17/15:17/21:17/03:17**)에 실행한다. GitHub schedule은 지연되거나 누락될 수 있으므로 정확한 시작·종료 판정은 런처가 로컬 시각으로 수행한다. 런처의 시작/절전 복귀/1시간 조회 계약은 유지한다. [GitHub schedule 문서](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#schedule)
 
-동일 workflow의 PR 실행은 읽기 권한의 테스트만 수행한다. 수집·발행은 원래 저장소 master의 schedule/수동 실행/관련 경로 push에서만 가능하다. 별도 중복 스케줄러는 필요 없다. 예약/수동 실행을 등록하려면 workflow가 기본 브랜치에 적용되어야 한다.
+PR 검사는 `.github/workflows/check-promotions.yml`의 **Check Event Promotions**에서 읽기 권한의 테스트만 수행한다. **Update Event Promotions**는 PR에서 실행하지 않으므로 수집·발행 작업이 PR 체크 목록에 생성되지 않는다. 수집·발행은 원래 저장소 master의 schedule/수동 실행/관련 경로 push에서 테스트를 통과한 뒤에만 가능하다. 별도 중복 스케줄러는 필요 없다. 예약/수동 실행을 등록하려면 workflow가 기본 브랜치에 적용되어야 한다.
 
 수집 단계는 `GITHUB_STEP_SUMMARY`에 네 소스의 상태/마지막 확인 시각/분류한 상품 수/할인 상품 ID/확정 기간을 기록한다. 실패 시 캐시 확정은 `Cached API confirmation`, 이번 성공은 `API confirmed`로 표시한다. 수동 기준과 날짜 예측은 별도 줄로 표시하므로 수동 표시를 API 감지 성공으로 오인하지 않는다.
 

--- a/scripts/promotions/contract.test.mjs
+++ b/scripts/promotions/contract.test.mjs
@@ -1,7 +1,8 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { existsSync } from "node:fs";
-import { resolve } from "node:path";
+import { extname, resolve } from "node:path";
+import { registerHooks } from "node:module";
 import { pathToFileURL } from "node:url";
 import { parsePromotionFeed } from "./contract.mjs";
 import samples from "./fixtures/stash-sales-contract.json" with { type: "json" };
@@ -207,6 +208,20 @@ test("validator matches the actual launcher consumer when available", async (t) 
     );
     return;
   }
+  // The launcher uses bundler-style imports; keep this Node-only check dependency-free.
+  const hooks = registerHooks({
+    resolve(specifier, context, nextResolve) {
+      if (
+        context.parentURL?.endsWith(".ts") &&
+        /^\.\.?\//.test(specifier) &&
+        !extname(specifier)
+      ) {
+        return nextResolve(`${specifier}.ts`, context);
+      }
+      return nextResolve(specifier, context);
+    },
+  });
+  t.after(() => hooks.deregister());
   const consumer = await import(pathToFileURL(path).href);
   for (const input of [...valid, ...Object.values(samples)])
     assert.deepEqual(

--- a/src/main/events/handlers/EventNotificationHandler.ts
+++ b/src/main/events/handlers/EventNotificationHandler.ts
@@ -1,0 +1,65 @@
+import {
+  EventType,
+  type EventHandler,
+  type ConfigChangeEvent,
+  type ConfigDeleteEvent,
+  type PromotionsUpdatedEvent,
+  type PromotionDismissEvent,
+} from "../types";
+
+import type { EventNotificationService } from "../../services/EventNotificationService";
+
+export const EventNotificationDismissHandler: EventHandler<PromotionDismissEvent> =
+  {
+    id: "EventNotificationDismissHandler",
+    targetEvent: EventType.PROMOTION_DISMISS,
+    handle: async (event, context) => {
+      const service = context.serviceManager.get<EventNotificationService>(
+        "EventNotificationService",
+      );
+      if (!service) return;
+      try {
+        service.dismiss(event.payload.request);
+        event.payload.result.value = { ok: true };
+      } catch {
+        event.payload.result.value = { ok: false, reason: "save-failed" };
+      }
+    },
+  };
+
+export const EventNotificationSettingsHandler: EventHandler<ConfigChangeEvent> =
+  {
+    id: "EventNotificationSettingsHandler",
+    targetEvent: EventType.CONFIG_CHANGE,
+    handle: async (event, context) => {
+      if (event.payload.key === "eventNotifications") {
+        context.serviceManager
+          .get<EventNotificationService>("EventNotificationService")
+          ?.settingsChanged();
+      }
+    },
+  };
+
+export const EventNotificationSettingsDeleteHandler: EventHandler<ConfigDeleteEvent> =
+  {
+    id: "EventNotificationSettingsDeleteHandler",
+    targetEvent: EventType.CONFIG_DELETE,
+    handle: async (event, context) => {
+      if (event.payload.key === "eventNotifications") {
+        context.serviceManager
+          .get<EventNotificationService>("EventNotificationService")
+          ?.settingsChanged();
+      }
+    },
+  };
+
+export const EventNotificationUISyncHandler: EventHandler<PromotionsUpdatedEvent> =
+  {
+    id: "EventNotificationUISyncHandler",
+    targetEvent: EventType.PROMOTIONS_UPDATED,
+    handle: async (event, context) => {
+      const window = context.mainWindow;
+      if (window && !window.isDestroyed())
+        window.webContents.send("promotions:updated", event.payload);
+    },
+  };

--- a/src/main/events/register-handlers.ts
+++ b/src/main/events/register-handlers.ts
@@ -18,6 +18,12 @@ import {
 } from "./handlers/ConfigSyncHandler";
 import { DebugLogHandler } from "./handlers/DebugLogHandler";
 import { DevToolsVisibilityHandler } from "./handlers/DevToolsVisibilityHandler";
+import {
+  EventNotificationDismissHandler,
+  EventNotificationSettingsHandler,
+  EventNotificationSettingsDeleteHandler,
+  EventNotificationUISyncHandler,
+} from "./handlers/EventNotificationHandler";
 import { GameInstallCheckHandler } from "./handlers/GameInstallCheckHandler";
 import {
   GameProcessStartHandler,
@@ -75,6 +81,10 @@ export const CORE_EVENT_HANDLERS = [
   KakaoMaintenanceUISyncHandler,
   RenewedPatchReservationCreateHandler,
   RenewedPatchReservationDeleteHandler,
+  EventNotificationSettingsHandler,
+  EventNotificationSettingsDeleteHandler,
+  EventNotificationUISyncHandler,
+  EventNotificationDismissHandler,
 ] as const;
 
 export function registerCoreEventHandlers() {

--- a/src/main/events/types.ts
+++ b/src/main/events/types.ts
@@ -12,6 +12,12 @@ import {
   RenewedPatchReservationCommandResult,
 } from "../../shared/types";
 
+import type {
+  PromotionDismissRequest,
+  PromotionDismissResult,
+  PromotionSnapshot,
+} from "../../shared/promotions";
+
 // Event Enums
 export enum EventType {
   UI_GAME_START_CLICK = "UI:GAME_START_CLICK",
@@ -57,6 +63,8 @@ export enum EventType {
 
   // Kakao Games maintenance
   KAKAO_MAINTENANCE_DETECTED = "KAKAO:MAINTENANCE_DETECTED",
+  PROMOTIONS_UPDATED = "PROMOTIONS:UPDATED",
+  PROMOTION_DISMISS = "PROMOTIONS:DISMISS",
 }
 
 export interface ToolForceRepairEvent {
@@ -289,6 +297,8 @@ export interface KakaoMaintenanceDetectedEvent {
 
 // --- Discriminated Union ---
 export type AppEvent =
+  | PromotionDismissEvent
+  | PromotionsUpdatedEvent
   | ConfigChangeEvent
   | ProcessEvent
   | UIEvent
@@ -320,6 +330,21 @@ export type AppEvent =
   | RenewedPatchReservationDeleteEvent
   | RemoteVersionUpdatedEvent
   | KakaoMaintenanceDetectedEvent;
+
+export interface PromotionsUpdatedEvent {
+  type: EventType.PROMOTIONS_UPDATED;
+  payload: PromotionSnapshot;
+  timestamp?: number;
+}
+
+export interface PromotionDismissEvent {
+  type: EventType.PROMOTION_DISMISS;
+  payload: {
+    request: PromotionDismissRequest;
+    result: { value: PromotionDismissResult };
+  };
+  timestamp?: number;
+}
 
 export interface RemoteVersionUpdatedEvent {
   type: EventType.REMOTE_VERSION_UPDATED;

--- a/src/main/ipc/event-notifications.ts
+++ b/src/main/ipc/event-notifications.ts
@@ -1,0 +1,58 @@
+import { ipcMain } from "electron";
+
+import { eventBus } from "../events/EventBus";
+import {
+  EventType,
+  type AppContext,
+  type PromotionDismissEvent,
+} from "../events/types";
+
+import type { PromotionDismissResult } from "../../shared/promotions";
+import type { EventNotificationService } from "../services/EventNotificationService";
+
+export async function dismissPromotion(
+  context: AppContext,
+  input: unknown,
+): Promise<PromotionDismissResult> {
+  if (
+    !input ||
+    typeof input !== "object" ||
+    !("key" in input) ||
+    !("mode" in input) ||
+    typeof input.key !== "string" ||
+    !/^[a-z0-9:-]{1,160}$/.test(input.key) ||
+    (input.mode !== "session" && input.mode !== "schedule")
+  ) {
+    return { ok: false, reason: "invalid-request" };
+  }
+  const result: PromotionDismissEvent["payload"]["result"] = {
+    value: { ok: false, reason: "service-unavailable" },
+  };
+  await eventBus.emit<PromotionDismissEvent>(
+    EventType.PROMOTION_DISMISS,
+    context,
+    {
+      request: { key: input.key, mode: input.mode },
+      result,
+    },
+  );
+  return result.value;
+}
+
+export function registerEventNotificationIpc(context: AppContext): void {
+  ipcMain.handle("promotions:dismiss", (_event, request: unknown) =>
+    dismissPromotion(context, request),
+  );
+  ipcMain.handle(
+    "promotions:get",
+    () =>
+      context.serviceManager
+        .get<EventNotificationService>("EventNotificationService")
+        ?.snapshot() ?? {
+        revision: 0,
+        events: [],
+        activeEvents: [],
+        upcomingEvents: [],
+      },
+  );
+}

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -74,6 +74,7 @@ import {
 } from "./game/GameInstallStatusReconciler";
 import { GameSessionTracker, SessionContext } from "./game/GameSessionTracker";
 import { registerDiagnosticLogIpc } from "./ipc/diagnostic-log-ipc";
+import { registerEventNotificationIpc } from "./ipc/event-notifications";
 import { registerGameStatusIpc } from "./ipc/game-status-ipc";
 import {
   createRenewedPatchReservation,
@@ -3362,6 +3363,7 @@ app.whenReady().then(async () => {
 
   // Register Font IPC Handlers early to avoid race conditions
   FontIpcHandler.register();
+  registerEventNotificationIpc(context);
 
   // Register custom protocol to load assets from %appdata%
   protocol.handle("asset", (request) => {

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -36,12 +36,30 @@ import {
   LauncherLogSaveResult,
 } from "../shared/types";
 
+import type {
+  PromotionDismissRequest,
+  PromotionDismissResult,
+  PromotionSnapshot,
+} from "../shared/promotions";
+
 const logger = new PreloadLogger({ type: "PRELOAD", typeColor: "#8BE9FD" });
 
 // --- Electron API Expose ---
 // Used by React Renderer (App.tsx)
 
 contextBridge.exposeInMainWorld("electronAPI", {
+  dismissPromotion: (
+    request: PromotionDismissRequest,
+  ): Promise<PromotionDismissResult> =>
+    ipcRenderer.invoke("promotions:dismiss", request),
+  getPromotions: (): Promise<PromotionSnapshot> =>
+    ipcRenderer.invoke("promotions:get"),
+  onPromotionsUpdated: (callback: (snapshot: PromotionSnapshot) => void) => {
+    const handler = (_event: IpcRendererEvent, snapshot: PromotionSnapshot) =>
+      callback(snapshot);
+    ipcRenderer.on("promotions:updated", handler);
+    return () => ipcRenderer.off("promotions:updated", handler);
+  },
   triggerGameStart: (context: GameLaunchContext) => {
     logger.log("[Preload] Sending trigger-game-start to Main Process");
     ipcRenderer.send("trigger-game-start", context);

--- a/src/main/services/EventNotificationService.ts
+++ b/src/main/services/EventNotificationService.ts
@@ -1,0 +1,132 @@
+import axios from "axios";
+import { Notification, powerMonitor } from "electron";
+import Store from "electron-store";
+
+import { buildPromotionToast } from "./promotion-toast";
+import {
+  PromotionController,
+  type PromotionCache,
+} from "./PromotionController";
+import {
+  promotionScheduleKey,
+  type PromotionDismissRequest,
+  type PromotionEvent,
+} from "../../shared/promotions";
+import { SUPPORT_URLS } from "../../shared/urls";
+import { eventBus } from "../events/EventBus";
+import { EventType, type AppContext, type IService } from "../events/types";
+import { logger } from "../utils/logger";
+
+export class EventNotificationService implements IService {
+  readonly id = "EventNotificationService";
+  private readonly controller: PromotionController;
+  private readonly notifications = new Map<
+    string,
+    { notification: Notification; targets: string[] }
+  >();
+  private readonly resume = () => this.controller.wake();
+
+  constructor(context: AppContext) {
+    const store = new Store<PromotionCache>({
+      name: "event-notifications",
+      defaults: { feed: null, windows: {} },
+    });
+    this.controller = new PromotionController({
+      load: () => store.store,
+      save: (value) => {
+        store.store = value;
+      },
+      preferences: () => context.getConfig("eventNotifications"),
+      fetchFeed: async (signal) =>
+        (
+          await axios.get(SUPPORT_URLS.PROMOTIONS_JSON, {
+            signal,
+            timeout: 15_000,
+            maxContentLength: 256 * 1024,
+            headers: { Accept: "application/json" },
+          })
+        ).data,
+      changed: (snapshot) => {
+        void eventBus.emit(EventType.PROMOTIONS_UPDATED, context, snapshot);
+      },
+      warn: (message) => logger.warn(`[EventNotificationService] ${message}`),
+      notify: (event) => this.notify(event),
+      prune: (active) => {
+        const currentTargets = new Map(
+          this.controller
+            .snapshot()
+            .activeEvents.map((event) => [
+              promotionScheduleKey(event),
+              new Set(
+                event.targets?.map(
+                  (target) => `${target.service}:${target.game}`,
+                ),
+              ),
+            ]),
+        );
+        for (const [id, { notification, targets }] of this.notifications) {
+          const revoked = targets.some(
+            (target) => !currentTargets.get(id)?.has(target),
+          );
+          if (!active.has(id) || revoked) {
+            notification.close();
+            this.notifications.delete(id);
+          }
+        }
+      },
+    });
+  }
+
+  init(): void {
+    powerMonitor.on("resume", this.resume);
+    this.controller.init();
+  }
+  stop(): void {
+    powerMonitor.removeListener("resume", this.resume);
+    this.controller.stop();
+  }
+  snapshot() {
+    return this.controller.snapshot();
+  }
+  settingsChanged(): void {
+    this.controller.settingsChanged();
+  }
+
+  dismiss(request: PromotionDismissRequest): void {
+    this.controller.dismiss(request);
+  }
+
+  private notify(event: PromotionEvent): Promise<boolean> {
+    if (process.platform !== "win32" || !Notification.isSupported())
+      return Promise.resolve(false);
+    return new Promise((resolve) => {
+      const notification = new Notification({
+        toastXml: buildPromotionToast(event),
+      });
+      const key = promotionScheduleKey(event);
+      this.notifications.set(key, {
+        notification,
+        targets:
+          event.targets?.map((target) => `${target.service}:${target.game}`) ??
+          [],
+      });
+      // A missing callback is uncertain, not proof that the OS rejected delivery.
+      const timer = setTimeout(() => resolve(true), 5000);
+      notification.once("show", () => {
+        clearTimeout(timer);
+        resolve(true);
+      });
+      notification.once("failed", () => {
+        clearTimeout(timer);
+        this.notifications.delete(key);
+        logger.warn(
+          "[EventNotificationService] Windows 알림을 표시하지 못했습니다.",
+        );
+        resolve(false);
+      });
+      // Windows emits "close" when only the banner times out. Keep the object
+      // so expiry/settings changes can also remove its Action Center entry.
+      notification.show();
+    });
+  }
+}

--- a/src/main/services/PromotionController.ts
+++ b/src/main/services/PromotionController.ts
@@ -1,0 +1,287 @@
+import {
+  getPromotionEvents,
+  isPromotionActive,
+  normalizeEventPreferences,
+  parsePromotionFeed,
+  promotionScheduleKey,
+  type PromotionDismissRequest,
+  type PromotionEvent,
+  type PromotionFeed,
+  type PromotionSnapshot,
+} from "../../shared/promotions";
+import { currentStashEstimate } from "../../shared/stash-sales";
+
+export interface PromotionCache {
+  feed: PromotionFeed | null;
+  /** Records expire at the campaign end, keyed by event schedule. */
+  windows: Record<string, number>;
+  hidden?: Record<string, number>;
+}
+
+interface Dependencies {
+  load: () => PromotionCache;
+  save: (cache: PromotionCache) => void;
+  fetchFeed: (signal: AbortSignal) => Promise<unknown>;
+  preferences: () => unknown;
+  notify: (event: PromotionEvent) => Promise<boolean>;
+  prune: (activeIds: Set<string>) => void;
+  changed: (snapshot: PromotionSnapshot) => void;
+  warn: (message: string) => void;
+}
+
+const REFRESH_MS = 60 * 60_000;
+
+export class PromotionController {
+  private cache: PromotionCache = { feed: null, windows: {} };
+  private current: PromotionSnapshot = {
+    revision: 0,
+    events: [],
+    activeEvents: [],
+    upcomingEvents: [],
+  };
+  private running = false;
+  private timer?: ReturnType<typeof setInterval>;
+  private request?: AbortController;
+  private lastFetch = -Infinity;
+  private delivering = false;
+  private retryAfter = new Map<string, { retryAt: number; end: number }>();
+  private sessionHidden = new Map<string, number>();
+  private cleanupPending = false;
+  private cleanupRetryAt = 0;
+
+  constructor(private readonly deps: Dependencies) {}
+
+  init(): void {
+    if (this.running) return;
+    this.sessionHidden.clear();
+    try {
+      const saved = this.deps.load();
+      this.cache = {
+        feed: saved.feed ? parsePromotionFeed(saved.feed) : null,
+        windows: saved.windows ?? {},
+        hidden: saved.hidden ?? {},
+      };
+    } catch {
+      this.deps.warn("이벤트 알림 캐시를 읽지 못했습니다.");
+    }
+    this.running = true;
+    this.tick();
+    this.timer = setInterval(() => this.tick(), 1000);
+  }
+
+  stop(): void {
+    this.running = false;
+    clearInterval(this.timer);
+    this.request?.abort();
+    this.deps.prune(new Set());
+  }
+
+  snapshot(): PromotionSnapshot {
+    return this.current;
+  }
+
+  settingsChanged(): void {
+    this.tick();
+  }
+
+  dismiss(request: PromotionDismissRequest): void {
+    if (request.mode !== "session" && request.mode !== "schedule")
+      throw new Error("Invalid dismissal mode");
+    const event = getPromotionEvents(this.cache.feed).find(
+      (item) =>
+        promotionScheduleKey(item) === request.key && isPromotionActive(item),
+    );
+    if (!this.running || !event) throw new Error("Unknown active schedule");
+    if (request.mode === "schedule") {
+      const next = {
+        ...this.cache,
+        hidden: {
+          ...this.cache.hidden,
+          [request.key]: Date.parse(event.endsAt),
+        },
+      };
+      this.deps.save(next);
+      this.cache = next;
+    } else {
+      this.sessionHidden.set(request.key, Date.parse(event.endsAt));
+    }
+    this.tick();
+  }
+
+  wake(): void {
+    this.lastFetch = -Infinity;
+    this.tick();
+  }
+
+  private tick(): void {
+    if (!this.running) return;
+    this.expireRecords();
+    const prefs = normalizeEventPreferences(this.deps.preferences());
+    const schedules = [
+      ...new Map(
+        getPromotionEvents(this.cache.feed).map((event) => [
+          promotionScheduleKey(event),
+          event,
+        ]),
+      ).values(),
+    ];
+    const activeEvents = schedules.filter((event) => isPromotionActive(event));
+    const upcomingEvents = schedules.filter(
+      (event) => Date.parse(event.startsAt) > Date.now(),
+    );
+    const stashEstimate = currentStashEstimate(
+      this.cache.feed?.stashSales?.nextEstimate,
+    );
+    const kind = (event: PromotionEvent) =>
+      event.kind === "twitch-drops" ? "twitch" : "stash";
+    const selected = activeEvents.filter((event) => prefs.types[kind(event)]);
+    const events = prefs.channels.inApp
+      ? selected.filter((event) => {
+          const key = promotionScheduleKey(event);
+          return !this.sessionHidden.has(key) && !this.cache.hidden?.[key];
+        })
+      : [];
+    if (
+      JSON.stringify(events) !== JSON.stringify(this.current.events) ||
+      JSON.stringify(activeEvents) !==
+        JSON.stringify(this.current.activeEvents) ||
+      JSON.stringify(upcomingEvents) !==
+        JSON.stringify(this.current.upcomingEvents) ||
+      JSON.stringify(stashEstimate) !==
+        JSON.stringify(this.current.stashEstimate)
+    ) {
+      this.current = {
+        revision: this.current.revision + 1,
+        events,
+        activeEvents,
+        upcomingEvents,
+        stashEstimate,
+      };
+      this.deps.changed(this.current);
+    }
+    const windows = prefs.channels.windows ? selected : [];
+    this.deps.prune(new Set(windows.map(promotionScheduleKey)));
+    if (!this.delivering) void this.deliver(windows);
+    if (!this.request && Date.now() - this.lastFetch >= REFRESH_MS)
+      void this.refresh();
+  }
+
+  private expireRecords(): void {
+    const now = Date.now();
+    for (const [key, end] of this.sessionHidden)
+      if (end <= now) this.sessionHidden.delete(key);
+    for (const [key, retry] of this.retryAfter)
+      if (retry.end <= now) this.retryAfter.delete(key);
+    for (const field of ["windows", "hidden"] as const) {
+      const entries = Object.entries(this.cache[field] ?? {});
+      const retained = entries
+        .filter(
+          ([key, end]) =>
+            /^[a-z0-9:-]{1,160}$/.test(key) &&
+            Number.isFinite(end) &&
+            end > now,
+        )
+        .slice(-500);
+      if (retained.length !== entries.length) {
+        this.cache = { ...this.cache, [field]: Object.fromEntries(retained) };
+        this.cleanupPending = true;
+      }
+    }
+    if (!this.cleanupPending || now < this.cleanupRetryAt) return;
+    try {
+      this.deps.save(this.cache);
+      this.cleanupPending = false;
+    } catch {
+      // Keep expired entries out of memory even if disk cleanup needs a retry.
+      this.cleanupRetryAt = now + REFRESH_MS;
+      this.deps.warn("만료된 이벤트 알림 기록을 저장하지 못했습니다.");
+    }
+  }
+
+  private async refresh(): Promise<void> {
+    const request = new AbortController();
+    this.request = request;
+    this.lastFetch = Date.now();
+    try {
+      const feed = parsePromotionFeed(
+        await this.deps.fetchFeed(request.signal),
+      );
+      if (!this.running || request.signal.aborted) return;
+      if (
+        Date.parse(feed.generatedAt) > Date.now() + 5 * 60_000 ||
+        (this.cache.feed &&
+          Date.parse(feed.generatedAt) <
+            Date.parse(this.cache.feed.generatedAt))
+      ) {
+        throw new Error("Feed generation time is invalid");
+      }
+      const next = { ...this.cache, feed };
+      this.deps.save(next);
+      this.cache = next;
+      this.tick();
+    } catch {
+      if (this.running)
+        this.deps.warn(
+          "이벤트 일정을 갱신하지 못해 마지막 정상 일정을 유지합니다.",
+        );
+    } finally {
+      if (this.request === request) this.request = undefined;
+    }
+  }
+
+  private async deliver(events: PromotionEvent[]): Promise<void> {
+    this.delivering = true;
+    try {
+      for (const queued of events) {
+        const event = getPromotionEvents(this.cache.feed).find(
+          (item) => item.id === queued.id,
+        );
+        if (!event) continue;
+        const key = event.kind === "twitch-drops" ? "twitch" : "stash";
+        const schedule = promotionScheduleKey(event);
+        const prefs = normalizeEventPreferences(this.deps.preferences());
+        if (
+          !this.running ||
+          !isPromotionActive(event) ||
+          !prefs.types[key] ||
+          !prefs.channels.windows ||
+          this.cache.windows[schedule] ||
+          (this.retryAfter.get(schedule)?.retryAt ?? 0) > Date.now()
+        )
+          continue;
+        const next = {
+          ...this.cache,
+          windows: {
+            ...this.cache.windows,
+            [schedule]: Date.parse(event.endsAt),
+          },
+        };
+        try {
+          // At-most-once on uncertain delivery: persist before invoking the native API.
+          this.deps.save(next);
+          this.cache = next;
+          const delivered = await this.deps.notify(event);
+          if (!delivered && this.running) {
+            const windows = { ...this.cache.windows };
+            delete windows[schedule];
+            const retry = { ...this.cache, windows };
+            this.deps.save(retry);
+            this.cache = retry;
+            this.retryAfter.set(schedule, {
+              retryAt: Date.now() + REFRESH_MS,
+              end: Date.parse(event.endsAt),
+            });
+          }
+        } catch {
+          this.retryAfter.set(schedule, {
+            retryAt: Date.now() + REFRESH_MS,
+            end: Date.parse(event.endsAt),
+          });
+          this.deps.warn("이벤트 알림을 저장하거나 전달하지 못했습니다.");
+        }
+      }
+    } finally {
+      this.delivering = false;
+    }
+  }
+}

--- a/src/main/services/promotion-toast.ts
+++ b/src/main/services/promotion-toast.ts
@@ -1,0 +1,33 @@
+import {
+  formatPromotionPeriod,
+  promotionActions,
+  promotionTitle,
+  type PromotionEvent,
+} from "../../shared/promotions";
+
+const xml = (text: string) =>
+  text.replace(
+    /[<>&"']/g,
+    (char) =>
+      ({
+        "<": "&lt;",
+        ">": "&gt;",
+        "&": "&amp;",
+        '"': "&quot;",
+        "'": "&apos;",
+      })[char]!,
+  );
+
+export function buildPromotionToast(event: PromotionEvent): string {
+  const links = promotionActions(event);
+  const launchUrl = event.targets
+    ? (links[0]?.url ?? event.sourceUrl)
+    : event.sourceUrl;
+  const actions = links
+    .map(
+      ({ label, url }) =>
+        `<action content="${xml(label)}" arguments="${xml(url)}" activationType="protocol"/>`,
+    )
+    .join("");
+  return `<toast activationType="protocol" launch="${xml(launchUrl)}"><visual><binding template="ToastGeneric"><text>${xml(`${promotionTitle(event)} 진행 중 (${formatPromotionPeriod(event)})`)}</text></binding></visual><actions>${actions}</actions></toast>`;
+}

--- a/src/main/services/register-services.ts
+++ b/src/main/services/register-services.ts
@@ -1,3 +1,4 @@
+import { EventNotificationService } from "./EventNotificationService";
 import { LogWatcher } from "./LogWatcher";
 import { PatchReservationService } from "./PatchReservationService";
 import { ProcessWatcher } from "./ProcessWatcher";
@@ -13,6 +14,7 @@ export function registerCoreServices(appContext: AppContext) {
   serviceManager.register(new LogWatcher(appContext));
   serviceManager.register(new PatchReservationService(appContext));
   serviceManager.register(new UpdateSchedulerService(appContext));
+  serviceManager.register(new EventNotificationService(appContext));
 }
 
 export async function initializeCoreServices(appContext: AppContext) {

--- a/src/main/tests/EventNotificationService.test.ts
+++ b/src/main/tests/EventNotificationService.test.ts
@@ -1,0 +1,209 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { promotionScheduleKey } from "../../shared/promotions";
+import { STASH_API_URLS } from "../../shared/stash-sales";
+import {
+  stashSection,
+  stashObservations,
+  observedStashPeriod,
+} from "../../shared/test-fixtures/stash-sales";
+import { EventNotificationService } from "../services/EventNotificationService";
+
+import type { AppContext } from "../events/types";
+import type { PromotionCache } from "../services/PromotionController";
+
+const mocks = vi.hoisted(() => ({
+  instances: [] as {
+    emit: (name: string) => void;
+    close: ReturnType<typeof vi.fn>;
+  }[],
+  cache: { feed: null, windows: {} } as PromotionCache,
+  supported: true,
+  delivery: "show",
+  on: vi.fn(),
+  remove: vi.fn(),
+}));
+vi.mock("electron", async () => {
+  const { EventEmitter } = await import("node:events");
+  class FakeNotification extends EventEmitter {
+    constructor() {
+      super();
+      mocks.instances.push(this);
+    }
+    static isSupported() {
+      return mocks.supported;
+    }
+    show() {
+      this.emit(mocks.delivery);
+    }
+    close = vi.fn(() => {
+      this.emit("close");
+    });
+  }
+  return {
+    Notification: FakeNotification,
+    powerMonitor: { on: mocks.on, removeListener: mocks.remove },
+  };
+});
+vi.mock("electron-store", () => ({
+  default: class {
+    get store() {
+      return mocks.cache;
+    }
+    set store(value: PromotionCache) {
+      mocks.cache = value;
+    }
+  },
+}));
+vi.mock("axios", () => ({
+  default: { get: vi.fn(async () => ({ data: mocks.cache.feed })) },
+}));
+vi.mock("../utils/logger", () => ({ logger: { warn: vi.fn() } }));
+vi.mock("../events/EventBus", () => ({ eventBus: { emit: vi.fn() } }));
+vi.mock("../../shared/urls", () => ({
+  SUPPORT_URLS: { PROMOTIONS_JSON: "https://example.test/promotions.json" },
+}));
+
+describe.skipIf(process.platform !== "win32")(
+  "Windows notification lifetime",
+  () => {
+    it("closes an already delivered toast when one shop is revoked without resetting its ledger", async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime("2026-09-04T00:10:00Z");
+      const first = {
+        ...stashSection.observations[0],
+        confirmedPeriod: observedStashPeriod,
+      };
+      const second = {
+        ...first,
+        service: "ggg" as const,
+        sourceUrl: STASH_API_URLS["ggg:poe2"],
+      };
+      mocks.cache = {
+        windows: {},
+        feed: {
+          schemaVersion: 1,
+          generatedAt: "2026-09-04T00:00:00Z",
+          events: [],
+          stashSales: {
+            ...stashSection,
+            observations: stashObservations(first, second),
+          },
+        },
+      };
+      const service = new EventNotificationService({
+        getConfig: () => ({ channels: { inApp: true, windows: true } }),
+      } as unknown as AppContext);
+      service.init();
+      await vi.advanceTimersByTimeAsync(1);
+      const toast = mocks.instances[0];
+      expect(toast).toBeDefined();
+      const ledger = { ...mocks.cache.windows };
+      mocks.cache.feed!.stashSales!.observations = stashObservations(first, {
+        ...second,
+        confirmedPeriod: null,
+      });
+      await vi.advanceTimersByTimeAsync(3600_000);
+      expect(toast.close).toHaveBeenCalledOnce();
+      expect(mocks.instances).toHaveLength(1);
+      expect(mocks.cache.windows).toEqual(ledger);
+      expect(service.snapshot().events[0].targets).toEqual([
+        { service: "kakao", game: "poe2" },
+      ]);
+      service.stop();
+    });
+    afterEach(() => {
+      vi.useRealTimers();
+      mocks.instances.length = 0;
+      mocks.supported = true;
+      mocks.delivery = "show";
+    });
+    it("retains timed-out banners until expiry and unregisters resume on stop", async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime("2026-09-04T00:00:00Z");
+      mocks.cache = {
+        windows: {},
+        feed: {
+          schemaVersion: 1,
+          generatedAt: "2026-09-04T00:00:00Z",
+          events: [
+            {
+              id: "ggg-1-twitch",
+              kind: "twitch-drops",
+              game: "poe1",
+              startsAt: "2026-09-03T00:00:00Z",
+              endsAt: "2026-09-04T00:00:02Z",
+              sourceUrl: "https://www.pathofexile.com/forum/view-thread/1",
+              precision: "exact",
+            },
+          ],
+        },
+      };
+      const service = new EventNotificationService({
+        getConfig: () => ({ channels: { inApp: true, windows: true } }),
+      } as unknown as AppContext);
+      service.init();
+      await vi.advanceTimersByTimeAsync(1);
+      const toast = mocks.instances[0];
+      expect(toast).toBeDefined();
+      toast.emit("close"); // Windows banner timeout; Action Center entry still exists.
+      expect(toast.close).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(2000);
+      expect(toast.close).toHaveBeenCalledOnce();
+      service.stop();
+      expect(mocks.remove).toHaveBeenCalledWith("resume", expect.any(Function));
+    });
+
+    const setupDelivery = () => {
+      vi.useFakeTimers();
+      vi.setSystemTime("2026-09-04T00:00:00Z");
+      mocks.cache = {
+        windows: {},
+        feed: {
+          schemaVersion: 1,
+          generatedAt: "2026-09-04T00:00:00Z",
+          events: [
+            {
+              id: "ggg-1-twitch",
+              kind: "twitch-drops",
+              game: "poe1",
+              startsAt: "2026-09-03T00:00:00Z",
+              endsAt: "2026-09-05T00:00:00Z",
+              sourceUrl: "https://www.pathofexile.com/forum/view-thread/1",
+              precision: "exact",
+            },
+          ],
+        },
+      };
+      return new EventNotificationService({
+        getConfig: () => ({ channels: { inApp: true, windows: true } }),
+      } as unknown as AppContext);
+    };
+
+    it("does not construct a toast when Windows reports notifications unsupported", async () => {
+      const service = setupDelivery();
+      mocks.supported = false;
+      service.init();
+      await vi.advanceTimersByTimeAsync(1);
+      expect(mocks.instances).toHaveLength(0);
+      expect(mocks.cache.windows).toEqual({});
+      service.stop();
+    });
+
+    it("clears a known failed delivery and retries only after the refresh interval", async () => {
+      const service = setupDelivery();
+      mocks.delivery = "failed";
+      service.init();
+      await vi.advanceTimersByTimeAsync(5000);
+      expect(mocks.instances).toHaveLength(1);
+      expect(mocks.cache.windows).toEqual({});
+      mocks.delivery = "show";
+      await vi.advanceTimersByTimeAsync(3600_000);
+      expect(mocks.instances).toHaveLength(2);
+      expect(
+        mocks.cache.windows[promotionScheduleKey(mocks.cache.feed!.events[0])],
+      ).toBeGreaterThan(Date.now());
+      service.stop();
+    });
+  },
+);

--- a/src/main/tests/PromotionController.test.ts
+++ b/src/main/tests/PromotionController.test.ts
@@ -1,0 +1,563 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  normalizeEventPreferences,
+  promotionScheduleKey,
+  type PromotionEvent,
+  type PromotionFeed,
+  type PromotionSnapshot,
+} from "../../shared/promotions";
+import { STASH_API_URLS } from "../../shared/stash-sales";
+import {
+  stashSection,
+  stashObservations,
+  observedStashPeriod,
+} from "../../shared/test-fixtures/stash-sales";
+import {
+  PromotionController,
+  type PromotionCache,
+} from "../services/PromotionController";
+
+const event = {
+  id: "ggg-1-twitch-1",
+  kind: "twitch-drops" as const,
+  game: "poe1" as const,
+  startsAt: "2026-09-03T21:00:00.000Z",
+  endsAt: "2026-09-04T21:00:00.000Z",
+  sourceUrl: "https://www.pathofexile.com/forum/view-thread/1",
+  precision: "exact" as const,
+};
+const feed: PromotionFeed = {
+  schemaVersion: 1,
+  generatedAt: "2026-09-04T00:00:00.000Z",
+  events: [event],
+};
+
+function setup(initial: PromotionCache = { feed, windows: {} }) {
+  let persisted = initial;
+  const prefs = normalizeEventPreferences({ channels: { windows: true } });
+  const notify = vi.fn(async (_event: PromotionEvent) => true);
+  const snapshots: PromotionSnapshot[] = [];
+  const fetchFeed = vi.fn(
+    async (_signal: AbortSignal): Promise<unknown> => feed,
+  );
+  const save = vi.fn((value: PromotionCache) => {
+    persisted = structuredClone(value);
+  });
+  const prune = vi.fn();
+  const controller = new PromotionController({
+    load: () => persisted,
+    save,
+    fetchFeed,
+    preferences: () => prefs,
+    notify,
+    changed: (snapshot) => snapshots.push(snapshot),
+    prune,
+    warn: vi.fn(),
+  });
+  return {
+    controller,
+    prefs,
+    notify,
+    snapshots,
+    fetchFeed,
+    save,
+    prune,
+    persisted: () => persisted,
+  };
+}
+
+describe("promotion delivery", () => {
+  it("keeps one stash delivery when targets grow and retains the other confirmed target on no-sale", async () => {
+    const first = {
+      ...stashSection.observations[0],
+      confirmedPeriod: observedStashPeriod,
+    };
+    const second = {
+      ...first,
+      service: "ggg" as const,
+      sourceUrl: STASH_API_URLS["ggg:poe2"],
+    };
+    const extended = {
+      ...feed,
+      events: [],
+      stashSales: { ...stashSection, observations: stashObservations(first) },
+    };
+    const s = setup({ feed: extended, windows: {} });
+    s.fetchFeed.mockResolvedValue(extended);
+    s.controller.init();
+    await vi.advanceTimersByTimeAsync(1);
+    const key = promotionScheduleKey(s.controller.snapshot().events[0]);
+    s.fetchFeed.mockResolvedValue({
+      ...extended,
+      stashSales: {
+        ...stashSection,
+        observations: stashObservations(second, first),
+      },
+    });
+    s.controller.wake();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(s.controller.snapshot().events).toHaveLength(1);
+    expect(s.controller.snapshot().events[0].targets).toHaveLength(2);
+    expect(promotionScheduleKey(s.controller.snapshot().events[0])).toBe(key);
+    expect(s.notify).toHaveBeenCalledTimes(1);
+    s.fetchFeed.mockResolvedValue({
+      ...extended,
+      stashSales: {
+        ...stashSection,
+        observations: stashObservations(
+          { ...second, confirmedPeriod: null },
+          first,
+        ),
+      },
+    });
+    s.controller.wake();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(s.controller.snapshot().events[0].targets).toEqual([
+      { service: "kakao", game: "poe2" },
+    ]);
+    expect(s.notify).toHaveBeenCalledTimes(1);
+    s.controller.stop();
+  });
+  it("keeps an estimate separate across its start and removes it after its last KST date", async () => {
+    const extended = { ...feed, events: [], stashSales: stashSection };
+    const s = setup({ feed: extended, windows: {} });
+    s.fetchFeed.mockResolvedValue(extended);
+    s.controller.init();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(s.controller.snapshot().stashEstimate).toEqual(
+      stashSection.nextEstimate,
+    );
+    vi.setSystemTime("2026-09-11T01:00:00Z");
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(s.controller.snapshot().events).toEqual([]);
+    expect(s.controller.snapshot().activeEvents).toEqual([]);
+    expect(s.notify).not.toHaveBeenCalled();
+    vi.setSystemTime("2026-09-15T15:00:00Z");
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(s.controller.snapshot().stashEstimate).toBeNull();
+    s.controller.stop();
+  });
+
+  it("delivers and dismisses an API-confirmed stash period through the shared event path", async () => {
+    const extended = {
+      ...feed,
+      events: [],
+      stashSales: {
+        ...stashSection,
+        observations: stashObservations({
+          ...stashSection.observations[0],
+          confirmedPeriod: observedStashPeriod,
+        }),
+      },
+    };
+    const s = setup({ feed: extended, windows: {} });
+    s.fetchFeed.mockResolvedValue(extended);
+    s.controller.init();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(s.controller.snapshot().activeEvents).toHaveLength(1);
+    expect(s.notify).toHaveBeenCalledTimes(1);
+    const current = s.controller.snapshot().events[0];
+    s.controller.dismiss({
+      key: promotionScheduleKey(current),
+      mode: "schedule",
+    });
+    expect(s.controller.snapshot().events).toEqual([]);
+    expect(s.controller.snapshot().activeEvents).toHaveLength(1);
+    expect(s.persisted().hidden?.[promotionScheduleKey(current)]).toBe(
+      Date.parse(observedStashPeriod.endsAt),
+    );
+    s.controller.stop();
+  });
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime("2026-09-04T00:10:00Z");
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("records before sending and does not resend on restart, refresh, or toggling", async () => {
+    const s = setup();
+    s.controller.init();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(s.notify).toHaveBeenCalledTimes(1);
+    expect(s.save.mock.invocationCallOrder[0]).toBeLessThan(
+      s.notify.mock.invocationCallOrder[0],
+    );
+    s.prefs.channels.windows = false;
+    s.controller.settingsChanged();
+    s.prefs.channels.windows = true;
+    s.controller.settingsChanged();
+    await vi.advanceTimersByTimeAsync(3600_000);
+    expect(s.notify).toHaveBeenCalledTimes(1);
+    s.controller.stop();
+    const restarted = setup(s.persisted());
+    restarted.controller.init();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(restarted.notify).not.toHaveBeenCalled();
+    restarted.controller.stop();
+  });
+
+  it("shows cached events offline and removes them exactly at expiration", async () => {
+    const s = setup();
+    s.fetchFeed.mockRejectedValue(new Error("offline"));
+    vi.setSystemTime(Date.parse(event.endsAt) - 1000);
+    s.controller.init();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(s.controller.snapshot().events).toHaveLength(1);
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(s.controller.snapshot().events).toEqual([]);
+    expect(s.persisted().feed?.events).toHaveLength(1);
+    s.controller.stop();
+  });
+
+  it("adds a running event when a channel is first enabled and keeps app/native independent", async () => {
+    const s = setup();
+    s.prefs.channels = { inApp: false, windows: false };
+    s.controller.init();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(s.controller.snapshot().events).toEqual([]);
+    expect(s.notify).not.toHaveBeenCalled();
+    s.prefs.channels.windows = true;
+    s.controller.settingsChanged();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(s.notify).toHaveBeenCalledTimes(1);
+    expect(s.controller.snapshot().events).toEqual([]);
+    s.prefs.channels.inApp = true;
+    s.controller.settingsChanged();
+    expect(s.controller.snapshot().events).toHaveLength(1);
+    s.controller.stop();
+  });
+
+  it("applies shared channels to selected types and prunes a disabled type", async () => {
+    const stash = {
+      ...event,
+      id: "ggg-1-stash",
+      kind: "stash-sale" as const,
+      game: "both" as const,
+    };
+    const both = { ...feed, events: [event, stash] };
+    const s = setup({ feed: both, windows: {} });
+    s.fetchFeed.mockResolvedValue(both);
+    s.prefs.types.twitch = false;
+    s.controller.init();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(s.controller.snapshot().events.map((item) => item.id)).toEqual([
+      stash.id,
+    ]);
+    expect(s.notify.mock.calls.map((call) => call[0])).toEqual([stash]);
+    s.prefs.types.twitch = true;
+    s.controller.settingsChanged();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(s.controller.snapshot().events).toHaveLength(2);
+    expect(s.notify).toHaveBeenCalledTimes(2);
+    s.prefs.channels.inApp = false;
+    s.prefs.types.stash = false;
+    s.controller.settingsChanged();
+    expect(s.controller.snapshot().events).toEqual([]);
+    expect(s.prune).toHaveBeenLastCalledWith(
+      new Set([promotionScheduleKey(event)]),
+    );
+    s.prefs.channels.windows = false;
+    s.controller.settingsChanged();
+    expect(s.prune).toHaveBeenLastCalledWith(new Set());
+    s.prefs.channels = { inApp: true, windows: true };
+    s.prefs.types.stash = true;
+    s.controller.settingsChanged();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(s.controller.snapshot().events).toHaveLength(2);
+    expect(s.notify).toHaveBeenCalledTimes(2);
+    s.controller.stop();
+  });
+
+  it("retains good data when the server returns malformed or older data", async () => {
+    const s = setup();
+    s.fetchFeed.mockResolvedValue({ schemaVersion: 2, events: [] });
+    s.controller.init();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(s.controller.snapshot().events).toHaveLength(1);
+    s.fetchFeed.mockResolvedValue({
+      ...feed,
+      generatedAt: "2026-09-03T00:00:00Z",
+      events: [],
+    });
+    await vi.advanceTimersByTimeAsync(3600_000);
+    expect(s.controller.snapshot().events).toHaveLength(1);
+    s.controller.stop();
+  });
+
+  it("aborts requests and ignores a late response after stop", async () => {
+    const s = setup({ feed: null, windows: {} });
+    let resolve!: (value: unknown) => void;
+    s.fetchFeed.mockImplementation(
+      () =>
+        new Promise((r) => {
+          resolve = r;
+        }),
+    );
+    s.controller.init();
+    s.controller.stop();
+    resolve(feed);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(s.fetchFeed.mock.calls[0][0].aborted).toBe(true);
+    expect(s.notify).not.toHaveBeenCalled();
+    expect(s.persisted().feed).toBeNull();
+  });
+
+  it("never sends when the delivery ledger cannot be persisted", async () => {
+    const s = setup();
+    s.save.mockImplementation(() => {
+      throw new Error("disk full");
+    });
+    s.controller.init();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(s.notify).not.toHaveBeenCalled();
+    s.controller.stop();
+  });
+
+  it("backs off a known native failure, but allows a later retry", async () => {
+    const s = setup();
+    s.notify.mockResolvedValue(false);
+    s.controller.init();
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(s.notify).toHaveBeenCalledTimes(1);
+    s.notify.mockResolvedValue(true);
+    await vi.advanceTimersByTimeAsync(3600_000);
+    expect(s.notify).toHaveBeenCalledTimes(2);
+    s.controller.stop();
+  });
+
+  it("uses the corrected live event after waiting for another notification", async () => {
+    const second = { ...event, id: "ggg-2-twitch-1", game: "poe2" as const };
+    const s = setup({
+      feed: { ...feed, events: [event, second] },
+      windows: {},
+    });
+    let finish!: (value: boolean) => void;
+    s.notify.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          finish = resolve;
+        }),
+    );
+    s.fetchFeed.mockResolvedValue({
+      ...feed,
+      events: [event, { ...second, startsAt: "2026-09-04T02:00:00.000Z" }],
+    });
+    s.controller.init();
+    await vi.advanceTimersByTimeAsync(1);
+    finish(true);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(s.notify).toHaveBeenCalledTimes(1);
+    expect(s.persisted().windows[promotionScheduleKey(second)]).toBeUndefined();
+    s.controller.stop();
+  });
+  it("deletes for the current app session across refreshes, then returns after restart", async () => {
+    const s = setup();
+    s.controller.init();
+    await vi.advanceTimersByTimeAsync(1);
+    s.controller.dismiss({ key: promotionScheduleKey(event), mode: "session" });
+    expect(s.controller.snapshot().events).toEqual([]);
+    s.controller.wake();
+    s.controller.settingsChanged();
+    await vi.advanceTimersByTimeAsync(3600_000);
+    expect(s.controller.snapshot().events).toEqual([]);
+    expect(s.notify).toHaveBeenCalledTimes(1);
+    s.controller.stop();
+    const restarted = setup(s.persisted());
+    restarted.controller.init();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(restarted.controller.snapshot().events).toHaveLength(1);
+    expect(restarted.notify).not.toHaveBeenCalled();
+    restarted.controller.stop();
+  });
+
+  it("keeps a schedule hidden after restart but displays and sends a different schedule", async () => {
+    const s = setup();
+    s.controller.init();
+    await vi.advanceTimersByTimeAsync(1);
+    s.controller.dismiss({
+      key: promotionScheduleKey(event),
+      mode: "schedule",
+    });
+    s.controller.stop();
+    const restarted = setup(s.persisted());
+    restarted.controller.init();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(restarted.controller.snapshot().events).toEqual([]);
+    expect(restarted.notify).not.toHaveBeenCalled();
+    const next = { ...event, endsAt: "2026-09-05T21:00:00Z" };
+    restarted.fetchFeed.mockResolvedValue({ ...feed, events: [next] });
+    restarted.controller.wake();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(restarted.controller.snapshot().events).toEqual([next]);
+    expect(restarted.notify).toHaveBeenCalledOnce();
+    restarted.controller.stop();
+  });
+
+  it("treats duplicate source IDs for the same schedule as one notification", async () => {
+    const s = setup();
+    s.fetchFeed.mockResolvedValue({
+      ...feed,
+      events: [event, { ...event, id: "ggg-repost" }],
+    });
+    s.controller.init();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(s.controller.snapshot().events).toHaveLength(1);
+    expect(s.notify).toHaveBeenCalledOnce();
+    s.controller.dismiss({
+      key: promotionScheduleKey(event),
+      mode: "schedule",
+    });
+    s.fetchFeed.mockResolvedValue({
+      ...feed,
+      events: [{ ...event, id: "ggg-new-source" }],
+    });
+    s.controller.wake();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(s.controller.snapshot().events).toEqual([]);
+    expect(s.notify).toHaveBeenCalledOnce();
+    s.controller.stop();
+  });
+
+  it("keeps the row visible on persistence failure and rejects unknown schedules", async () => {
+    const s = setup();
+    s.controller.init();
+    await vi.advanceTimersByTimeAsync(1);
+    s.save.mockImplementation(() => {
+      throw new Error("disk full");
+    });
+    expect(() =>
+      s.controller.dismiss({
+        key: promotionScheduleKey(event),
+        mode: "schedule",
+      }),
+    ).toThrow("disk full");
+    expect(s.controller.snapshot().events).toHaveLength(1);
+    expect(() =>
+      s.controller.dismiss({ key: "unknown", mode: "session" }),
+    ).toThrow();
+    s.controller.dismiss({ key: promotionScheduleKey(event), mode: "session" });
+    expect(s.controller.snapshot().events).toEqual([]);
+    s.controller.stop();
+  });
+
+  it("expires hidden and Windows records at the end without rewriting every tick", async () => {
+    vi.setSystemTime(Date.parse(event.endsAt) - 1000);
+    const s = setup();
+    s.fetchFeed.mockRejectedValue(new Error("offline"));
+    s.controller.init();
+    await vi.advanceTimersByTimeAsync(1);
+    s.controller.dismiss({
+      key: promotionScheduleKey(event),
+      mode: "schedule",
+    });
+    expect(Object.keys(s.persisted().windows)).toHaveLength(1);
+    expect(Object.keys(s.persisted().hidden!)).toHaveLength(1);
+    s.save.mockClear();
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(s.persisted().windows).toEqual({});
+    expect(s.persisted().hidden).toEqual({});
+    expect(s.save).toHaveBeenCalledOnce();
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(s.save).toHaveBeenCalledOnce();
+    s.controller.stop();
+  });
+
+  it("persists cleanup of records expired while closed and retains ongoing schedules", async () => {
+    const expiredEnd = Date.now() - 1;
+    const records = {
+      expired: expiredEnd,
+      [promotionScheduleKey(event)]: Date.parse(event.endsAt),
+    };
+    const s = setup({ feed, windows: records, hidden: records });
+    s.fetchFeed.mockRejectedValue(new Error("offline"));
+    s.controller.init();
+    await vi.advanceTimersByTimeAsync(1);
+    const retained = {
+      [promotionScheduleKey(event)]: Date.parse(event.endsAt),
+    };
+    expect(s.persisted().windows).toEqual(retained);
+    expect(s.persisted().hidden).toEqual(retained);
+    expect(s.controller.snapshot().events).toEqual([]);
+    expect(s.notify).not.toHaveBeenCalled();
+    s.controller.stop();
+  });
+
+  it("retries failed expiration cleanup with backoff", async () => {
+    const records = { expired: Date.now() - 1 };
+    const s = setup({ feed: null, windows: records, hidden: records });
+    s.fetchFeed.mockRejectedValue(new Error("offline"));
+    s.save.mockImplementationOnce(() => {
+      throw new Error("disk full");
+    });
+    s.controller.init();
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(s.save).toHaveBeenCalledOnce();
+    await vi.advanceTimersByTimeAsync(3600_000);
+    expect(s.save).toHaveBeenCalledTimes(2);
+    expect(s.persisted().windows).toEqual({});
+    expect(s.persisted().hidden).toEqual({});
+    s.controller.stop();
+  });
+
+  it("can send Windows after the same schedule is hidden in the app", async () => {
+    const s = setup();
+    s.prefs.channels.windows = false;
+    s.controller.init();
+    await vi.advanceTimersByTimeAsync(1);
+    s.controller.dismiss({
+      key: promotionScheduleKey(event),
+      mode: "schedule",
+    });
+    s.prefs.channels.windows = true;
+    s.controller.settingsChanged();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(s.controller.snapshot().events).toEqual([]);
+    expect(s.notify).toHaveBeenCalledOnce();
+    s.controller.stop();
+  });
+
+  it("moves an upcoming schedule into active status at its start with notifications off", async () => {
+    vi.setSystemTime(Date.parse(event.startsAt) - 1000);
+    const s = setup();
+    s.prefs.types.twitch = false;
+    s.prefs.channels = { inApp: false, windows: false };
+    s.fetchFeed.mockRejectedValue(new Error("offline"));
+    s.controller.init();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(s.controller.snapshot().activeEvents).toEqual([]);
+    expect(s.controller.snapshot().upcomingEvents).toEqual([event]);
+    const revision = s.controller.snapshot().revision;
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(s.controller.snapshot().activeEvents).toEqual([event]);
+    expect(s.controller.snapshot().upcomingEvents).toEqual([]);
+    expect(s.controller.snapshot().revision).toBeGreaterThan(revision);
+    expect(s.notify).not.toHaveBeenCalled();
+    s.controller.stop();
+  });
+
+  it("publishes active schedules independently of notification preferences and dismissal", async () => {
+    const s = setup();
+    s.prefs.types.twitch = false;
+    s.prefs.channels = { inApp: false, windows: false };
+    s.fetchFeed.mockRejectedValue(new Error("offline"));
+    s.controller.init();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(s.controller.snapshot().events).toEqual([]);
+    expect(s.controller.snapshot().activeEvents).toEqual([event]);
+    s.controller.dismiss({
+      key: promotionScheduleKey(event),
+      mode: "schedule",
+    });
+    expect(s.controller.snapshot().activeEvents).toEqual([event]);
+    const revision = s.controller.snapshot().revision;
+    vi.setSystemTime(event.endsAt);
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(s.controller.snapshot().activeEvents).toEqual([]);
+    expect(s.controller.snapshot().revision).toBeGreaterThan(revision);
+    expect(s.notify).not.toHaveBeenCalled();
+    s.controller.stop();
+  });
+});

--- a/src/main/tests/event-notification-ipc.test.ts
+++ b/src/main/tests/event-notification-ipc.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { eventBus } from "../events/EventBus";
+import { EventNotificationDismissHandler } from "../events/handlers/EventNotificationHandler";
+import {
+  EventType,
+  type AppContext,
+  type PromotionDismissEvent,
+} from "../events/types";
+import { dismissPromotion } from "../ipc/event-notifications";
+
+vi.mock("electron", () => ({ ipcMain: { handle: vi.fn() } }));
+vi.mock("../events/EventBus", () => ({ eventBus: { emit: vi.fn() } }));
+
+describe("promotion dismissal acknowledgement", () => {
+  const dismiss = vi.fn();
+  const context = {
+    serviceManager: { get: () => ({ dismiss }) },
+  } as unknown as AppContext;
+  const request = { key: "stash-sale:both:100:200", mode: "schedule" } as const;
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("rejects malformed requests without emitting a command", async () => {
+    for (const input of [
+      null,
+      {},
+      { ...request, mode: "all" },
+      { ...request, key: "x".repeat(200) },
+    ]) {
+      expect(await dismissPromotion(context, input)).toEqual({
+        ok: false,
+        reason: "invalid-request",
+      });
+    }
+    expect(eventBus.emit).not.toHaveBeenCalled();
+  });
+
+  it("returns failure if no handler acknowledges the command", async () => {
+    expect(await dismissPromotion(context, request)).toEqual({
+      ok: false,
+      reason: "service-unavailable",
+    });
+  });
+
+  it("acknowledges only after the service succeeds and reports storage failure", async () => {
+    vi.mocked(eventBus.emit).mockImplementation(async (_type, ctx, payload) => {
+      await EventNotificationDismissHandler.handle(
+        { type: EventType.PROMOTION_DISMISS, payload } as PromotionDismissEvent,
+        ctx,
+      );
+    });
+    expect(await dismissPromotion(context, request)).toEqual({ ok: true });
+    expect(dismiss).toHaveBeenCalledWith(request);
+    dismiss.mockImplementation(() => {
+      throw new Error("disk full");
+    });
+    expect(await dismissPromotion(context, request)).toEqual({
+      ok: false,
+      reason: "save-failed",
+    });
+  });
+});

--- a/src/main/tests/promotion-toast.test.ts
+++ b/src/main/tests/promotion-toast.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+
+import { buildPromotionToast } from "../services/promotion-toast";
+
+import type { PromotionEvent } from "../../shared/promotions";
+
+const event: PromotionEvent = {
+  id: "ggg-1-stash",
+  kind: "stash-sale",
+  game: "both",
+  startsAt: "2026-09-04T00:00:00Z",
+  endsAt: "2026-09-08T00:00:00Z",
+  sourceUrl: "https://www.pathofexile.com/forum/view-thread/1",
+  precision: "exact",
+};
+describe("Windows promotion XML", () => {
+  it("restricts API-confirmed shop buttons to observed targets and opens the shop from the body", () => {
+    const document = new DOMParser().parseFromString(
+      buildPromotionToast({
+        ...event,
+        sourceUrl:
+          "https://poe2.kakaogames.com/api/shop-microtransactions?game=poe2",
+        targets: [{ service: "kakao", game: "poe2" }],
+      }),
+      "text/xml",
+    );
+    expect(document.querySelectorAll("action")).toHaveLength(1);
+    expect(document.querySelector("action")?.getAttribute("content")).toBe(
+      "Kakao POE2",
+    );
+    expect(document.querySelector("toast")?.getAttribute("launch")).toBe(
+      "https://poe2.kakaogames.com/shop/stash-tabs",
+    );
+  });
+  it("renders four independent protocol actions with the exact Kakao PoE2 shop", () => {
+    const document = new DOMParser().parseFromString(
+      buildPromotionToast(event),
+      "text/xml",
+    );
+    expect(document.querySelector("parsererror")).toBeNull();
+    expect(document.querySelectorAll("action")).toHaveLength(4);
+    expect(
+      [...document.querySelectorAll("action")].every(
+        (x) => x.getAttribute("activationType") === "protocol",
+      ),
+    ).toBe(true);
+    expect(
+      document
+        .querySelector('action[content="Kakao POE2"]')
+        ?.getAttribute("arguments"),
+    ).toBe("https://poe2.kakaogames.com/shop/stash-tabs");
+    expect(document.querySelector("text")?.textContent).toContain(
+      "보관함 할인 진행 중 (",
+    );
+    expect(document.querySelector("toast")?.getAttribute("launch")).toBe(
+      event.sourceUrl,
+    );
+  });
+  it("uses one game-specific Twitch action and escapes XML attributes", () => {
+    const sourceUrl = 'https://www.pathofexile.com/forum/view-thread/1?x="<&';
+    const document = new DOMParser().parseFromString(
+      buildPromotionToast({
+        ...event,
+        kind: "twitch-drops",
+        game: "poe2",
+        sourceUrl,
+      }),
+      "text/xml",
+    );
+    expect(document.querySelector("parsererror")).toBeNull();
+    expect(document.querySelectorAll("action")).toHaveLength(1);
+    expect(document.querySelector("action")?.getAttribute("arguments")).toBe(
+      "https://www.twitch.tv/directory/category/path-of-exile-2",
+    );
+    expect(document.querySelector("toast")?.getAttribute("launch")).toBe(
+      sourceUrl,
+    );
+  });
+});

--- a/src/main/tests/register-handlers.test.ts
+++ b/src/main/tests/register-handlers.test.ts
@@ -72,6 +72,10 @@ const CORE_HANDLER_IDS = [
   "KakaoMaintenanceUISyncHandler",
   "RenewedPatchReservationCreateHandler",
   "RenewedPatchReservationDeleteHandler",
+  "EventNotificationSettingsHandler",
+  "EventNotificationSettingsDeleteHandler",
+  "EventNotificationUISyncHandler",
+  "EventNotificationDismissHandler",
 ] as const;
 
 describe("CORE_EVENT_HANDLERS", () => {

--- a/src/main/tests/register-services.test.ts
+++ b/src/main/tests/register-services.test.ts
@@ -47,6 +47,12 @@ vi.mock("../services/UpdateSchedulerService", () => ({
   },
 }));
 
+vi.mock("../services/EventNotificationService", () => ({
+  EventNotificationService: class MockEventNotificationService {
+    readonly id = "EventNotificationService";
+  },
+}));
+
 describe("initializeCoreServices", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -69,6 +75,7 @@ describe("initializeCoreServices", () => {
       "LogWatcher",
       "PatchReservationService",
       "UpdateSchedulerService",
+      "EventNotificationService",
     ]);
     expect(serviceManager.initAll).toHaveBeenCalledOnce();
     expect(result.processWatcher).toBe(processWatcher);

--- a/src/renderer/App.css
+++ b/src/renderer/App.css
@@ -67,6 +67,7 @@ body {
   .onboarding-modal-overlay,
   .patch-fix-modal-overlay,
   .patch-reservation-modal-overlay,
+  .event-notification-overlay,
   .settings-overlay,
   .confirm-modal-overlay,
   .game-path-modal-overlay,
@@ -246,7 +247,7 @@ img {
   gap: 6px;
   padding: 0;
   box-sizing: border-box;
-  z-index: 5;
+  z-index: 110;
 }
 
 .news-open-mode-panel,

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -54,9 +54,11 @@ import NoticeModal from "./components/modals/NoticeModal";
 import { OnboardingModal } from "./components/modals/OnboardingModal";
 import { PatchFixModal } from "./components/modals/PatchFixModal";
 import { PatchReservationModal } from "./components/modals/PatchReservationModal";
+import EventNotificationModal from "./components/modals/EventNotificationModal";
 import NewsDashboard from "./components/news/NewsDashboard";
 import NewsSection from "./components/news/NewsSection";
 import OfficialLinkButtons from "./components/OfficialLinkButtons";
+import PromotionStatus from "./components/PromotionStatus";
 import ServiceChannelSelector from "./components/ServiceChannelSelector";
 import SettingsModal from "./components/settings/SettingsModal";
 import SupportLinks from "./components/SupportLinks";
@@ -309,6 +311,7 @@ function App() {
 
   // Patch Reservation State
   const [isPatchReservationOpen, setIsPatchReservationOpen] = useState(false);
+  const [isEventNotificationOpen, setIsEventNotificationOpen] = useState(false);
 
   // UI States (Local only)
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
@@ -2493,6 +2496,15 @@ function App() {
         onClose={handlePatchClose}
       />
 
+      {isEventNotificationOpen && (
+        <EventNotificationModal
+          onClose={() => setIsEventNotificationOpen(false)}
+          preferences={config.eventNotifications}
+          onSave={(preferences) =>
+            window.electronAPI.setConfig("eventNotifications", preferences)
+          }
+        />
+      )}
       {/* Modal: Patch Reservation */}
       <PatchReservationModal
         isOpen={isPatchReservationOpen}
@@ -2662,6 +2674,9 @@ function App() {
               >
                 <SupportLinks
                   remoteVersions={remoteVersions}
+                  onEventNotificationRequest={() =>
+                    setIsEventNotificationOpen(true)
+                  }
                   onForcedRepairRequest={handleForcedRepairRequest}
                   onPatchReservationRequest={() =>
                     setIsPatchReservationOpen(true)
@@ -2757,6 +2772,10 @@ function App() {
             {/* === Right Panel: Content Area === */}
             <div className="right-panel">
               <div className="news-refresh-toolbar">
+                <PromotionStatus
+                  activeGame={config.activeGame}
+                  serviceChannel={config.serviceChannel}
+                />
                 <div className="news-open-mode-panel">
                   <span className="news-open-mode-label">게시글 보기:</span>
                   <div

--- a/src/renderer/components/PromotionRow.css
+++ b/src/renderer/components/PromotionRow.css
@@ -1,0 +1,103 @@
+.promotion-item {
+  position: relative;
+}
+.promotion-row {
+  display: grid;
+  grid-template-columns: 24px 1fr;
+  gap: 8px;
+  width: 100%;
+  box-sizing: border-box;
+  padding: 13px 36px 13px 10px;
+  border: 0;
+  border-bottom: 1px solid #ffffff0d;
+  border-radius: 6px;
+  background: transparent;
+  color: #ddd;
+  font: inherit;
+  text-align: left;
+  text-decoration: none;
+}
+.promotion-twitch:hover {
+  background: #90bcee12;
+}
+.promotion-row > .material-symbols-outlined {
+  color: #90bcee;
+  font-size: 19px;
+  margin-top: 2px;
+}
+.promotion-row > span:last-child {
+  min-width: 0;
+}
+.promotion-row strong {
+  display: block;
+  color: #d8e7f6;
+  font-size: 12px;
+  line-height: 1.5;
+}
+.promotion-period {
+  white-space: nowrap;
+}
+.promotion-shop-links {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 3px 8px;
+  color: #aaa;
+  font-size: 11px;
+  margin-top: 7px;
+}
+.promotion-service {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  white-space: nowrap;
+}
+.promotion-service + .promotion-service::before {
+  content: "|";
+  color: #666;
+  margin-right: 2px;
+}
+.promotion-service a {
+  color: #90bcee;
+  padding: 3px 0;
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+.promotion-service a:hover {
+  color: #d8e7f6;
+}
+.promotion-service a:focus-visible {
+  outline: 2px solid #90bcee;
+  outline-offset: 2px;
+}
+.promotion-row:focus-visible {
+  outline: 2px solid #90bcee;
+  outline-offset: -2px;
+}
+
+.promotion-dismiss {
+  position: absolute;
+  top: 8px;
+  right: 2px;
+  display: grid;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: #aaa;
+  cursor: pointer;
+}
+.promotion-dismiss .material-symbols-outlined {
+  font-size: 17px;
+}
+.promotion-dismiss:hover {
+  background: #ffffff12;
+  color: #eee;
+}
+.promotion-item button:focus-visible {
+  outline: 2px solid #90bcee;
+  outline-offset: -2px;
+}

--- a/src/renderer/components/PromotionRow.tsx
+++ b/src/renderer/components/PromotionRow.tsx
@@ -1,0 +1,105 @@
+import {
+  STASH_LINKS,
+  TWITCH_LINKS,
+  formatPromotionPeriod,
+  promotionTitle,
+  promotionMatchesTarget,
+  type PromotionEvent,
+} from "../../shared/promotions";
+
+import "./PromotionRow.css";
+
+export function PromotionRow({
+  event,
+  isRead,
+  onRead,
+  onDismiss,
+}: {
+  event: PromotionEvent;
+  isRead: boolean;
+  onRead: () => void;
+  onDismiss: () => void;
+}) {
+  const exactPeriod = `${new Date(event.startsAt).toLocaleString()} ~ ${new Date(event.endsAt).toLocaleString()} (${Intl.DateTimeFormat().resolvedOptions().timeZone})`;
+  const content = (
+    <>
+      <span className="material-symbols-outlined" aria-hidden="true">
+        info
+      </span>
+      <span>
+        <strong>
+          {promotionTitle(event)} 진행 중{" "}
+          <span className="promotion-period" title={exactPeriod}>
+            ({formatPromotionPeriod(event)})
+          </span>
+        </strong>
+        {event.kind === "stash-sale" && (
+          <span className="promotion-shop-links">
+            {STASH_LINKS.filter((service) =>
+              service.games.some((link) =>
+                promotionMatchesTarget(event, service.service, link.game),
+              ),
+            ).map((service) => (
+              <span key={service.service} className="promotion-service">
+                <span>{service.service}:</span>
+                {service.games
+                  .filter((link) =>
+                    promotionMatchesTarget(event, service.service, link.game),
+                  )
+                  .map((link) => (
+                    <a
+                      key={link.game}
+                      href={link.url}
+                      target="_blank"
+                      rel="noreferrer"
+                      aria-label={`${service.service} ${link.game} 보관함 상점`}
+                      onClick={onRead}
+                      onAuxClick={(e) => {
+                        if (e.button === 1) onRead();
+                      }}
+                    >
+                      {link.game}
+                    </a>
+                  ))}
+              </span>
+            ))}
+          </span>
+        )}
+      </span>
+    </>
+  );
+  return (
+    <div
+      className={`promotion-item${isRead ? " notification-read" : ""}`}
+      data-promotion-id={event.id}
+    >
+      {event.kind === "twitch-drops" ? (
+        <a
+          className="promotion-row promotion-twitch"
+          href={TWITCH_LINKS[event.game === "poe1" ? "POE1" : "POE2"]}
+          target="_blank"
+          rel="noreferrer"
+          onClick={onRead}
+          onAuxClick={(e) => {
+            if (e.button === 1) onRead();
+          }}
+        >
+          {content}
+        </a>
+      ) : (
+        <div className="promotion-row">{content}</div>
+      )}
+      <button
+        type="button"
+        className="promotion-dismiss"
+        aria-label={`${promotionTitle(event)} 알림 닫기`}
+        aria-haspopup="dialog"
+        onClick={onDismiss}
+      >
+        <span className="material-symbols-outlined" aria-hidden="true">
+          close
+        </span>
+      </button>
+    </div>
+  );
+}

--- a/src/renderer/components/PromotionStatus.css
+++ b/src/renderer/components/PromotionStatus.css
@@ -1,0 +1,137 @@
+.promotion-status {
+  height: 32px;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0 8px 0 10px;
+  background: rgba(0, 0, 0, 0.4);
+  border: 1px solid #ffffff0d;
+  border-radius: 8px;
+  box-sizing: border-box;
+}
+.promotion-status > .news-open-mode-label {
+  margin-right: 2px;
+}
+.promotion-buff-slot {
+  position: relative;
+  display: flex;
+}
+.promotion-buff-slot > a {
+  display: flex;
+  border-radius: 5px;
+}
+.promotion-buff {
+  position: relative;
+  display: grid;
+  place-items: center;
+  width: 26px;
+  height: 26px;
+  border-radius: 5px;
+  overflow: hidden;
+  color: #756f60;
+  background: #ffffff10;
+}
+.promotion-buff::after {
+  content: "";
+  position: absolute;
+  inset: 1px;
+  border-radius: 4px;
+  background: #171713;
+}
+.promotion-buff svg {
+  position: relative;
+  z-index: 1;
+  width: 16px;
+  height: 16px;
+}
+.promotion-buff.active {
+  color: var(--theme-accent, #dfcf99);
+  background: color-mix(in srgb, var(--theme-accent, #dfcf99) 35%, transparent);
+  box-shadow: 0 0 7px
+    color-mix(in srgb, var(--theme-accent, #dfcf99) 15%, transparent);
+}
+.promotion-buff.active::before {
+  content: "";
+  position: absolute;
+  inset: -65%;
+  background: conic-gradient(
+    transparent 0deg 240deg,
+    var(--theme-accent, #dfcf99) 300deg,
+    #fff7d2 330deg,
+    transparent 360deg
+  );
+  animation: promotion-buff-orbit 3s linear infinite;
+}
+.promotion-buff.active::after {
+  inset: 2px;
+  border-radius: 3px;
+}
+.promotion-buff-slot > a:hover .promotion-buff {
+  filter: brightness(1.2);
+}
+.promotion-buff-slot > a:focus-visible,
+.promotion-buff-slot > [tabindex]:focus-visible {
+  outline: 2px solid var(--theme-accent, #dfcf99);
+  outline-offset: 3px;
+}
+.promotion-buff-tooltip {
+  position: absolute;
+  top: calc(100% + 10px);
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 10;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: max-content;
+  max-width: 300px;
+  padding: 12px 14px;
+  border: 1px solid color-mix(in srgb, var(--theme-accent, #dfcf99) 30%, #333);
+  border-radius: 7px;
+  background: #151513;
+  box-shadow: 0 8px 24px #0009;
+  color: #aaa;
+  font-size: 12px;
+  line-height: 1.6;
+  pointer-events: none;
+  visibility: hidden;
+  opacity: 0;
+  transition: opacity 0.12s;
+}
+.promotion-buff-tooltip strong {
+  color: #e8e1c9;
+  font-size: 12px;
+  font-weight: 600;
+}
+.promotion-buff-period {
+  display: flex;
+  flex-direction: column;
+}
+.promotion-buff-next {
+  color: var(--theme-accent, #dfcf99);
+  font-size: 11px;
+}
+.promotion-buff-destination {
+  padding-top: 6px;
+  border-top: 1px solid #ffffff12;
+  color: var(--theme-accent, #dfcf99);
+  font-size: 11px;
+}
+.promotion-buff-slot:hover .promotion-buff-tooltip,
+.promotion-buff-slot:focus-within .promotion-buff-tooltip {
+  visibility: visible;
+  opacity: 1;
+}
+@keyframes promotion-buff-orbit {
+  to {
+    transform: rotate(360deg);
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .promotion-buff.active::before {
+    animation: none;
+  }
+  .promotion-buff-tooltip {
+    transition: none;
+  }
+}

--- a/src/renderer/components/PromotionStatus.test.tsx
+++ b/src/renderer/components/PromotionStatus.test.tsx
@@ -1,0 +1,203 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import PromotionStatus from "./PromotionStatus";
+import { stashSection } from "../../shared/test-fixtures/stash-sales";
+
+import type { PromotionEvent } from "../../shared/promotions";
+import type {
+  ActiveGame,
+  ElectronAPI,
+  ServiceChannel,
+} from "../../shared/types";
+
+const drops: PromotionEvent = {
+  id: "qa-drops",
+  kind: "twitch-drops",
+  game: "poe1",
+  startsAt: "2026-09-04T00:00:00Z",
+  endsAt: "2026-09-05T00:00:00Z",
+  sourceUrl: "https://www.pathofexile.com/forum/view-thread/1",
+  precision: "exact",
+};
+const stash: PromotionEvent = {
+  ...drops,
+  id: "qa-stash",
+  kind: "stash-sale",
+  game: "both",
+};
+
+describe("promotion status shortcuts", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime("2026-09-04T01:00:00Z");
+    (
+      globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+    window.electronAPI = {
+      getPromotions: vi.fn().mockResolvedValue({
+        revision: 1,
+        events: [],
+        activeEvents: [drops, stash],
+        upcomingEvents: [],
+      }),
+      onPromotionsUpdated: vi.fn(() => vi.fn()),
+    } as unknown as ElectronAPI;
+    container = document.createElement("div");
+    document.body.append(container);
+    root = createRoot(container);
+  });
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    vi.useRealTimers();
+  });
+  const render = async (
+    serviceChannel: ServiceChannel,
+    activeGame: ActiveGame,
+  ) =>
+    act(async () =>
+      root.render(
+        <PromotionStatus
+          serviceChannel={serviceChannel}
+          activeGame={activeGame}
+        />,
+      ),
+    );
+
+  it.each([
+    ["GGG", "POE1", "https://www.pathofexile.com/shop/category/stash-tabs"],
+    ["GGG", "POE2", "https://pathofexile2.com/shop/stash-tabs"],
+    [
+      "Kakao Games",
+      "POE1",
+      "https://poe.kakaogames.com/shop/category/stash-tabs",
+    ],
+    ["Kakao Games", "POE2", "https://poe2.kakaogames.com/shop/stash-tabs"],
+  ] as const)(
+    "opens the %s %s shop independently of dismissed notifications",
+    async (service, game, url) => {
+      await render(service, game);
+      const label = container.querySelector(".news-open-mode-label");
+      expect(label?.textContent).toBe("이달의 주요 소식");
+      expect(label?.tagName).toBe("SPAN");
+      expect(label?.closest("a")).toBeNull();
+      expect(
+        container
+          .querySelector('[data-promotion-status="stash-sale"] a')
+          ?.getAttribute("href"),
+      ).toBe(url);
+      expect(container.querySelectorAll(".promotion-buff.active")).toHaveLength(
+        2,
+      );
+      // Only PoE 1 drops exist; selecting PoE 2 must still show those drops.
+      expect(
+        container
+          .querySelector('[data-promotion-status="twitch-drops"] a')
+          ?.getAttribute("href"),
+      ).toBe("https://www.twitch.tv/directory/category/path-of-exile");
+      expect(container.textContent).toContain("PoE 1 트위치 드롭스");
+    },
+  );
+  it("stops highlighting and linking expired events without a new IPC snapshot", async () => {
+    await render("GGG", "POE2");
+    vi.setSystemTime(drops.endsAt);
+    await act(async () => vi.advanceTimersByTimeAsync(1000));
+    expect(container.querySelectorAll(".promotion-buff.active")).toHaveLength(
+      0,
+    );
+    expect(container.querySelectorAll(".promotion-buff-slot a")).toHaveLength(
+      0,
+    );
+    expect(container.textContent).toContain("예정된 일정이 없습니다");
+  });
+
+  it("does not expand a confirmed service/game pair to other shops", async () => {
+    window.electronAPI.getPromotions = vi.fn().mockResolvedValue({
+      revision: 1,
+      events: [],
+      activeEvents: [
+        { ...stash, targets: [{ service: "kakao", game: "poe2" }] },
+      ],
+      upcomingEvents: [],
+    });
+    for (const [service, game] of [
+      ["GGG", "POE1"],
+      ["GGG", "POE2"],
+      ["Kakao Games", "POE1"],
+    ] as const) {
+      await render(service, game);
+      expect(container.querySelectorAll(".promotion-buff.active")).toHaveLength(
+        0,
+      );
+    }
+    await render("Kakao Games", "POE2");
+    expect(container.querySelectorAll(".promotion-buff.active")).toHaveLength(
+      1,
+    );
+  });
+
+  it("shows estimated dates without activating at their start and expires them locally", async () => {
+    window.electronAPI.getPromotions = vi.fn().mockResolvedValue({
+      revision: 1,
+      events: [],
+      activeEvents: [],
+      upcomingEvents: [],
+      stashEstimate: stashSection.nextEstimate,
+    });
+    await render("GGG", "POE2");
+    expect(container.textContent).toContain("다음 예상 일정");
+    expect(container.textContent).toContain("9/11 ~ 9/15");
+    vi.setSystemTime("2026-09-11T01:00:00Z");
+    await act(async () => vi.advanceTimersByTimeAsync(1000));
+    expect(container.querySelectorAll(".promotion-buff.active")).toHaveLength(
+      0,
+    );
+    expect(container.querySelectorAll(".promotion-buff-slot a")).toHaveLength(
+      0,
+    );
+    vi.setSystemTime("2026-09-15T15:00:00Z");
+    await act(async () => vi.advanceTimersByTimeAsync(1000));
+    expect(container.textContent).not.toContain("9/11 ~ 9/15");
+  });
+
+  it("shows the earliest upcoming schedule on inactive icons and activates at its start", async () => {
+    const next = { ...drops, startsAt: "2026-09-04T02:00:00Z" };
+    const later = {
+      ...drops,
+      id: "later",
+      game: "poe2",
+      startsAt: "2026-09-04T03:00:00Z",
+    };
+    window.electronAPI.getPromotions = vi.fn().mockResolvedValue({
+      revision: 1,
+      events: [],
+      activeEvents: [],
+      upcomingEvents: [later, next],
+    });
+    await render("Kakao Games", "POE2");
+    const tip = container.querySelector(
+      '[data-promotion-status="twitch-drops"] [role="tooltip"]',
+    )!;
+    expect(tip.textContent).toContain("다음 이벤트");
+    expect(tip.textContent).toContain("PoE 1 트위치 드롭스");
+    expect(tip.textContent).not.toContain("PoE 2 트위치 드롭스");
+    expect(container.querySelectorAll(".promotion-buff.active")).toHaveLength(
+      0,
+    );
+    expect(container.querySelectorAll(".promotion-buff-slot a")).toHaveLength(
+      0,
+    );
+    vi.setSystemTime(next.startsAt);
+    await act(async () => vi.advanceTimersByTimeAsync(1000));
+    expect(container.querySelectorAll(".promotion-buff.active")).toHaveLength(
+      1,
+    );
+    expect(
+      container.querySelector(".promotion-buff-slot a")?.getAttribute("href"),
+    ).toBe("https://www.twitch.tv/directory/category/path-of-exile");
+  });
+});

--- a/src/renderer/components/PromotionStatus.tsx
+++ b/src/renderer/components/PromotionStatus.tsx
@@ -1,0 +1,208 @@
+import { useId } from "react";
+
+import {
+  STASH_LINKS,
+  TWITCH_LINKS,
+  isPromotionActive,
+  promotionScheduleKey,
+  promotionTitle,
+  promotionMatchesTarget,
+  type PromotionEvent,
+} from "../../shared/promotions";
+import {
+  formatStashEstimate,
+  type StashEstimate,
+} from "../../shared/stash-sales";
+import { usePromotionSchedule } from "../hooks/usePromotions";
+
+import type { ActiveGame, ServiceChannel } from "../../shared/types";
+
+import "./PromotionStatus.css";
+
+const dateTime = new Intl.DateTimeFormat("ko-KR", {
+  month: "numeric",
+  day: "numeric",
+  hour: "2-digit",
+  minute: "2-digit",
+  hour12: false,
+});
+
+const period = (event: PromotionEvent) =>
+  `${dateTime.format(new Date(event.startsAt))} ~ ${dateTime.format(new Date(event.endsAt))}`;
+
+function BuffIcon({ kind }: { kind: PromotionEvent["kind"] }) {
+  return kind === "twitch-drops" ? (
+    <svg viewBox="0 0 24 24" aria-hidden="true">
+      <path
+        fill="currentColor"
+        d="M4 2 1 5v15h5v3l4-3h5l7-7V2H4zm16 10-4 4h-5l-3 3v-3H4V4h16v8z"
+      />
+      <path fill="currentColor" d="M10 6h2v6h-2zm5 0h2v6h-2z" />
+    </svg>
+  ) : (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.6"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="m3 7 9-4 9 4v12l-9 3-9-3V7Zm0 0 9 4 9-4M12 11v11M7.5 5l9 4v5l-3 1" />
+    </svg>
+  );
+}
+
+function EventBuff({
+  kind,
+  events,
+  href,
+  destination,
+  nextEvent,
+  estimate,
+}: {
+  kind: PromotionEvent["kind"];
+  events: PromotionEvent[];
+  href: string | undefined;
+  destination: string;
+  nextEvent?: PromotionEvent;
+  estimate?: StashEstimate | null;
+}) {
+  const tooltipId = useId();
+  const label = kind === "twitch-drops" ? "트위치 드롭스" : "보관함 할인";
+  const active = events.length > 0;
+  const icon = (
+    <span className={`promotion-buff ${active ? "active" : ""}`}>
+      <BuffIcon kind={kind} />
+    </span>
+  );
+  return (
+    <span className="promotion-buff-slot" data-promotion-status={kind}>
+      {active && href ? (
+        <a
+          href={href}
+          target="_blank"
+          rel="noreferrer"
+          aria-label={`${label} 진행 중 · ${destination}`}
+          aria-describedby={tooltipId}
+        >
+          {icon}
+        </a>
+      ) : (
+        <span
+          tabIndex={0}
+          role="img"
+          aria-label={`${label}: ${nextEvent ? "다음 이벤트 예정" : estimate ? "다음 예상 일정" : "예정된 일정이 없습니다"}`}
+          aria-describedby={tooltipId}
+        >
+          {icon}
+        </span>
+      )}
+      <span className="promotion-buff-tooltip" id={tooltipId} role="tooltip">
+        {active ? (
+          <>
+            {events.map((event) => (
+              <span
+                className="promotion-buff-period"
+                key={promotionScheduleKey(event)}
+              >
+                <strong>{promotionTitle(event)}</strong>
+                <span>{period(event)}</span>
+              </span>
+            ))}
+            <span className="promotion-buff-destination">{destination}</span>
+          </>
+        ) : nextEvent ? (
+          <>
+            <span className="promotion-buff-next">다음 이벤트</span>
+            <span className="promotion-buff-period">
+              <strong>{promotionTitle(nextEvent)}</strong>
+              <span>{period(nextEvent)}</span>
+            </span>
+          </>
+        ) : estimate ? (
+          <>
+            <span className="promotion-buff-next">다음 예상 일정</span>
+            <span className="promotion-buff-period">
+              <strong>{label}</strong>
+              <span>{formatStashEstimate(estimate)} (한국시간)</span>
+            </span>
+          </>
+        ) : (
+          <>
+            <strong>{label}</strong>
+            <span>예정된 일정이 없습니다</span>
+          </>
+        )}
+      </span>
+    </span>
+  );
+}
+
+export default function PromotionStatus({
+  activeGame,
+  serviceChannel,
+}: {
+  activeGame: ActiveGame;
+  serviceChannel: ServiceChannel;
+}) {
+  const { events: schedules, stashEstimate } = usePromotionSchedule();
+  const events = schedules.filter((event) => isPromotionActive(event));
+  const upcoming = schedules
+    .filter((event) => !isPromotionActive(event))
+    .sort((a, b) => Date.parse(a.startsAt) - Date.parse(b.startsAt));
+  const game = activeGame === "POE1" ? "poe1" : "poe2";
+  const drops = events.filter((event) => event.kind === "twitch-drops");
+  const dropTarget = drops.find((event) => event.game === game) ?? drops[0];
+  const stash = events.filter(
+    (event) =>
+      event.kind === "stash-sale" &&
+      promotionMatchesTarget(
+        event,
+        serviceChannel === "GGG" ? "GGG" : "KakaoGames",
+        activeGame === "POE1" ? "POE" : "POE2",
+      ) &&
+      (event.game === "both" || event.game === game),
+  );
+  const shop =
+    STASH_LINKS[serviceChannel === "GGG" ? 0 : 1].games[
+      activeGame === "POE1" ? 0 : 1
+    ];
+  return (
+    <div
+      className="promotion-status"
+      role="group"
+      aria-label="이달의 주요 소식"
+    >
+      <span className="news-open-mode-label">이달의 주요 소식</span>
+      <EventBuff
+        kind="twitch-drops"
+        events={drops}
+        nextEvent={upcoming.find((event) => event.kind === "twitch-drops")}
+        href={
+          dropTarget
+            ? TWITCH_LINKS[dropTarget.game === "poe1" ? "POE1" : "POE2"]
+            : undefined
+        }
+        destination={`PoE ${dropTarget?.game === "poe1" ? "1" : "2"} Twitch`}
+      />
+      <EventBuff
+        kind="stash-sale"
+        events={stash}
+        estimate={stashEstimate}
+        nextEvent={upcoming.find(
+          (event) =>
+            event.kind === "stash-sale" &&
+            promotionMatchesTarget(
+              event,
+              serviceChannel === "GGG" ? "GGG" : "KakaoGames",
+              activeGame === "POE1" ? "POE" : "POE2",
+            ) &&
+            (event.game === "both" || event.game === game),
+        )}
+        href={shop.url}
+        destination={`${serviceChannel === "GGG" ? "GGG" : "KakaoGames"} ${activeGame === "POE1" ? "POE" : "POE2"} 상점`}
+      />
+    </div>
+  );
+}

--- a/src/renderer/components/SupportLinks.css
+++ b/src/renderer/components/SupportLinks.css
@@ -26,6 +26,27 @@
   color: var(--theme-accent, #dfcf99);
 }
 
+.event-notification-menu {
+  width: 100%;
+  border: 0;
+  background: transparent;
+  text-align: left;
+  font-family: inherit;
+}
+
+.event-notification-menu .support-link-icon {
+  width: 20px;
+  height: 20px;
+  margin-right: 10px;
+  font-size: 20px;
+}
+
+.event-notification-menu:focus-visible {
+  outline: 2px solid var(--theme-accent, #dfcf99);
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
 .support-link-icon {
   font-size: 16px;
   display: inline-block;

--- a/src/renderer/components/SupportLinks.tsx
+++ b/src/renderer/components/SupportLinks.tsx
@@ -154,6 +154,7 @@ interface SupportLinksProps {
     timestamp: string | number;
   }) => void;
   onPatchReservationRequest?: () => void;
+  onEventNotificationRequest?: () => void;
   onFontManagerSettingsRequest?: () => void;
 }
 
@@ -161,6 +162,7 @@ const SupportLinks: React.FC<SupportLinksProps> = ({
   remoteVersions,
   onForcedRepairRequest,
   onPatchReservationRequest,
+  onEventNotificationRequest,
   onFontManagerSettingsRequest,
 }) => {
   // Define Links Configuration
@@ -336,6 +338,19 @@ const SupportLinks: React.FC<SupportLinksProps> = ({
 
   return (
     <div className="support-links-wrapper">
+      <button
+        type="button"
+        className="support-link event-notification-menu"
+        onClick={onEventNotificationRequest}
+      >
+        <span
+          className="material-symbols-outlined support-link-icon"
+          aria-hidden="true"
+        >
+          notifications_active
+        </span>
+        이벤트 알림 관리
+      </button>
       {linkDefinitions.map((def) => (
         <SupportLinkItemRenderer key={def.id} item={def} />
       ))}

--- a/src/renderer/components/WindowControls.css
+++ b/src/renderer/components/WindowControls.css
@@ -1,0 +1,4 @@
+.notification-read {
+  filter: saturate(0.15);
+  opacity: 0.78;
+}

--- a/src/renderer/components/WindowControls.test.tsx
+++ b/src/renderer/components/WindowControls.test.tsx
@@ -3,7 +3,12 @@ import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import WindowControls from "./WindowControls";
+import { promotionScheduleKey } from "../../shared/promotions";
 
+import type {
+  PromotionEvent,
+  PromotionSnapshot,
+} from "../../shared/promotions";
 import type {
   DebugLogPayload,
   ElectronAPI,
@@ -34,6 +39,7 @@ describe("WindowControls notifications", () => {
       }
     ).IS_REACT_ACT_ENVIRONMENT = true;
     window.localStorage.clear();
+    window.sessionStorage.clear();
     emitException = undefined;
     window.electronAPI = {
       getDebugHistory: vi.fn().mockResolvedValue([]),
@@ -46,6 +52,7 @@ describe("WindowControls notifications", () => {
       setConfig: vi.fn(),
     } as unknown as ElectronAPI;
     container = document.createElement("div");
+    container.id = "app-container";
     document.body.append(container);
     root = createRoot(container);
   });
@@ -53,6 +60,7 @@ describe("WindowControls notifications", () => {
   afterEach(async () => {
     await act(async () => root.unmount());
     container.remove();
+    vi.restoreAllMocks();
   });
 
   it("deduplicates an operational warning and sends its exact context without opening the exception report", async () => {
@@ -97,6 +105,13 @@ describe("WindowControls notifications", () => {
       }),
     );
     expect(reportListener).not.toHaveBeenCalled();
+    expect(container.querySelector("[data-notification-badge]")).toBeNull();
+    await act(async () => notificationToggle?.click());
+    expect(
+      container
+        .querySelector(`[data-notification-id="${warning.id}"]`)
+        ?.classList.contains("notification-read"),
+    ).toBe(true);
     window.removeEventListener("SHOW_REPORT_MODAL", reportListener);
   });
 
@@ -122,5 +137,395 @@ describe("WindowControls notifications", () => {
     expect(
       container.querySelector('button[title="알림 2건 확인"]'),
     ).not.toBeNull();
+  });
+
+  it("keeps fresh information beside warnings when an older initial query resolves late", async () => {
+    let update!: (snapshot: PromotionSnapshot) => void;
+    let resolveInitial!: (snapshot: PromotionSnapshot) => void;
+    const unsubscribe = vi.fn();
+    window.electronAPI.getPromotions = () =>
+      new Promise((resolve) => {
+        resolveInitial = resolve;
+      });
+    window.electronAPI.onPromotionsUpdated = (callback) => {
+      update = callback;
+      return unsubscribe;
+    };
+    await act(async () =>
+      root.render(
+        <WindowControls
+          devMode={false}
+          debugConsole={false}
+          operationalNotifications={[warning]}
+        />,
+      ),
+    );
+    const now = Date.now();
+    await act(async () =>
+      update({
+        revision: 2,
+        activeEvents: [],
+        upcomingEvents: [],
+        events: [
+          {
+            id: "ggg-1-stash",
+            kind: "stash-sale",
+            game: "both",
+            startsAt: new Date(now - 1000).toISOString(),
+            endsAt: new Date(now + 86400_000).toISOString(),
+            sourceUrl: "https://www.pathofexile.com/forum/view-thread/1",
+            precision: "exact",
+          },
+        ],
+      }),
+    );
+    await act(async () =>
+      resolveInitial({
+        revision: 1,
+        activeEvents: [],
+        upcomingEvents: [],
+        events: [],
+      }),
+    );
+    await act(async () =>
+      container
+        .querySelector<HTMLButtonElement>("[data-notification-toggle]")
+        ?.click(),
+    );
+    expect(container.textContent).toContain("보관함 할인 진행 중");
+    expect(container.textContent).not.toContain("예시");
+    expect(
+      container.querySelectorAll('[data-promotion-id="ggg-1-stash"] a'),
+    ).toHaveLength(4);
+    expect(container.querySelector("[data-notification-id]")).not.toBeNull();
+    await act(async () =>
+      update({ revision: 3, activeEvents: [], upcomingEvents: [], events: [] }),
+    );
+    expect(container.textContent).not.toContain("보관함 할인 진행 중");
+    await act(async () => root.render(null));
+    expect(unsubscribe).toHaveBeenCalledOnce();
+  });
+
+  it.each(["session", "schedule"] as const)(
+    "dismisses an in-app promotion using %s mode without activating its link",
+    async (mode) => {
+      const event: PromotionEvent = {
+        id: "qa-twitch",
+        kind: "twitch-drops",
+        game: "poe2",
+        startsAt: new Date(Date.now() - 1000).toISOString(),
+        endsAt: new Date(Date.now() + 86400_000).toISOString(),
+        sourceUrl: "https://www.pathofexile.com/forum/view-thread/1",
+        precision: "manual",
+      };
+      let update!: (snapshot: PromotionSnapshot) => void;
+      window.electronAPI.getPromotions = vi.fn().mockResolvedValue({
+        revision: 1,
+        activeEvents: [],
+        upcomingEvents: [],
+        events: [event],
+      });
+      window.electronAPI.onPromotionsUpdated = (callback) => {
+        update = callback;
+        return vi.fn();
+      };
+      window.electronAPI.dismissPromotion = vi.fn(async () => {
+        update({
+          revision: 2,
+          activeEvents: [],
+          upcomingEvents: [],
+          events: [],
+        });
+        return { ok: true as const };
+      });
+      await act(async () =>
+        root.render(<WindowControls devMode={false} debugConsole={false} />),
+      );
+      const click = async (selector: string) =>
+        act(async () =>
+          container.querySelector<HTMLButtonElement>(selector)!.click(),
+        );
+      await click("[data-notification-toggle]");
+      const close =
+        container.querySelector<HTMLButtonElement>(".promotion-dismiss")!;
+      expect(close.closest("a")).toBeNull();
+      await click(".promotion-dismiss");
+      const dialog = container.querySelector('[role="dialog"]');
+      expect(dialog).not.toBeNull();
+      expect(dialog?.parentElement?.parentElement).toBe(container);
+      expect(container.querySelector("[data-notification-panel]")).toBeNull();
+      expect(container.textContent).toContain("알림 삭제");
+      expect(container.textContent).toContain("이번 일정 내 표시하지 않음");
+      await click(".promotion-dismiss-modal input");
+      await act(async () =>
+        document.activeElement!.dispatchEvent(
+          new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+        ),
+      );
+      expect(container.querySelector('[role="dialog"]')).toBeNull();
+      expect(document.activeElement).toBe(
+        container.querySelector("[data-notification-toggle]"),
+      );
+      expect(window.electronAPI.dismissPromotion).not.toHaveBeenCalled();
+      expect(
+        container.querySelector("[data-notification-badge]")?.textContent,
+      ).toBe("1");
+      await click("[data-notification-toggle]");
+      await click(".promotion-dismiss");
+      expect(
+        container.querySelector<HTMLInputElement>(
+          ".promotion-dismiss-modal input",
+        )?.checked,
+      ).toBe(true);
+      if (mode === "session") await click(".promotion-dismiss-modal input");
+      await click(".promotion-dismiss-modal .event-notification-confirm");
+      expect(window.electronAPI.dismissPromotion).toHaveBeenCalledWith({
+        key: promotionScheduleKey(event),
+        mode,
+      });
+      expect(container.querySelector("[data-promotion-id]")).toBeNull();
+      expect(document.activeElement).toBe(
+        container.querySelector('[aria-label="창 최소화"]'),
+      );
+    },
+  );
+
+  it("keeps an event visible when the dismissal command fails", async () => {
+    const event: PromotionEvent = {
+      id: "qa-stash",
+      kind: "stash-sale",
+      game: "both",
+      startsAt: new Date(Date.now() - 1000).toISOString(),
+      endsAt: new Date(Date.now() + 86400_000).toISOString(),
+      sourceUrl: "https://www.pathofexile.com/forum/view-thread/1",
+      precision: "manual",
+    };
+    window.electronAPI.getPromotions = vi.fn().mockResolvedValue({
+      revision: 1,
+      activeEvents: [],
+      upcomingEvents: [],
+      events: [event],
+    });
+    let finish!: (result: { ok: false; reason: "save-failed" }) => void;
+    window.electronAPI.dismissPromotion = vi.fn(
+      () =>
+        new Promise<{ ok: false; reason: "save-failed" }>((resolve) => {
+          finish = resolve;
+        }),
+    );
+    await act(async () =>
+      root.render(<WindowControls devMode={false} debugConsole={false} />),
+    );
+    await act(async () =>
+      container
+        .querySelector<HTMLButtonElement>("[data-notification-toggle]")!
+        .click(),
+    );
+    await act(async () =>
+      container.querySelector<HTMLButtonElement>(".promotion-dismiss")!.click(),
+    );
+    await act(async () =>
+      container
+        .querySelector<HTMLButtonElement>(
+          ".promotion-dismiss-modal .event-notification-confirm",
+        )!
+        .click(),
+    );
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>(".event-notification-confirm")!
+        .click();
+      container
+        .querySelector<HTMLButtonElement>(".event-notification-cancel")!
+        .click();
+      container
+        .querySelector<HTMLButtonElement>(".event-notification-close")!
+        .click();
+      container
+        .querySelector<HTMLElement>(".promotion-dismiss-overlay")!
+        .click();
+      document.activeElement!.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+      );
+    });
+    expect(window.electronAPI.dismissPromotion).toHaveBeenCalledOnce();
+    expect(
+      container.querySelector<HTMLInputElement>(
+        ".promotion-dismiss-modal input",
+      )?.disabled,
+    ).toBe(true);
+    expect(container.querySelector('[role="dialog"]')).not.toBeNull();
+    await act(async () => finish({ ok: false, reason: "save-failed" }));
+    expect(
+      container.querySelector<HTMLInputElement>(
+        ".promotion-dismiss-modal input",
+      )?.checked,
+    ).toBe(true);
+    expect(container.querySelector('[role="dialog"]')).not.toBeNull();
+    expect(
+      container.querySelector("[data-notification-toggle]"),
+    ).not.toBeNull();
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain(
+      "다시 시도",
+    );
+  });
+
+  it("counts only unread items, keeps read links accessible and identifies promotions by schedule", async () => {
+    const now = Date.now();
+    const event: PromotionEvent = {
+      id: "read-twitch",
+      kind: "twitch-drops",
+      game: "poe1",
+      startsAt: new Date(now - 1000).toISOString(),
+      endsAt: new Date(now + 86400_000).toISOString(),
+      sourceUrl: "https://www.pathofexile.com/forum/view-thread/1",
+      precision: "exact",
+    };
+    let events = [
+      event,
+      {
+        ...event,
+        id: "read-stash",
+        kind: "stash-sale" as const,
+        game: "both" as const,
+      },
+    ];
+    window.electronAPI.getPromotions = vi.fn(async () => ({
+      revision: 1,
+      activeEvents: [],
+      upcomingEvents: [],
+      events,
+    }));
+    const render = () =>
+      root.render(<WindowControls devMode={false} debugConsole={false} />);
+    const click = (selector: string) =>
+      act(async () => container.querySelector<HTMLElement>(selector)!.click());
+    const badge = () =>
+      container.querySelector("[data-notification-badge]")?.textContent;
+    // Exercise React handlers while suppressing jsdom's external navigation only.
+    container.addEventListener("click", (e) => {
+      if ((e.target as Element).closest("a")) e.preventDefault();
+    });
+    await act(async () => render());
+    expect(badge()).toBe("2");
+    await click("[data-notification-toggle]");
+    expect(badge()).toBe("2");
+    await act(async () =>
+      container
+        .querySelector('[data-promotion-id="read-twitch"] a')!
+        .dispatchEvent(
+          new MouseEvent("auxclick", { button: 2, bubbles: true }),
+        ),
+    );
+    expect(badge()).toBe("2");
+    await click('[data-promotion-id="read-twitch"] a');
+    expect(badge()).toBe("1");
+    expect(
+      container
+        .querySelector('[data-promotion-id="read-twitch"]')
+        ?.classList.contains("notification-read"),
+    ).toBe(true);
+    await act(async () =>
+      container
+        .querySelector('[data-promotion-id="read-stash"] a')!
+        .dispatchEvent(
+          new MouseEvent("auxclick", { button: 1, bubbles: true }),
+        ),
+    );
+    expect(badge()).toBeUndefined();
+    expect(container.textContent).toContain("모두 읽음");
+    expect(container.querySelectorAll("[data-promotion-id]")).toHaveLength(2);
+    await click('[data-promotion-id="read-stash"] a:last-child');
+    expect(badge()).toBeUndefined();
+    await click("[data-notification-toggle]");
+    await click("[data-notification-toggle]");
+    expect(container.querySelectorAll(".notification-read")).toHaveLength(2);
+
+    // Reload/remount and an article ID change retain read state for the same schedule.
+    await act(async () => root.render(null));
+    events = [{ ...event, id: "new-article-same-schedule" }];
+    await act(async () => render());
+    expect(badge()).toBeUndefined();
+    await click("[data-notification-toggle]");
+    expect(container.querySelector(".notification-read")).not.toBeNull();
+    await act(async () => root.render(null));
+    events = [{ ...event, endsAt: new Date(now + 172800_000).toISOString() }];
+    await act(async () => render());
+    expect(badge()).toBe("1");
+    // A fresh renderer session (actual process restart is covered by Electron QA).
+    await act(async () => root.render(null));
+    window.sessionStorage.clear();
+    events = [event];
+    await act(async () => render());
+    expect(badge()).toBe("1");
+  });
+
+  it("marks an opened error report read and counts a newly arriving error", async () => {
+    const log: DebugLogPayload = {
+      type: "renderer_exception",
+      content: "Unhandled exception\n at App",
+      isError: true,
+      timestamp: 1,
+    };
+    window.electronAPI.getDebugHistory = vi.fn().mockResolvedValue([log]);
+    await act(async () =>
+      root.render(<WindowControls devMode={false} debugConsole={false} />),
+    );
+    await act(async () =>
+      container
+        .querySelector<HTMLElement>("[data-notification-toggle]")!
+        .click(),
+    );
+    await act(async () =>
+      container
+        .querySelector<HTMLElement>("[data-error-notification] button")!
+        .click(),
+    );
+    expect(container.querySelector("[data-notification-badge]")).toBeNull();
+    await act(async () =>
+      container
+        .querySelector<HTMLElement>("[data-notification-toggle]")!
+        .click(),
+    );
+    expect(
+      container
+        .querySelector("[data-error-notification]")
+        ?.classList.contains("notification-read"),
+    ).toBe(true);
+    await act(async () => emitException?.({ ...log, timestamp: 2 }));
+    expect(
+      container.querySelector("[data-notification-badge]")?.textContent,
+    ).toBe("1");
+  });
+
+  it("still marks notifications read when session storage is unavailable", async () => {
+    vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("unavailable");
+    });
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("unavailable");
+    });
+    await act(async () =>
+      root.render(
+        <WindowControls
+          devMode={false}
+          debugConsole={false}
+          operationalNotifications={[warning]}
+          onOperationalNotificationClick={vi.fn()}
+        />,
+      ),
+    );
+    await act(async () =>
+      container
+        .querySelector<HTMLElement>("[data-notification-toggle]")!
+        .click(),
+    );
+    await act(async () =>
+      container.querySelector<HTMLElement>("[data-notification-id]")!.click(),
+    );
+    expect(
+      container.querySelector("[data-notification-toggle]"),
+    ).not.toBeNull();
+    expect(container.querySelector("[data-notification-badge]")).toBeNull();
   });
 });

--- a/src/renderer/components/WindowControls.tsx
+++ b/src/renderer/components/WindowControls.tsx
@@ -1,5 +1,8 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 
+import PromotionDismissModal from "./modals/PromotionDismissModal";
+import { PromotionRow } from "./PromotionRow";
 import {
   buildErrorReportData,
   getDebugLogNotificationId,
@@ -8,8 +11,16 @@ import {
   getDebugLogPreview,
   getExceptionDebugLogs,
 } from "../../shared/debug-log-policy";
+import {
+  promotionScheduleKey,
+  type PromotionEvent,
+} from "../../shared/promotions";
 import { DebugLogPayload, OperationalNotification } from "../../shared/types";
+import { usePromotions } from "../hooks/usePromotions";
+import { useReadNotifications } from "../hooks/useReadNotifications";
 import { dedupeOperationalNotifications } from "../utils/game-path-registry-warning";
+
+import "./WindowControls.css";
 
 interface WindowControlsProps {
   devMode: boolean;
@@ -23,7 +34,6 @@ interface WindowControlsProps {
 const DISMISSED_NOTIFICATION_STORAGE_KEY =
   "poe-launcher:dismissed-error-notifications";
 const MAX_DISMISSED_NOTIFICATION_IDS = 100;
-const MAX_VISIBLE_NOTIFICATION_ITEMS = 4;
 
 const WindowControls: React.FC<WindowControlsProps> = ({
   devMode,
@@ -32,12 +42,16 @@ const WindowControls: React.FC<WindowControlsProps> = ({
   onOperationalNotificationClick,
 }) => {
   const [exceptionLogs, setExceptionLogs] = useState<DebugLogPayload[]>([]);
+  const promotions = usePromotions();
+  const { readIds, markRead } = useReadNotifications();
   const [isNotificationOpen, setIsNotificationOpen] = useState(false);
+  const [dismissTarget, setDismissTarget] = useState<PromotionEvent | null>(
+    null,
+  );
   const [dismissedNotificationIds, setDismissedNotificationIds] = useState<
     Set<string>
   >(loadDismissedNotificationIds);
   const controlsRef = useRef<HTMLDivElement>(null);
-
   useEffect(() => {
     let isMounted = true;
     let unsubscribe: (() => void) | undefined;
@@ -100,9 +114,24 @@ const WindowControls: React.FC<WindowControlsProps> = ({
     [operationalNotifications],
   );
   const notificationCount =
-    notificationLogs.length + operationalNotificationItems.length;
-  const shouldScrollNotifications =
-    notificationCount >= MAX_VISIBLE_NOTIFICATION_ITEMS;
+    notificationLogs.length +
+    operationalNotificationItems.length +
+    promotions.length;
+  const unreadWarningCount =
+    notificationLogs.filter(
+      (log) => !readIds.has(`error:${getDebugLogNotificationId(log)}`),
+    ).length +
+    operationalNotificationItems.filter(
+      (item) => !readIds.has(`operational:${item.id}`),
+    ).length;
+  const unreadCount =
+    unreadWarningCount +
+    promotions.filter(
+      (event) => !readIds.has(`promotion:${promotionScheduleKey(event)}`),
+    ).length;
+  const hasWarnings = unreadWarningCount > 0;
+  const notificationColor =
+    unreadCount === 0 ? "#888888" : hasWarnings ? "#ffb74d" : "#90bcee";
 
   const handleToggleDebug = async () => {
     if (window.electronAPI) {
@@ -129,13 +158,17 @@ const WindowControls: React.FC<WindowControlsProps> = ({
       },
     });
     window.dispatchEvent(event);
+    markRead(`error:${getDebugLogNotificationId(selectedLog)}`);
     setIsNotificationOpen(false);
   };
 
   const handleOpenOperationalNotification = (
     notification: OperationalNotification,
   ) => {
-    onOperationalNotificationClick?.(notification);
+    if (onOperationalNotificationClick) {
+      onOperationalNotificationClick(notification);
+      markRead(`operational:${notification.id}`);
+    }
     setIsNotificationOpen(false);
   };
 
@@ -192,6 +225,15 @@ const WindowControls: React.FC<WindowControlsProps> = ({
   return (
     <div
       ref={controlsRef}
+      onKeyDown={(event) => {
+        if (event.key === "Escape" && isNotificationOpen) {
+          event.preventDefault();
+          setIsNotificationOpen(false);
+          controlsRef.current
+            ?.querySelector<HTMLButtonElement>("[data-notification-toggle]")
+            ?.focus();
+        }
+      }}
       style={
         {
           display: "flex",
@@ -228,54 +270,63 @@ const WindowControls: React.FC<WindowControlsProps> = ({
       )}
       {notificationCount > 0 && (
         <button
+          data-notification-toggle
+          aria-expanded={isNotificationOpen}
           onClick={() => setIsNotificationOpen((prev) => !prev)}
           style={{
             ...buttonStyle,
-            color: "#ffb74d",
-            textShadow: "0 0 8px rgba(255, 183, 77, 0.55)",
+            color: notificationColor,
+            textShadow:
+              unreadCount > 0 ? `0 0 8px ${notificationColor}80` : "none",
             position: "relative",
           }}
-          title={`알림 ${notificationCount}건 확인`}
+          title={unreadCount > 0 ? `알림 ${unreadCount}건 확인` : "알림 확인"}
           onMouseEnter={(e) => {
             e.currentTarget.style.background = "rgba(255,183,77,0.12)";
             e.currentTarget.style.color = "#fff";
           }}
           onMouseLeave={(e) => {
             e.currentTarget.style.background = "transparent";
-            e.currentTarget.style.color = "#ffb74d";
+            e.currentTarget.style.color = notificationColor;
           }}
         >
           <span
             className="material-symbols-outlined"
             style={{ fontSize: "17px" }}
           >
-            warning
+            {hasWarnings ? "warning" : "notifications"}
           </span>
-          <span
-            style={{
-              position: "absolute",
-              top: "3px",
-              right: "4px",
-              minWidth: "15px",
-              height: "15px",
-              padding: "0 4px",
-              borderRadius: "999px",
-              background: "#ff4444",
-              color: "#fff",
-              fontSize: "10px",
-              fontWeight: 700,
-              lineHeight: "15px",
-              textAlign: "center",
-              boxSizing: "border-box",
-              boxShadow: "0 0 6px rgba(255, 68, 68, 0.9)",
-            }}
-          >
-            {notificationCount > 9 ? "9+" : notificationCount}
-          </span>
+          {unreadCount > 0 && (
+            <span
+              data-notification-badge
+              style={{
+                position: "absolute",
+                top: "3px",
+                right: "4px",
+                minWidth: "15px",
+                height: "15px",
+                padding: "0 4px",
+                borderRadius: "999px",
+                background: hasWarnings ? "#ff4444" : "#487caf",
+                color: "#fff",
+                fontSize: "10px",
+                fontWeight: 700,
+                lineHeight: "15px",
+                textAlign: "center",
+                boxSizing: "border-box",
+                boxShadow: hasWarnings
+                  ? "0 0 6px rgba(255, 68, 68, 0.9)"
+                  : "none",
+              }}
+            >
+              {unreadCount > 9 ? "9+" : unreadCount}
+            </span>
+          )}
         </button>
       )}
       {isNotificationOpen && notificationCount > 0 && (
         <div
+          data-notification-panel
           style={
             {
               position: "absolute",
@@ -284,7 +335,7 @@ const WindowControls: React.FC<WindowControlsProps> = ({
               width: "380px",
               maxHeight: "460px",
               background: "rgba(17, 17, 17, 0.98)",
-              border: "1px solid rgba(255, 183, 77, 0.35)",
+              border: `1px solid ${notificationColor}59`,
               borderRadius: "8px",
               boxShadow: "0 18px 48px rgba(0, 0, 0, 0.65)",
               zIndex: 10002,
@@ -306,15 +357,15 @@ const WindowControls: React.FC<WindowControlsProps> = ({
             }}
           >
             <span>알림</span>
-            <span style={{ color: "#ffb74d", fontSize: "12px" }}>
-              {notificationCount}건
+            <span style={{ color: notificationColor, fontSize: "12px" }}>
+              {unreadCount > 0 ? `안 읽음 ${unreadCount}건` : "모두 읽음"}
             </span>
           </div>
           <div
             className="custom-scrollbar"
             style={{
-              maxHeight: shouldScrollNotifications ? "328px" : "none",
-              overflowY: shouldScrollNotifications ? "auto" : "visible",
+              maxHeight: "min(328px, calc(100vh - 96px))",
+              overflowY: "auto",
               padding: "6px",
             }}
           >
@@ -323,6 +374,11 @@ const WindowControls: React.FC<WindowControlsProps> = ({
                 key={notification.id}
                 type="button"
                 data-notification-id={notification.id}
+                className={
+                  readIds.has(`operational:${notification.id}`)
+                    ? "notification-read"
+                    : undefined
+                }
                 onClick={() => handleOpenOperationalNotification(notification)}
                 style={{
                   width: "100%",
@@ -388,6 +444,12 @@ const WindowControls: React.FC<WindowControlsProps> = ({
             {notificationLogs.map((log) => (
               <div
                 key={getDebugLogNotificationId(log)}
+                data-error-notification
+                className={
+                  readIds.has(`error:${getDebugLogNotificationId(log)}`)
+                    ? "notification-read"
+                    : undefined
+                }
                 style={{
                   width: "100%",
                   display: "grid",
@@ -522,11 +584,34 @@ const WindowControls: React.FC<WindowControlsProps> = ({
                 </button>
               </div>
             ))}
+            {promotions.map((event) => (
+              <PromotionRow
+                key={promotionScheduleKey(event)}
+                event={event}
+                isRead={readIds.has(`promotion:${promotionScheduleKey(event)}`)}
+                onRead={() =>
+                  markRead(`promotion:${promotionScheduleKey(event)}`)
+                }
+                onDismiss={() => {
+                  setIsNotificationOpen(false);
+                  setDismissTarget(event);
+                }}
+              />
+            ))}
           </div>
         </div>
       )}
+      {dismissTarget &&
+        createPortal(
+          <PromotionDismissModal
+            event={dismissTarget}
+            onClose={() => setDismissTarget(null)}
+          />,
+          document.getElementById("app-container") ?? document.body,
+        )}
       <button
         onClick={handleMinimize}
+        aria-label="창 최소화"
         style={buttonStyle}
         onMouseEnter={(e) => {
           e.currentTarget.style.background = "rgba(255,255,255,0.1)";

--- a/src/renderer/components/modals/EventNotificationModal.css
+++ b/src/renderer/components/modals/EventNotificationModal.css
@@ -1,0 +1,183 @@
+.event-notification-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 12000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  box-sizing: border-box;
+  background: rgba(0, 0, 0, 0.8);
+  backdrop-filter: blur(7px);
+}
+.event-notification-modal {
+  width: 500px;
+  max-width: 100%;
+  max-height: 100%;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  background: #141414;
+  border: 1px solid rgba(223, 207, 153, 0.25);
+  border-radius: 12px;
+  box-shadow: 0 24px 70px rgba(0, 0, 0, 0.7);
+}
+.event-notification-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 20px 24px;
+  flex-shrink: 0;
+  border-bottom: 1px solid #2c2a24;
+}
+.event-notification-header-icon {
+  color: var(--theme-accent);
+  font-size: 26px;
+}
+.event-notification-header h2 {
+  margin: 0;
+  color: var(--theme-accent);
+  font-size: 19px;
+}
+.event-notification-close {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  margin-left: auto;
+  flex-shrink: 0;
+  color: #aaa;
+  background: transparent;
+  border: 0;
+  border-radius: 6px;
+  cursor: pointer;
+}
+.event-notification-close:hover {
+  color: #fff;
+  background: #292929;
+}
+.event-notification-body {
+  padding: 24px;
+  min-height: 0;
+  overflow-y: auto;
+}
+.event-notification-group {
+  min-width: 0;
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+.event-notification-group + .event-notification-group {
+  margin-top: 28px;
+}
+.event-notification-group legend {
+  padding: 0;
+  margin-bottom: 12px;
+  color: #eee;
+  font-size: 14px;
+  font-weight: 600;
+}
+.event-notification-hint {
+  margin: -4px 0 12px;
+  color: #aaa;
+  font-size: 12px;
+  line-height: 1.5;
+}
+.event-notification-options {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+}
+.event-notification-option {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 15px 12px;
+  border: 1px solid #363636;
+  border-radius: 7px;
+  background: #1b1b1b;
+  color: #bbb;
+  font-size: 13px;
+  cursor: pointer;
+}
+.event-notification-option:has(input:checked) {
+  border-color: color-mix(in srgb, var(--theme-accent) 45%, #363636);
+  background: color-mix(in srgb, var(--theme-accent) 6%, #1b1b1b);
+  color: #eee;
+}
+.event-notification-option:hover {
+  border-color: #888;
+}
+.event-notification-option input {
+  flex-shrink: 0;
+  width: 17px;
+  height: 17px;
+  margin: 0;
+  accent-color: var(--theme-accent);
+  cursor: pointer;
+}
+.event-notification-option .material-symbols-outlined {
+  color: #c9bd96;
+  font-size: 21px;
+}
+.event-notification-error {
+  margin: 18px 0 0;
+  color: #ffb5a9;
+  font-size: 12px;
+}
+.event-notification-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 16px 24px;
+  flex-shrink: 0;
+  border-top: 1px solid #303030;
+  background: #181818;
+}
+.event-notification-footer button {
+  min-width: 80px;
+  padding: 9px 20px;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  font: inherit;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+}
+.event-notification-confirm {
+  background: var(--theme-accent);
+  color: #171717;
+}
+.event-notification-footer .event-notification-cancel {
+  border-color: #4b4b4b;
+  background: #252525;
+  color: #ddd;
+}
+.event-notification-footer button:hover {
+  filter: brightness(1.15);
+}
+.event-notification-modal button[aria-disabled="true"],
+.event-notification-group:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+.event-notification-modal :is(button, input):focus-visible {
+  outline: 2px solid var(--theme-accent);
+  outline-offset: 3px;
+}
+@media (max-width: 560px) {
+  .event-notification-overlay {
+    padding: 16px;
+  }
+  .event-notification-header,
+  .event-notification-body {
+    padding: 18px;
+  }
+  .event-notification-footer {
+    padding: 14px 18px;
+  }
+  .event-notification-options {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/renderer/components/modals/EventNotificationModal.test.tsx
+++ b/src/renderer/components/modals/EventNotificationModal.test.tsx
@@ -1,0 +1,99 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import EventNotificationModal from "./EventNotificationModal";
+import { normalizeEventPreferences } from "../../../shared/promotions";
+
+describe("event settings confirmation", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  beforeEach(() => {
+    (
+      globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.append(container);
+    root = createRoot(container);
+  });
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+  });
+  const click = async (selector: string) => {
+    const element = container.querySelector<HTMLElement>(selector);
+    expect(element).not.toBeNull();
+    await act(async () => element!.click());
+  };
+  const mount = async (onSave = vi.fn(async () => {}), onClose = vi.fn()) => {
+    await act(async () =>
+      root.render(
+        <EventNotificationModal
+          preferences={normalizeEventPreferences(undefined)}
+          onSave={onSave}
+          onClose={onClose}
+        />,
+      ),
+    );
+    return { onSave, onClose };
+  };
+
+  it("cancels without saving draft type or channel changes", async () => {
+    const { onSave, onClose } = await mount();
+    await click("input");
+    await click(".event-notification-cancel");
+    expect(onSave).not.toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("waits for confirmation to persist and blocks dismissal while saving", async () => {
+    let finish!: () => void;
+    const onSave = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          finish = resolve;
+        }),
+    );
+    const { onClose } = await mount(onSave);
+    await click("input");
+    await click(".event-notification-confirm");
+    expect(onSave).toHaveBeenCalledWith({
+      types: { twitch: false, stash: true },
+      channels: { inApp: true, windows: false },
+    });
+    await click(".event-notification-confirm");
+    await click(".event-notification-cancel");
+    await click(".event-notification-close");
+    await click(".event-notification-overlay");
+    await act(async () =>
+      container
+        .querySelector('[role="dialog"]')!
+        .dispatchEvent(
+          new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+        ),
+    );
+    expect(onClose).not.toHaveBeenCalled();
+    expect(onSave).toHaveBeenCalledOnce();
+    await act(async () => finish());
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("preserves the draft after a save failure and allows retry", async () => {
+    const onSave = vi
+      .fn(async () => {})
+      .mockRejectedValueOnce(new Error("write failed"));
+    const { onClose } = await mount(onSave);
+    await click("input");
+    await click(".event-notification-confirm");
+    expect(onClose).not.toHaveBeenCalled();
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain(
+      "저장하지 못했습니다",
+    );
+    expect(container.querySelector<HTMLInputElement>("input")?.checked).toBe(
+      false,
+    );
+    await click(".event-notification-confirm");
+    expect(onClose).toHaveBeenCalledOnce();
+    expect(onSave.mock.calls[1]).toEqual(onSave.mock.calls[0]);
+  });
+});

--- a/src/renderer/components/modals/EventNotificationModal.tsx
+++ b/src/renderer/components/modals/EventNotificationModal.tsx
@@ -1,0 +1,203 @@
+import { useEffect, useRef, useState } from "react";
+
+import {
+  normalizeEventPreferences,
+  type EventNotificationPreferences,
+} from "../../../shared/promotions";
+
+import "./EventNotificationModal.css";
+
+const GROUPS = [
+  {
+    id: "types",
+    name: "알림 종류",
+    options: [
+      { id: "twitch", name: "트위치 드롭스", icon: "live_tv" },
+      { id: "stash", name: "보관함 할인", icon: "inventory_2" },
+    ],
+  },
+  {
+    id: "channels",
+    name: "알림 방식",
+    options: [
+      { id: "inApp", name: "앱 내 알림", icon: "notifications" },
+      { id: "windows", name: "Windows 알림", icon: "desktop_windows" },
+    ],
+  },
+] as const;
+
+interface EventNotificationModalProps {
+  onClose: () => void;
+  preferences: EventNotificationPreferences;
+  onSave: (preferences: EventNotificationPreferences) => Promise<void>;
+}
+
+export default function EventNotificationModal({
+  onClose,
+  preferences,
+  onSave,
+}: EventNotificationModalProps) {
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const savingRef = useRef(false);
+  const [selection, setSelection] = useState(() =>
+    normalizeEventPreferences(preferences),
+  );
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState("");
+
+  useEffect(() => {
+    const opener = document.activeElement;
+    dialogRef.current?.querySelector<HTMLInputElement>("input")?.focus();
+    return () => {
+      if (opener instanceof HTMLElement && opener.isConnected) opener.focus();
+    };
+  }, []);
+
+  const close = () => {
+    if (!savingRef.current) onClose();
+  };
+  const save = async () => {
+    if (savingRef.current) return;
+    savingRef.current = true;
+    setSaving(true);
+    setSaveError("");
+    try {
+      await onSave(selection);
+      onClose();
+    } catch {
+      setSaveError("설정을 저장하지 못했습니다. 다시 시도해 주세요.");
+    } finally {
+      savingRef.current = false;
+      setSaving(false);
+    }
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      event.stopPropagation();
+      close();
+      return;
+    }
+    if (event.key !== "Tab") return;
+    const controls = dialogRef.current?.querySelectorAll<HTMLElement>(
+      "button:not(:disabled), input:not(:disabled)",
+    );
+    if (!controls?.length) return;
+    const first = controls[0];
+    const last = controls[controls.length - 1];
+    if (event.shiftKey && document.activeElement === first) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  };
+
+  return (
+    <div className="event-notification-overlay" onClick={close}>
+      <div
+        ref={dialogRef}
+        className="event-notification-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="event-notification-title"
+        onClick={(event) => event.stopPropagation()}
+        onKeyDown={handleKeyDown}
+      >
+        <header className="event-notification-header">
+          <span
+            className="material-symbols-outlined event-notification-header-icon"
+            aria-hidden="true"
+          >
+            notifications_active
+          </span>
+          <h2 id="event-notification-title">이벤트 알림 관리</h2>
+          <button
+            type="button"
+            className="event-notification-close"
+            aria-label="이벤트 알림 관리 닫기"
+            aria-disabled={saving}
+            onClick={close}
+          >
+            <span className="material-symbols-outlined" aria-hidden="true">
+              close
+            </span>
+          </button>
+        </header>
+        <div className="event-notification-body custom-scrollbar">
+          {GROUPS.map((group) => (
+            <fieldset
+              key={group.id}
+              className="event-notification-group"
+              disabled={saving}
+            >
+              <legend>{group.name}</legend>
+              {group.id === "channels" && (
+                <p className="event-notification-hint">
+                  선택한 모든 알림 종류에 공통으로 적용됩니다.
+                </p>
+              )}
+              <div className="event-notification-options">
+                {group.options.map((option) => (
+                  <label key={option.id} className="event-notification-option">
+                    <input
+                      type="checkbox"
+                      checked={Boolean(
+                        (selection[group.id] as Record<string, boolean>)[
+                          option.id
+                        ],
+                      )}
+                      onChange={(event) => {
+                        const checked = event.target.checked;
+                        setSaveError("");
+                        setSelection((previous) => ({
+                          ...previous,
+                          [group.id]: {
+                            ...previous[group.id],
+                            [option.id]: checked,
+                          },
+                        }));
+                      }}
+                    />
+                    <span
+                      className="material-symbols-outlined"
+                      aria-hidden="true"
+                    >
+                      {option.icon}
+                    </span>
+                    <span>{option.name}</span>
+                  </label>
+                ))}
+              </div>
+            </fieldset>
+          ))}
+          {saveError && (
+            <p className="event-notification-error" role="alert">
+              {saveError}
+            </p>
+          )}
+        </div>
+        <footer className="event-notification-footer">
+          <button
+            type="button"
+            className="event-notification-confirm"
+            aria-disabled={saving}
+            onClick={save}
+          >
+            {saving ? "저장 중…" : "확인"}
+          </button>
+          <button
+            type="button"
+            className="event-notification-cancel"
+            aria-disabled={saving}
+            onClick={close}
+          >
+            취소
+          </button>
+        </footer>
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/components/modals/PromotionDismissModal.css
+++ b/src/renderer/components/modals/PromotionDismissModal.css
@@ -1,0 +1,32 @@
+.promotion-dismiss-modal {
+  width: 420px;
+}
+.promotion-dismiss-event {
+  margin: 0;
+  color: #eee;
+  font-size: 15px;
+  font-weight: 600;
+}
+.promotion-dismiss-period {
+  margin: 8px 0 24px;
+  color: #aaa;
+  font-size: 13px;
+}
+.promotion-dismiss-remember {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  color: #ccc;
+  font-size: 13px;
+  cursor: pointer;
+}
+.promotion-dismiss-remember input {
+  width: 16px;
+  height: 16px;
+  margin: 0;
+  accent-color: var(--theme-accent);
+}
+.promotion-dismiss-remember:has(input:disabled) {
+  opacity: 0.6;
+  cursor: default;
+}

--- a/src/renderer/components/modals/PromotionDismissModal.tsx
+++ b/src/renderer/components/modals/PromotionDismissModal.tsx
@@ -1,0 +1,150 @@
+import { useEffect, useRef, useState } from "react";
+
+import {
+  formatPromotionPeriod,
+  promotionScheduleKey,
+  promotionTitle,
+  type PromotionEvent,
+} from "../../../shared/promotions";
+
+import "./EventNotificationModal.css";
+import "./PromotionDismissModal.css";
+
+export default function PromotionDismissModal({
+  event,
+  onClose,
+}: {
+  event: PromotionEvent;
+  onClose: () => void;
+}) {
+  const dialog = useRef<HTMLDivElement>(null);
+  const pending = useRef(false);
+  const [hideSchedule, setHideSchedule] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState("");
+  useEffect(() => {
+    dialog.current
+      ?.querySelector<HTMLButtonElement>(".event-notification-cancel")
+      ?.focus();
+    return () => {
+      document
+        .querySelector<HTMLButtonElement>(
+          '[data-notification-toggle], [aria-label="창 최소화"]',
+        )
+        ?.focus();
+    };
+  }, []);
+  const close = () => {
+    if (!pending.current) onClose();
+  };
+  const dismiss = async () => {
+    if (pending.current) return;
+    pending.current = true;
+    setSaving(true);
+    setError("");
+    try {
+      const result = await window.electronAPI.dismissPromotion({
+        key: promotionScheduleKey(event),
+        mode: hideSchedule ? "schedule" : "session",
+      });
+      if (!result.ok) throw new Error(result.reason);
+      onClose();
+    } catch {
+      setError("알림을 숨기지 못했습니다. 다시 시도해 주세요.");
+    } finally {
+      pending.current = false;
+      setSaving(false);
+    }
+  };
+  return (
+    <div
+      className="event-notification-overlay promotion-dismiss-overlay"
+      onClick={close}
+    >
+      <div
+        ref={dialog}
+        className="event-notification-modal promotion-dismiss-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="promotion-dismiss-title"
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={(e) => {
+          if (e.key === "Escape") {
+            e.preventDefault();
+            e.stopPropagation();
+            close();
+          } else if (e.key === "Tab") {
+            const items = dialog.current?.querySelectorAll<HTMLElement>(
+              "button, input:not(:disabled)",
+            );
+            if (!items?.length) return;
+            const first = items[0];
+            const last = items[items.length - 1];
+            if (e.shiftKey && document.activeElement === first) {
+              e.preventDefault();
+              last.focus();
+            } else if (!e.shiftKey && document.activeElement === last) {
+              e.preventDefault();
+              first.focus();
+            }
+          }
+        }}
+      >
+        <header className="event-notification-header">
+          <h2 id="promotion-dismiss-title">알림 삭제</h2>
+          <button
+            type="button"
+            className="event-notification-close"
+            aria-label="알림 삭제 닫기"
+            aria-disabled={saving}
+            onClick={close}
+          >
+            <span className="material-symbols-outlined" aria-hidden="true">
+              close
+            </span>
+          </button>
+        </header>
+        <div className="event-notification-body">
+          <p className="promotion-dismiss-event">
+            {promotionTitle(event)} 진행 중
+          </p>
+          <p className="promotion-dismiss-period">
+            {formatPromotionPeriod(event)}
+          </p>
+          <label className="promotion-dismiss-remember">
+            <input
+              type="checkbox"
+              checked={hideSchedule}
+              disabled={saving}
+              onChange={(e) => setHideSchedule(e.target.checked)}
+            />
+            <span>이번 일정 내 표시하지 않음</span>
+          </label>
+          {error && (
+            <p className="event-notification-error" role="alert">
+              {error}
+            </p>
+          )}
+        </div>
+        <footer className="event-notification-footer">
+          <button
+            type="button"
+            className="event-notification-confirm"
+            aria-disabled={saving}
+            onClick={() => void dismiss()}
+          >
+            {saving ? "삭제 중…" : "삭제"}
+          </button>
+          <button
+            type="button"
+            className="event-notification-cancel"
+            aria-disabled={saving}
+            onClick={close}
+          >
+            취소
+          </button>
+        </footer>
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/hooks/usePromotions.ts
+++ b/src/renderer/hooks/usePromotions.ts
@@ -1,0 +1,79 @@
+import { useEffect, useState } from "react";
+
+import {
+  isPromotionActive,
+  type PromotionSnapshot,
+} from "../../shared/promotions";
+import { currentStashEstimate } from "../../shared/stash-sales";
+
+function usePromotionSnapshot() {
+  const [snapshot, setSnapshot] = useState<PromotionSnapshot>({
+    revision: -1,
+    events: [],
+    activeEvents: [],
+    upcomingEvents: [],
+  });
+  const [now, setNow] = useState(Date.now);
+  useEffect(() => {
+    let active = true;
+    const accept = (next: PromotionSnapshot) => {
+      if (active) {
+        setNow(Date.now());
+        setSnapshot((previous) =>
+          next.revision >= previous.revision ? next : previous,
+        );
+      }
+    };
+    const unsubscribe = window.electronAPI?.onPromotionsUpdated?.(accept);
+    window.electronAPI
+      ?.getPromotions?.()
+      .then(accept)
+      .catch(() => {});
+    return () => {
+      active = false;
+      unsubscribe?.();
+    };
+  }, []);
+  const hasSchedules = !!(
+    snapshot.events.length ||
+    snapshot.activeEvents.length ||
+    snapshot.upcomingEvents.length ||
+    snapshot.stashEstimate
+  );
+  useEffect(() => {
+    if (!hasSchedules) return;
+    const update = () => setNow(Date.now());
+    const timer = setInterval(update, 1000);
+    window.addEventListener("focus", update);
+    return () => {
+      clearInterval(timer);
+      window.removeEventListener("focus", update);
+    };
+  }, [hasSchedules]);
+  return { snapshot, now };
+}
+
+export function usePromotions(
+  scope: "notifications" | "schedule" = "notifications",
+) {
+  const { snapshot, now } = usePromotionSnapshot();
+  const events =
+    scope === "schedule"
+      ? [...snapshot.activeEvents, ...snapshot.upcomingEvents]
+      : snapshot.events;
+  return events.filter((event) =>
+    scope === "schedule"
+      ? now < Date.parse(event.endsAt)
+      : isPromotionActive(event, now),
+  );
+}
+
+export function usePromotionSchedule() {
+  const { snapshot, now } = usePromotionSnapshot();
+  return {
+    events: [...snapshot.activeEvents, ...snapshot.upcomingEvents].filter(
+      (event) => now < Date.parse(event.endsAt),
+    ),
+    stashEstimate: currentStashEstimate(snapshot.stashEstimate, now),
+  };
+}

--- a/src/renderer/hooks/useReadNotifications.ts
+++ b/src/renderer/hooks/useReadNotifications.ts
@@ -1,0 +1,40 @@
+import { useEffect, useState } from "react";
+
+const STORAGE_KEY = "poe-launcher:read-notifications";
+const MAX_READ_IDS = 500;
+
+// Browser-window session only: reloads retain read state; app restarts reset it.
+export function useReadNotifications() {
+  const [readIds, setReadIds] = useState<Set<string>>(() => {
+    try {
+      const stored: unknown = JSON.parse(
+        window.sessionStorage.getItem(STORAGE_KEY) ?? "[]",
+      );
+      return new Set(
+        Array.isArray(stored)
+          ? stored
+              .filter((id): id is string => typeof id === "string")
+              .slice(-MAX_READ_IDS)
+          : [],
+      );
+    } catch {
+      return new Set();
+    }
+  });
+
+  useEffect(() => {
+    try {
+      window.sessionStorage.setItem(STORAGE_KEY, JSON.stringify([...readIds]));
+    } catch {
+      // Reading an alert still works when browser storage is unavailable.
+    }
+  }, [readIds]);
+
+  const markRead = (id: string) => {
+    setReadIds((prev) =>
+      prev.has(id) ? prev : new Set([...prev, id].slice(-MAX_READ_IDS)),
+    );
+  };
+
+  return { readIds, markRead };
+}

--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -1,6 +1,14 @@
+import { normalizeEventPreferences } from "./promotions";
 import { AppConfig, ConfigDefinition } from "./types";
 
 export const CONFIG_METADATA: Record<string, ConfigDefinition> = {
+  EVENT_NOTIFICATIONS: {
+    key: "eventNotifications",
+    name: "Event Notifications",
+    category: "General",
+    description:
+      "이벤트 알림 종류와 전체 종류에 공통 적용할 알림 방식을 설정합니다.",
+  },
   LAUNCHER_VERSION: {
     key: "launcherVersion",
     name: "Launcher Version",
@@ -297,6 +305,7 @@ export const DEFAULT_CONFIG: AppConfig = {
   quitOnGameStart: false,
   showOnboarding: true,
   newsOpenMode: "inline",
+  eventNotifications: normalizeEventPreferences(undefined),
   processWatchMode: "resource-saving",
   aggressivePatchMode: false,
   skipDaumGameStarterUac: false,

--- a/src/shared/promotions.test.ts
+++ b/src/shared/promotions.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  formatPromotionPeriod,
+  isPromotionActive,
+  normalizeEventPreferences,
+  parsePromotionFeed,
+  promotionScheduleKey,
+} from "./promotions";
+import { stashSection } from "./test-fixtures/stash-sales";
+import stashContractSamples from "./test-fixtures/stash-sales-contract.json";
+
+export const samplePromotion = {
+  id: "ggg-4000901-twitch-1",
+  kind: "twitch-drops" as const,
+  game: "poe1" as const,
+  startsAt: "2026-09-03T21:00:00.000Z",
+  endsAt: "2026-09-04T21:00:00.000Z",
+  sourceUrl: "https://www.pathofexile.com/forum/view-thread/4000901",
+  precision: "exact" as const,
+};
+
+describe("promotion contract", () => {
+  it("requires all four shop observations and distinct manual sources", () => {
+    const sample = stashContractSamples.manual;
+    expect(() =>
+      parsePromotionFeed({
+        ...sample,
+        stashSales: {
+          ...sample.stashSales,
+          observations: sample.stashSales.observations.slice(1),
+        },
+      }),
+    ).toThrow();
+    expect(() =>
+      parsePromotionFeed({
+        ...sample,
+        stashSales: {
+          ...sample.stashSales,
+          anchor: {
+            ...sample.stashSales.anchor,
+            sourceUrls: [
+              sample.stashSales.anchor.sourceUrls[0],
+              sample.stashSales.anchor.sourceUrls[0],
+            ],
+          },
+          nextEstimate: null,
+        },
+      }),
+    ).toThrow();
+  });
+  it("round trips the collector's manual, confirmed, unavailable and expired samples", () => {
+    for (const sample of Object.values(stashContractSamples))
+      expect(parsePromotionFeed(sample)).toEqual(sample);
+  });
+  it("rejects mismatched shop sources, duplicate targets, malformed dates and ungrounded predictions", () => {
+    const parse = (stashSales: unknown) =>
+      parsePromotionFeed({
+        schemaVersion: 1,
+        generatedAt: "2026-09-04T00:00:00Z",
+        events: [],
+        stashSales,
+      });
+    for (const section of [
+      {
+        ...stashSection,
+        observations: [
+          {
+            ...stashSection.observations[0],
+            sourceUrl:
+              "https://poe2.kakaogames.com.evil.test/api/shop-microtransactions?game=poe2",
+          },
+          ...stashSection.observations.slice(1),
+        ],
+      },
+      {
+        ...stashSection,
+        observations: [
+          { ...stashSection.observations[0], game: "poe1" },
+          ...stashSection.observations.slice(1),
+        ],
+      },
+      {
+        ...stashSection,
+        observations: [
+          stashSection.observations[0],
+          stashSection.observations[0],
+          ...stashSection.observations.slice(2),
+        ],
+      },
+      {
+        ...stashSection,
+        anchor: { ...stashSection.anchor, startDate: "2026-02-30" },
+      },
+      {
+        ...stashSection,
+        nextEstimate: { ...stashSection.nextEstimate, startDate: "2026-10-02" },
+      },
+      {
+        ...stashSection,
+        nextEstimate: { ...stashSection.nextEstimate, basisOrigin: "api" },
+      },
+      { ...stashSection, anchor: null },
+    ])
+      expect(() => parse(section)).toThrow();
+  });
+  it("preserves the optional shop section without promoting estimates into events", () => {
+    const parsed = parsePromotionFeed({
+      schemaVersion: 1,
+      generatedAt: "2026-09-04T00:00:00Z",
+      events: [samplePromotion],
+      stashSales: stashSection,
+    });
+    expect(parsed.stashSales).toEqual(stashSection);
+    expect(parsed.events).toEqual([samplePromotion]);
+  });
+  it("identifies a schedule by kind, game, and exact instants rather than source ID", () => {
+    const key = promotionScheduleKey(samplePromotion);
+    expect(
+      promotionScheduleKey({
+        ...samplePromotion,
+        id: "another-source",
+        startsAt: "2026-09-03T21:00:00Z",
+      }),
+    ).toBe(key);
+    expect(promotionScheduleKey({ ...samplePromotion, game: "poe2" })).not.toBe(
+      key,
+    );
+    expect(
+      promotionScheduleKey({
+        ...samplePromotion,
+        endsAt: "2026-09-05T21:00:00Z",
+      }),
+    ).not.toBe(key);
+  });
+  it("uses exact start-inclusive/end-exclusive instants", () => {
+    const start = Date.parse(samplePromotion.startsAt);
+    const end = Date.parse(samplePromotion.endsAt);
+    expect(isPromotionActive(samplePromotion, start - 1)).toBe(false);
+    expect(isPromotionActive(samplePromotion, start)).toBe(true);
+    expect(isPromotionActive(samplePromotion, end - 1)).toBe(true);
+    expect(isPromotionActive(samplePromotion, end)).toBe(false);
+  });
+
+  it("formats the same instants in the PC timezone without shifting the end", () => {
+    expect(formatPromotionPeriod(samplePromotion, "Asia/Seoul")).toBe(
+      "9/4 ~ 9/5",
+    );
+    expect(formatPromotionPeriod(samplePromotion, "America/Los_Angeles")).toBe(
+      "9/3 ~ 9/4",
+    );
+  });
+
+  it("separates event types from shared channels and fills partial preferences", () => {
+    expect(
+      normalizeEventPreferences({
+        types: { twitch: false },
+        channels: { inApp: "true", windows: true },
+      }),
+    ).toEqual({
+      types: { twitch: false, stash: true },
+      channels: { inApp: true, windows: true },
+    });
+    expect(normalizeEventPreferences(null)).toEqual({
+      types: { twitch: true, stash: true },
+      channels: { inApp: true, windows: false },
+    });
+  });
+
+  it("rejects an entire invalid feed rather than silently deleting valid events", () => {
+    const feed = {
+      schemaVersion: 1,
+      generatedAt: "2026-09-04T00:00:00.000Z",
+      events: [samplePromotion],
+    };
+    expect(parsePromotionFeed(feed).events).toHaveLength(1);
+    for (const bad of [
+      { ...samplePromotion, game: "unknown" },
+      { ...samplePromotion, endsAt: samplePromotion.startsAt },
+      { ...samplePromotion, startsAt: "2026-02-30T00:00:00.000Z" },
+      {
+        ...samplePromotion,
+        sourceUrl: "https://www.pathofexile.com.evil.test/forum/view-thread/1",
+      },
+      {
+        ...samplePromotion,
+        sourceUrl: "http://www.pathofexile.com/forum/view-thread/1",
+      },
+    ])
+      expect(() =>
+        parsePromotionFeed({ ...feed, events: [samplePromotion, bad] }),
+      ).toThrow();
+    expect(() =>
+      parsePromotionFeed({
+        ...feed,
+        events: [samplePromotion, samplePromotion],
+      }),
+    ).toThrow();
+    expect(() => parsePromotionFeed({ ...feed, schemaVersion: 2 })).toThrow();
+  });
+});

--- a/src/shared/promotions.ts
+++ b/src/shared/promotions.ts
@@ -1,0 +1,287 @@
+import {
+  parseStashSales,
+  type StashSales,
+  type StashEstimate,
+  type StashTarget,
+} from "./stash-sales";
+
+export interface EventNotificationPreferences {
+  types: { twitch: boolean; stash: boolean };
+  channels: { inApp: boolean; windows: boolean };
+}
+
+export interface PromotionEvent {
+  id: string;
+  kind: "twitch-drops" | "stash-sale";
+  game: "poe1" | "poe2" | "both";
+  startsAt: string;
+  endsAt: string;
+  sourceUrl: string;
+  precision: "exact" | "derived-start" | "manual";
+  /** Present only on normalized, API-confirmed shop events. */
+  targets?: StashTarget[];
+}
+
+export interface PromotionFeed {
+  schemaVersion: 1;
+  generatedAt: string;
+  events: PromotionEvent[];
+  stashSales?: StashSales;
+}
+
+export interface PromotionSnapshot {
+  revision: number;
+  /** Active schedules regardless of notification settings or dismissal. */
+  activeEvents: PromotionEvent[];
+  upcomingEvents: PromotionEvent[];
+  events: PromotionEvent[];
+  stashEstimate?: StashEstimate | null;
+}
+
+export interface PromotionDismissRequest {
+  key: string;
+  mode: "session" | "schedule";
+}
+
+export type PromotionDismissResult =
+  | { ok: true }
+  | {
+      ok: false;
+      reason: "invalid-request" | "service-unavailable" | "save-failed";
+    };
+
+export function promotionScheduleKey(event: PromotionEvent): string {
+  if (event.kind === "stash-sale" && event.targets)
+    return `stash-sale:api:${Date.parse(event.startsAt)}:${Date.parse(event.endsAt)}`;
+  return `${event.kind}:${event.game}:${Date.parse(event.startsAt)}:${Date.parse(event.endsAt)}`;
+}
+
+export const TWITCH_LINKS = {
+  POE1: "https://www.twitch.tv/directory/category/path-of-exile",
+  POE2: "https://www.twitch.tv/directory/category/path-of-exile-2",
+} as const;
+
+export const STASH_LINKS = [
+  {
+    service: "GGG",
+    games: [
+      {
+        game: "POE",
+        url: "https://www.pathofexile.com/shop/category/stash-tabs",
+      },
+      { game: "POE2", url: "https://pathofexile2.com/shop/stash-tabs" },
+    ],
+  },
+  {
+    service: "KakaoGames",
+    games: [
+      {
+        game: "POE",
+        url: "https://poe.kakaogames.com/shop/category/stash-tabs",
+      },
+      { game: "POE2", url: "https://poe2.kakaogames.com/shop/stash-tabs" },
+    ],
+  },
+] as const;
+
+function record(value: unknown): Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+export function normalizeEventPreferences(
+  value: unknown,
+): EventNotificationPreferences {
+  const input = record(value);
+  const types = record(input.types);
+  const channels = record(input.channels);
+  return {
+    types: {
+      twitch: typeof types.twitch === "boolean" ? types.twitch : true,
+      stash: typeof types.stash === "boolean" ? types.stash : true,
+    },
+    channels: {
+      inApp: typeof channels.inApp === "boolean" ? channels.inApp : true,
+      windows: typeof channels.windows === "boolean" ? channels.windows : false,
+    },
+  };
+}
+
+export function isUtcInstant(value: unknown): value is string {
+  if (
+    typeof value !== "string" ||
+    !/^\d{4}-\d\d-\d\dT\d\d:\d\d:\d\d(?:\.\d{3})?Z$/.test(value)
+  )
+    return false;
+  const time = Date.parse(value);
+  return (
+    Number.isFinite(time) &&
+    new Date(time).toISOString() === value.replace(/(?<=:\d\d)Z$/, ".000Z")
+  );
+}
+
+export function parsePromotionFeed(value: unknown): PromotionFeed {
+  const feed = record(value);
+  if (
+    feed.schemaVersion !== 1 ||
+    !isUtcInstant(feed.generatedAt) ||
+    !Array.isArray(feed.events) ||
+    feed.events.length > 200
+  ) {
+    throw new Error("Invalid promotion feed");
+  }
+  const ids = new Set<string>();
+  const events = feed.events.map((entry): PromotionEvent => {
+    const item = record(entry);
+    if (
+      typeof item.id !== "string" ||
+      !/^[a-z0-9:-]{1,160}$/.test(item.id) ||
+      ids.has(item.id) ||
+      !["twitch-drops", "stash-sale"].includes(item.kind as string) ||
+      !["poe1", "poe2", "both"].includes(item.game as string) ||
+      (item.kind === "twitch-drops" && item.game === "both") ||
+      !["exact", "derived-start", "manual"].includes(
+        item.precision as string,
+      ) ||
+      !isUtcInstant(item.startsAt) ||
+      !isUtcInstant(item.endsAt) ||
+      Date.parse(item.endsAt) <= Date.parse(item.startsAt) ||
+      Date.parse(item.endsAt) - Date.parse(item.startsAt) > 90 * 86400_000 ||
+      typeof item.sourceUrl !== "string" ||
+      !/^https:\/\/www\.pathofexile\.com\/forum\/view-thread\/\d+(?:\/filter-account-type\/staff)?$/.test(
+        item.sourceUrl,
+      )
+    ) {
+      throw new Error("Invalid promotion event");
+    }
+    ids.add(item.id);
+    return {
+      id: item.id,
+      kind: item.kind as PromotionEvent["kind"],
+      game: item.game as PromotionEvent["game"],
+      startsAt: item.startsAt,
+      endsAt: item.endsAt,
+      sourceUrl: item.sourceUrl,
+      precision: item.precision as PromotionEvent["precision"],
+    };
+  });
+  return {
+    schemaVersion: 1,
+    generatedAt: feed.generatedAt,
+    events,
+    ...(feed.stashSales === undefined
+      ? {}
+      : { stashSales: parseStashSales(feed.stashSales, isUtcInstant) }),
+  };
+}
+
+/** All confirmed events, shared by display, dismissal, and native delivery. */
+export function getPromotionEvents(
+  feed: PromotionFeed | null,
+): PromotionEvent[] {
+  if (!feed) return [];
+  const groups = new Map<string, PromotionEvent>();
+  const observations = [...(feed.stashSales?.observations ?? [])].sort((a, b) =>
+    `${a.service}:${a.game}`.localeCompare(`${b.service}:${b.game}`),
+  );
+  for (const observation of observations) {
+    const period = observation.confirmedPeriod;
+    if (!period) continue;
+    const key = `${Date.parse(period.startsAt)}:${Date.parse(period.endsAt)}`;
+    const target = { service: observation.service, game: observation.game };
+    const event = groups.get(key);
+    if (event) {
+      event.targets!.push(target);
+      if (event.game !== target.game) event.game = "both";
+    } else {
+      groups.set(key, {
+        id: `shop-stash:${key}`,
+        kind: "stash-sale",
+        game: target.game,
+        startsAt: period.startsAt,
+        endsAt: period.endsAt,
+        sourceUrl: observation.sourceUrl,
+        precision: "exact",
+        targets: [target],
+      });
+    }
+  }
+  return [...feed.events, ...groups.values()];
+}
+
+export function promotionMatchesTarget(
+  event: PromotionEvent,
+  service: "GGG" | "KakaoGames",
+  game: "POE" | "POE2",
+): boolean {
+  return (
+    !event.targets ||
+    event.targets.some(
+      (target) =>
+        target.service === (service === "GGG" ? "ggg" : "kakao") &&
+        target.game === (game === "POE" ? "poe1" : "poe2"),
+    )
+  );
+}
+
+export function isPromotionActive(
+  event: PromotionEvent,
+  now = Date.now(),
+): boolean {
+  return Date.parse(event.startsAt) <= now && now < Date.parse(event.endsAt);
+}
+
+export function formatPromotionPeriod(
+  event: Pick<PromotionEvent, "startsAt" | "endsAt">,
+  timeZone?: string,
+): string {
+  const formatter = new Intl.DateTimeFormat("en-US", {
+    month: "numeric",
+    day: "numeric",
+    timeZone,
+  });
+  const crossesYear = new Intl.DateTimeFormat("en-US", {
+    year: "numeric",
+    timeZone,
+  });
+  if (
+    crossesYear.format(new Date(event.startsAt)) !==
+    crossesYear.format(new Date(event.endsAt))
+  ) {
+    const full = new Intl.DateTimeFormat("en-CA", {
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      timeZone,
+    });
+    return `${full.format(new Date(event.startsAt))} ~ ${full.format(new Date(event.endsAt))}`;
+  }
+  return `${formatter.format(new Date(event.startsAt))} ~ ${formatter.format(new Date(event.endsAt))}`;
+}
+
+export function promotionTitle(event: PromotionEvent): string {
+  return event.kind === "stash-sale"
+    ? "보관함 할인"
+    : `${event.game === "poe1" ? "PoE 1" : "PoE 2"} 트위치 드롭스`;
+}
+
+export function promotionActions(
+  event: PromotionEvent,
+): { label: string; url: string }[] {
+  return event.kind === "twitch-drops"
+    ? [
+        {
+          label: `${event.game === "poe1" ? "PoE 1" : "PoE 2"} Twitch`,
+          url: TWITCH_LINKS[event.game === "poe1" ? "POE1" : "POE2"],
+        },
+      ]
+    : STASH_LINKS.flatMap(({ service, games }) =>
+        games
+          .filter(({ game }) => promotionMatchesTarget(event, service, game))
+          .map(({ game, url }) => ({
+            label: `${service === "KakaoGames" ? "Kakao" : service} ${game}`,
+            url,
+          })),
+      );
+}

--- a/src/shared/stash-sales.ts
+++ b/src/shared/stash-sales.ts
@@ -1,0 +1,249 @@
+export interface StashTarget {
+  service: "ggg" | "kakao";
+  game: "poe1" | "poe2";
+}
+export interface StashPeriod {
+  startsAt: string;
+  endsAt: string;
+  observedAt: string;
+  productIds: string[];
+}
+export interface StashObservation extends StashTarget {
+  sourceUrl: string;
+  checkedAt: string;
+  status: "ok" | "unavailable" | "period-unavailable";
+  confirmedPeriod: StashPeriod | null;
+}
+export interface StashApiAnchor extends StashTarget {
+  origin: "api";
+  sourceUrl: string;
+  startsAt: string;
+  endsAt: string;
+  observedAt: string;
+}
+export interface StashManualAnchor {
+  origin: "manual-announcement";
+  startDate: string;
+  endDate: string;
+  timeZone: "Asia/Seoul";
+  sourceUrls: string[];
+  scope: StashTarget[];
+}
+/** Estimates cannot enter the notification/event pipeline. */
+export interface StashEstimate {
+  startDate: string;
+  endDate: string;
+  timeZone: "Asia/Seoul";
+  intervalDays: 21;
+  basisOrigin: "api" | "manual-announcement";
+  basisSourceUrl: string;
+}
+export interface StashSales {
+  version: 1;
+  observations: StashObservation[];
+  anchor: StashApiAnchor | StashManualAnchor | null;
+  nextEstimate: StashEstimate | null;
+}
+export const STASH_API_URLS = {
+  "ggg:poe1":
+    "https://www.pathofexile.com/api/shop-microtransaction-categories/stash-tabs",
+  "ggg:poe2": "https://pathofexile2.com/api/shop-microtransactions?game=poe2",
+  "kakao:poe1":
+    "https://poe.kakaogames.com/api/shop-microtransaction-categories/stash-tabs",
+  "kakao:poe2":
+    "https://poe2.kakaogames.com/api/shop-microtransactions?game=poe2",
+} as const;
+const DAY = 86400_000;
+const record = (v: unknown): Record<string, unknown> =>
+  v !== null && typeof v === "object" && !Array.isArray(v)
+    ? (v as Record<string, unknown>)
+    : {};
+function requireValue(condition: unknown): asserts condition {
+  if (!condition) throw new Error("Invalid stash sale feed");
+}
+function target(value: unknown): StashTarget {
+  const item = record(value);
+  requireValue(item.service === "ggg" || item.service === "kakao");
+  requireValue(item.game === "poe1" || item.game === "poe2");
+  return { service: item.service, game: item.game };
+}
+function date(value: unknown): string {
+  requireValue(typeof value === "string" && /^\d{4}-\d\d-\d\d$/.test(value));
+  const instant = Date.parse(`${value}T00:00:00Z`);
+  requireValue(
+    Number.isFinite(instant) &&
+      new Date(instant).toISOString().slice(0, 10) === value,
+  );
+  return value;
+}
+const kstDate = (instant: string) =>
+  new Date(Date.parse(instant) + 9 * 3600_000).toISOString().slice(0, 10);
+const plus21 = (value: string) =>
+  new Date(Date.parse(`${value}T00:00:00Z`) + 21 * DAY)
+    .toISOString()
+    .slice(0, 10);
+const announcement = (value: unknown): value is string =>
+  typeof value === "string" &&
+  /^https:\/\/(?:www\.pathofexile\.com|poe(?:2)?\.kakaogames\.com)\/forum\/view-thread\/\d+$/.test(
+    value,
+  );
+
+export function parseStashSales(
+  value: unknown,
+  isUtc: (value: unknown) => value is string,
+): StashSales {
+  const input = record(value);
+  requireValue(
+    input.version === 1 &&
+      Array.isArray(input.observations) &&
+      input.observations.length === 4,
+  );
+  function period(value: unknown) {
+    const item = record(value);
+    requireValue(
+      isUtc(item.startsAt) && isUtc(item.endsAt) && isUtc(item.observedAt),
+    );
+    const duration = Date.parse(item.endsAt) - Date.parse(item.startsAt);
+    requireValue(duration > 0 && duration <= 90 * DAY);
+    return {
+      startsAt: item.startsAt,
+      endsAt: item.endsAt,
+      observedAt: item.observedAt,
+    };
+  }
+  function api(value: unknown) {
+    const item = record(value);
+    const scope = target(value);
+    requireValue(
+      item.sourceUrl === STASH_API_URLS[`${scope.service}:${scope.game}`],
+    );
+    return { ...scope, sourceUrl: item.sourceUrl as string };
+  }
+  const seen = new Set<string>();
+  const observations = input.observations.map((value): StashObservation => {
+    const item = record(value);
+    const source = api(value);
+    const key = `${source.service}:${source.game}`;
+    requireValue(!seen.has(key));
+    seen.add(key);
+    requireValue(isUtc(item.checkedAt));
+    requireValue(
+      item.status === "ok" ||
+        item.status === "unavailable" ||
+        item.status === "period-unavailable",
+    );
+    let confirmedPeriod: StashPeriod | null = null;
+    if (item.confirmedPeriod !== null) {
+      requireValue(item.status !== "period-unavailable");
+      const timing = period(item.confirmedPeriod);
+      const ids = record(item.confirmedPeriod).productIds;
+      requireValue(Array.isArray(ids) && ids.length > 0 && ids.length <= 100);
+      requireValue(
+        ids.every(
+          (id) => typeof id === "string" && /^[A-Za-z0-9_-]{1,160}$/.test(id),
+        ) && new Set(ids).size === ids.length,
+      );
+      requireValue(Date.parse(timing.observedAt) <= Date.parse(item.checkedAt));
+      confirmedPeriod = { ...timing, productIds: [...ids] as string[] };
+    }
+    return {
+      ...source,
+      checkedAt: item.checkedAt,
+      status: item.status,
+      confirmedPeriod,
+    };
+  });
+  let anchor: StashSales["anchor"] = null;
+  if (input.anchor !== null) {
+    const item = record(input.anchor);
+    if (item.origin === "api") {
+      anchor = { origin: "api", ...api(item), ...period(item) };
+    } else {
+      requireValue(
+        item.origin === "manual-announcement" && item.timeZone === "Asia/Seoul",
+      );
+      const startDate = date(item.startDate),
+        endDate = date(item.endDate);
+      requireValue(
+        endDate >= startDate &&
+          Date.parse(endDate) - Date.parse(startDate) <= 90 * DAY,
+      );
+      requireValue(
+        Array.isArray(item.sourceUrls) &&
+          item.sourceUrls.length > 0 &&
+          item.sourceUrls.length <= 4 &&
+          new Set(item.sourceUrls).size === item.sourceUrls.length &&
+          item.sourceUrls.every(announcement),
+      );
+      requireValue(
+        Array.isArray(item.scope) &&
+          item.scope.length > 0 &&
+          item.scope.length <= 4,
+      );
+      const scope = item.scope.map(target);
+      requireValue(
+        new Set(scope.map((item) => `${item.service}:${item.game}`)).size ===
+          scope.length,
+      );
+      anchor = {
+        origin: "manual-announcement",
+        startDate,
+        endDate,
+        timeZone: "Asia/Seoul",
+        sourceUrls: [...item.sourceUrls] as string[],
+        scope,
+      };
+    }
+  }
+  let nextEstimate: StashEstimate | null = null;
+  if (input.nextEstimate !== null) {
+    const item = record(input.nextEstimate);
+    requireValue(
+      anchor &&
+        item.timeZone === "Asia/Seoul" &&
+        item.intervalDays === 21 &&
+        item.basisOrigin === anchor.origin,
+    );
+    const startDate = date(item.startDate),
+      endDate = date(item.endDate);
+    const basisStart =
+      anchor.origin === "api" ? kstDate(anchor.startsAt) : anchor.startDate;
+    const basisEnd =
+      anchor.origin === "api" ? kstDate(anchor.endsAt) : anchor.endDate;
+    const sources =
+      anchor.origin === "api" ? [anchor.sourceUrl] : anchor.sourceUrls;
+    requireValue(
+      startDate === plus21(basisStart) &&
+        endDate === plus21(basisEnd) &&
+        typeof item.basisSourceUrl === "string" &&
+        sources.includes(item.basisSourceUrl),
+    );
+    nextEstimate = {
+      startDate,
+      endDate,
+      timeZone: "Asia/Seoul",
+      intervalDays: 21,
+      basisOrigin: anchor.origin,
+      basisSourceUrl: item.basisSourceUrl,
+    };
+  }
+  return { version: 1, observations, anchor, nextEstimate };
+}
+export function currentStashEstimate(
+  estimate: StashEstimate | null | undefined,
+  now = Date.now(),
+): StashEstimate | null {
+  return estimate &&
+    now < Date.parse(`${estimate.endDate}T00:00:00+09:00`) + DAY
+    ? estimate
+    : null;
+}
+export function formatStashEstimate(estimate: StashEstimate): string {
+  const sameYear =
+    estimate.startDate.slice(0, 4) === estimate.endDate.slice(0, 4);
+  const short = (value: string) =>
+    `${Number(value.slice(5, 7))}/${Number(value.slice(8, 10))}`;
+  return sameYear
+    ? `${short(estimate.startDate)} ~ ${short(estimate.endDate)}`
+    : `${estimate.startDate} ~ ${estimate.endDate}`;
+}

--- a/src/shared/test-fixtures/stash-sales-contract.json
+++ b/src/shared/test-fixtures/stash-sales-contract.json
@@ -1,0 +1,252 @@
+{
+  "manual": {
+    "schemaVersion": 1,
+    "generatedAt": "2026-09-04T10:00:00.000Z",
+    "events": [],
+    "stashSales": {
+      "version": 1,
+      "observations": [
+        {
+          "service": "ggg",
+          "game": "poe1",
+          "sourceUrl": "https://www.pathofexile.com/api/shop-microtransaction-categories/stash-tabs",
+          "checkedAt": "2026-09-04T10:00:00.000Z",
+          "status": "unavailable",
+          "confirmedPeriod": null
+        },
+        {
+          "service": "ggg",
+          "game": "poe2",
+          "sourceUrl": "https://pathofexile2.com/api/shop-microtransactions?game=poe2",
+          "checkedAt": "2026-09-04T10:00:00.000Z",
+          "status": "ok",
+          "confirmedPeriod": null
+        },
+        {
+          "service": "kakao",
+          "game": "poe1",
+          "sourceUrl": "https://poe.kakaogames.com/api/shop-microtransaction-categories/stash-tabs",
+          "checkedAt": "2026-09-04T10:00:00.000Z",
+          "status": "ok",
+          "confirmedPeriod": null
+        },
+        {
+          "service": "kakao",
+          "game": "poe2",
+          "sourceUrl": "https://poe2.kakaogames.com/api/shop-microtransactions?game=poe2",
+          "checkedAt": "2026-09-04T10:00:00.000Z",
+          "status": "ok",
+          "confirmedPeriod": null
+        }
+      ],
+      "anchor": {
+        "origin": "manual-announcement",
+        "startDate": "2026-08-21",
+        "endDate": "2026-08-25",
+        "timeZone": "Asia/Seoul",
+        "sourceUrls": [
+          "https://poe.kakaogames.com/forum/view-thread/3991174",
+          "https://poe.kakaogames.com/forum/view-thread/3998528"
+        ],
+        "scope": [
+          {
+            "service": "kakao",
+            "game": "poe1"
+          },
+          {
+            "service": "kakao",
+            "game": "poe2"
+          }
+        ]
+      },
+      "nextEstimate": {
+        "startDate": "2026-09-11",
+        "endDate": "2026-09-15",
+        "timeZone": "Asia/Seoul",
+        "intervalDays": 21,
+        "basisOrigin": "manual-announcement",
+        "basisSourceUrl": "https://poe.kakaogames.com/forum/view-thread/3998528"
+      }
+    }
+  },
+  "confirmed": {
+    "schemaVersion": 1,
+    "generatedAt": "2026-09-11T01:00:00.000Z",
+    "events": [],
+    "stashSales": {
+      "version": 1,
+      "observations": [
+        {
+          "service": "ggg",
+          "game": "poe1",
+          "sourceUrl": "https://www.pathofexile.com/api/shop-microtransaction-categories/stash-tabs",
+          "checkedAt": "2026-09-11T01:00:00.000Z",
+          "status": "unavailable",
+          "confirmedPeriod": null
+        },
+        {
+          "service": "ggg",
+          "game": "poe2",
+          "sourceUrl": "https://pathofexile2.com/api/shop-microtransactions?game=poe2",
+          "checkedAt": "2026-09-11T01:00:00.000Z",
+          "status": "ok",
+          "confirmedPeriod": {
+            "startsAt": "2026-09-11T00:00:01.000Z",
+            "endsAt": "2026-09-15T00:00:00.000Z",
+            "observedAt": "2026-09-11T01:00:00.000Z",
+            "productIds": ["CurrencyTab", "PremiumStashTab"]
+          }
+        },
+        {
+          "service": "kakao",
+          "game": "poe1",
+          "sourceUrl": "https://poe.kakaogames.com/api/shop-microtransaction-categories/stash-tabs",
+          "checkedAt": "2026-09-11T01:00:00.000Z",
+          "status": "ok",
+          "confirmedPeriod": null
+        },
+        {
+          "service": "kakao",
+          "game": "poe2",
+          "sourceUrl": "https://poe2.kakaogames.com/api/shop-microtransactions?game=poe2",
+          "checkedAt": "2026-09-11T01:00:00.000Z",
+          "status": "ok",
+          "confirmedPeriod": null
+        }
+      ],
+      "anchor": {
+        "origin": "api",
+        "service": "ggg",
+        "game": "poe2",
+        "sourceUrl": "https://pathofexile2.com/api/shop-microtransactions?game=poe2",
+        "startsAt": "2026-09-11T00:00:01.000Z",
+        "endsAt": "2026-09-15T00:00:00.000Z",
+        "observedAt": "2026-09-11T01:00:00.000Z"
+      },
+      "nextEstimate": {
+        "startDate": "2026-10-02",
+        "endDate": "2026-10-06",
+        "timeZone": "Asia/Seoul",
+        "intervalDays": 21,
+        "basisOrigin": "api",
+        "basisSourceUrl": "https://pathofexile2.com/api/shop-microtransactions?game=poe2"
+      }
+    }
+  },
+  "unavailable": {
+    "schemaVersion": 1,
+    "generatedAt": "2026-09-11T07:00:00.000Z",
+    "events": [],
+    "stashSales": {
+      "version": 1,
+      "observations": [
+        {
+          "service": "ggg",
+          "game": "poe1",
+          "sourceUrl": "https://www.pathofexile.com/api/shop-microtransaction-categories/stash-tabs",
+          "checkedAt": "2026-09-11T01:00:00.000Z",
+          "status": "unavailable",
+          "confirmedPeriod": null
+        },
+        {
+          "service": "ggg",
+          "game": "poe2",
+          "sourceUrl": "https://pathofexile2.com/api/shop-microtransactions?game=poe2",
+          "checkedAt": "2026-09-11T01:00:00.000Z",
+          "status": "unavailable",
+          "confirmedPeriod": {
+            "startsAt": "2026-09-11T00:00:01.000Z",
+            "endsAt": "2026-09-15T00:00:00.000Z",
+            "observedAt": "2026-09-11T01:00:00.000Z",
+            "productIds": ["CurrencyTab", "PremiumStashTab"]
+          }
+        },
+        {
+          "service": "kakao",
+          "game": "poe1",
+          "sourceUrl": "https://poe.kakaogames.com/api/shop-microtransaction-categories/stash-tabs",
+          "checkedAt": "2026-09-11T01:00:00.000Z",
+          "status": "ok",
+          "confirmedPeriod": null
+        },
+        {
+          "service": "kakao",
+          "game": "poe2",
+          "sourceUrl": "https://poe2.kakaogames.com/api/shop-microtransactions?game=poe2",
+          "checkedAt": "2026-09-11T01:00:00.000Z",
+          "status": "ok",
+          "confirmedPeriod": null
+        }
+      ],
+      "anchor": {
+        "origin": "api",
+        "service": "ggg",
+        "game": "poe2",
+        "sourceUrl": "https://pathofexile2.com/api/shop-microtransactions?game=poe2",
+        "startsAt": "2026-09-11T00:00:01.000Z",
+        "endsAt": "2026-09-15T00:00:00.000Z",
+        "observedAt": "2026-09-11T01:00:00.000Z"
+      },
+      "nextEstimate": {
+        "startDate": "2026-10-02",
+        "endDate": "2026-10-06",
+        "timeZone": "Asia/Seoul",
+        "intervalDays": 21,
+        "basisOrigin": "api",
+        "basisSourceUrl": "https://pathofexile2.com/api/shop-microtransactions?game=poe2"
+      }
+    }
+  },
+  "expired": {
+    "schemaVersion": 1,
+    "generatedAt": "2026-10-06T15:00:00.000Z",
+    "events": [],
+    "stashSales": {
+      "version": 1,
+      "observations": [
+        {
+          "service": "ggg",
+          "game": "poe1",
+          "sourceUrl": "https://www.pathofexile.com/api/shop-microtransaction-categories/stash-tabs",
+          "checkedAt": "2026-09-11T01:00:00.000Z",
+          "status": "unavailable",
+          "confirmedPeriod": null
+        },
+        {
+          "service": "ggg",
+          "game": "poe2",
+          "sourceUrl": "https://pathofexile2.com/api/shop-microtransactions?game=poe2",
+          "checkedAt": "2026-09-11T01:00:00.000Z",
+          "status": "ok",
+          "confirmedPeriod": null
+        },
+        {
+          "service": "kakao",
+          "game": "poe1",
+          "sourceUrl": "https://poe.kakaogames.com/api/shop-microtransaction-categories/stash-tabs",
+          "checkedAt": "2026-09-11T01:00:00.000Z",
+          "status": "ok",
+          "confirmedPeriod": null
+        },
+        {
+          "service": "kakao",
+          "game": "poe2",
+          "sourceUrl": "https://poe2.kakaogames.com/api/shop-microtransactions?game=poe2",
+          "checkedAt": "2026-09-11T01:00:00.000Z",
+          "status": "ok",
+          "confirmedPeriod": null
+        }
+      ],
+      "anchor": {
+        "origin": "api",
+        "service": "ggg",
+        "game": "poe2",
+        "sourceUrl": "https://pathofexile2.com/api/shop-microtransactions?game=poe2",
+        "startsAt": "2026-09-11T00:00:01.000Z",
+        "endsAt": "2026-09-15T00:00:00.000Z",
+        "observedAt": "2026-09-11T01:00:00.000Z"
+      },
+      "nextEstimate": null
+    }
+  }
+}

--- a/src/shared/test-fixtures/stash-sales.ts
+++ b/src/shared/test-fixtures/stash-sales.ts
@@ -1,0 +1,69 @@
+import { STASH_API_URLS, type StashObservation } from "../stash-sales";
+
+export const stashSection = {
+  version: 1 as const,
+  observations: [
+    {
+      service: "kakao" as const,
+      game: "poe2" as const,
+      sourceUrl:
+        "https://poe2.kakaogames.com/api/shop-microtransactions?game=poe2",
+      checkedAt: "2026-09-04T00:00:00Z",
+      status: "ok" as const,
+      confirmedPeriod: null,
+    },
+    ...(
+      [
+        ["ggg", "poe1"],
+        ["ggg", "poe2"],
+        ["kakao", "poe1"],
+      ] as const
+    ).map(([service, game]) => ({
+      service,
+      game,
+      sourceUrl: STASH_API_URLS[`${service}:${game}`],
+      checkedAt: "2026-09-04T00:00:00Z",
+      status: "ok" as const,
+      confirmedPeriod: null,
+    })),
+  ],
+  anchor: {
+    origin: "manual-announcement" as const,
+    startDate: "2026-08-21",
+    endDate: "2026-08-25",
+    timeZone: "Asia/Seoul" as const,
+    sourceUrls: [
+      "https://poe.kakaogames.com/forum/view-thread/3991174",
+      "https://poe.kakaogames.com/forum/view-thread/3998528",
+    ],
+    scope: [
+      { service: "kakao" as const, game: "poe1" as const },
+      { service: "kakao" as const, game: "poe2" as const },
+    ],
+  },
+  nextEstimate: {
+    startDate: "2026-09-11",
+    endDate: "2026-09-15",
+    timeZone: "Asia/Seoul" as const,
+    intervalDays: 21 as const,
+    basisOrigin: "manual-announcement" as const,
+    basisSourceUrl: "https://poe.kakaogames.com/forum/view-thread/3998528",
+  },
+};
+
+export const stashObservations = (
+  ...overrides: StashObservation[]
+): StashObservation[] =>
+  stashSection.observations.map(
+    (item) =>
+      overrides.find(
+        (other) => other.service === item.service && other.game === item.game,
+      ) ?? item,
+  );
+
+export const observedStashPeriod = {
+  startsAt: "2026-09-04T00:00:00Z",
+  endsAt: "2026-09-08T00:00:00Z",
+  observedAt: "2026-09-04T00:00:00Z",
+  productIds: ["PremiumStashTab", "StashTab", "CurrencyTab"],
+};

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1,3 +1,10 @@
+import type {
+  EventNotificationPreferences,
+  PromotionDismissRequest,
+  PromotionDismissResult,
+  PromotionSnapshot,
+} from "./promotions";
+
 export const CONFIG_CATEGORIES = [
   "Info",
   "General",
@@ -66,6 +73,7 @@ export interface AppConfig {
   quitOnGameStart: boolean;
   showOnboarding: boolean;
   newsOpenMode: NewsOpenMode;
+  eventNotifications: EventNotificationPreferences;
   /**
    * - "resource-saving": Optimization Mode (Background Scan OFF)
    * - "always-on": High Performance Mode (Background Scan ON)
@@ -743,6 +751,13 @@ export interface RevalidateThemeColorsEventDetail {
 }
 
 export interface ElectronAPI {
+  dismissPromotion: (
+    request: PromotionDismissRequest,
+  ) => Promise<PromotionDismissResult>;
+  getPromotions: () => Promise<PromotionSnapshot>;
+  onPromotionsUpdated: (
+    callback: (snapshot: PromotionSnapshot) => void,
+  ) => () => void;
   getAllChangelogs: () => Promise<ChangelogItem[]>;
   onShowChangelog?: (
     callback: (

--- a/src/shared/urls.ts
+++ b/src/shared/urls.ts
@@ -56,6 +56,8 @@ export const SUPPORT_URLS = {
     "https://nerdhead-lab.github.io/POE2-unofficial-launcher/latest-versions.json",
   THEMES_JSON:
     "https://nerdhead-lab.github.io/POE2-unofficial-launcher/themes.json",
+  PROMOTIONS_JSON:
+    "https://nerdhead-lab.github.io/POE2-unofficial-launcher/promotions.json",
   ASSETS_BASE: "https://nerdhead-lab.github.io/POE2-unofficial-launcher/",
 };
 


### PR DESCRIPTION
## Summary

- 게임 패치 예약 위에 이벤트 알림 관리를 추가하고, 트위치 드롭스·보관함 할인 종류와 전체에 공통 적용할 앱 내·Windows 알림 방식을 설정합니다. 기본값은 앱 내 알림 켜짐, Windows 알림 꺼짐입니다.
- 알림에는 이벤트와 기간을 표시하고 게임별 Twitch 또는 확인된 서비스·게임의 상점으로 연결합니다. Windows 알림은 동일 일정당 한 번, 앱 내 알림은 재실행 시 다시 표시하며 삭제 모달에서 이번 일정 전체를 숨길 수 있습니다. 종료된 숨김·발송 이력은 만료됩니다.
- 열어 본 알림은 저채도로 표시하고 미읽음 숫자에서 제외합니다. ‘이달의 주요 소식’ 아이콘은 알림 설정과 독립적으로 현재 이벤트를 강조하고 다음 일정 또는 예상 일정을 안내합니다.
- 배포된 수집기 #289의 stashSales를 읽어 실제 확인된 할인만 활성화합니다. 9/11 ~ 9/15 예상은 비활성 안내로만 표시하며 알림을 보내지 않습니다. 기존 설정 파일은 마이그레이션 없이 새 설정 기본값을 적용하고, 기존 오류·운영 알림 경로를 유지합니다.
- PR에서는 Check Event Promotions의 테스트만 실행하도록 정기 발행 workflow와 분리해, collect-and-publish가 skipped 체크로 표시되지 않게 합니다. 정기·수동·master 갱신은 기존처럼 테스트 통과 후 수집·발행하며 보관함 소비자 변경도 검사 대상으로 포함합니다.

Windows에서 관련 11파일 67개 테스트, 수집기 59개 테스트(실제 소비자 교차 검사 포함, skip 0), 전체 src lint, 설치 파일 빌드를 통과했습니다. 분리 리뷰와 숨김 실제 Electron QA에서 공개 피드→캐시→IPC→화면 일치, 서비스·게임 4조합, 읽음·삭제·재실행 및 격리 프로필의 정확한 종료를 확인했습니다. 수집기 테스트가 런처의 확장자 없는 TypeScript import를 읽도록 테스트 범위의 Node resolve hook을 추가했습니다.

<details>
<summary>QA 캡처 6장</summary>

공개 피드 캡처와 합성 할인 일정 검증을 구분했습니다. 1024×683은 실제 Electron의 CDP viewport이며 OS 창 크기 변경 검증은 아닙니다.

**알림 종류와 공통 알림 방식을 분리한 설정 화면**

![알림 종류와 공통 알림 방식을 분리한 설정 화면](https://raw.githubusercontent.com/NERDHEAD-lab/POE2-unofficial-launcher/5b1be0216547304c7709bcbc4de3490089a78823/qa/event-notification-ui/2026-09-04/settings.png)

**실제 공개 피드: 비활성 보관함 아이콘의 다음 예상 일정**

![실제 공개 피드: 비활성 보관함 아이콘의 다음 예상 일정](https://raw.githubusercontent.com/NERDHEAD-lab/POE2-unofficial-launcher/5b1be0216547304c7709bcbc4de3490089a78823/qa/event-notification-ui/2026-09-04/published-estimate.png)

**실제 공개 피드: 진행 중인 PoE 1 드롭스 알림**

![실제 공개 피드: 진행 중인 PoE 1 드롭스 알림](https://raw.githubusercontent.com/NERDHEAD-lab/POE2-unofficial-launcher/5b1be0216547304c7709bcbc4de3490089a78823/qa/event-notification-ui/2026-09-04/published-notifications.png)

**삭제 모달: 이번 일정 내 표시하지 않음 기본 선택**

![삭제 모달: 이번 일정 내 표시하지 않음 기본 선택](https://raw.githubusercontent.com/NERDHEAD-lab/POE2-unofficial-launcher/5b1be0216547304c7709bcbc4de3490089a78823/qa/event-notification-ui/2026-09-04/dismiss-default.png)

**읽은 알림의 채도 감소와 미읽음 숫자 제외**

![읽은 알림의 채도 감소와 미읽음 숫자 제외](https://raw.githubusercontent.com/NERDHEAD-lab/POE2-unofficial-launcher/5b1be0216547304c7709bcbc4de3490089a78823/qa/event-notification-ui/2026-09-04/read-notification.png)

**합성 일정 QA: 확인된 Kakao PoE 2 상점 링크만 표시**

![합성 일정 QA: 확인된 Kakao PoE 2 상점 링크만 표시](https://raw.githubusercontent.com/NERDHEAD-lab/POE2-unofficial-launcher/5b1be0216547304c7709bcbc4de3490089a78823/qa/event-notification-ui/2026-09-04/confirmed-stash-synthetic.png)

</details>

## Motivation

드롭스와 보관함 할인 기간을 놓치지 않도록 런처에서 현재 상태와 이동 경로를 제공하고, 같은 일정의 반복 알림은 사용자가 조절할 수 있게 합니다. 확정된 할인과 주기 기반 예상을 분리해 예상만으로 진행 중 표시나 알림이 발생하지 않게 합니다.

PR 검토 시 실제 실행하는 검사만 체크 목록에 보이도록 하고, 정기 발행의 검증 및 동시 실행 제한을 유지합니다.
