### PR TITLE
fix: 카카오 게임 실행과 계정 확인 중 보안 확인 창을 표시하도록 개선

### DIFF
--- a/docs/work/2026-09-04-cloudflare-challenge-visibility.md
+++ b/docs/work/2026-09-04-cloudflare-challenge-visibility.md
@@ -1,0 +1,125 @@
+# Cloudflare 보안 확인 창 표시
+
+> 작성일: 2026-09-04 · 갱신: 2026-09-04 · 상태: PR 제출 승인, 실제 사이트 검증 미실시 · 브랜치: fix/cloudflare-challenge-visibility
+
+## 승인과 범위
+
+사용자가 게임 실행·계정 확인에서 Cloudflare 확인 창 표시, 확인 중 자동화와
+제한시간 정지, 확인 후 원래 작업 재개 및 이를 위한 IPC 변경을 승인했다(“ㅇㅇ”).
+기준 master: 320f88be222d4b57978bbd86ef25f3b2127782f9. PR #292는 이미 사용자 머지 완료.
+다른 세션의 `2026-09-04-event-notification-ui.md`는 수정하지 않는다.
+
+영향: 카카오 PoE 사이트의 최상위 문서가 공식 `cf-mitigated: challenge` 헤더를
+보낼 때만 사용자 입력을 기다린다. UA, 쿠키, 설정 스키마, 스타터/UAC, 업데이트
+절차는 변경하지 않는다. 자동 CAPTCHA 풀이를 하지 않는다.
+
+## 원인과 설계
+
+현재 preload는 URL로 일반 핸들러를 선택한다. 같은 URL의 보안 확인 문서에서
+게임 시작 버튼 탐색 실패 또는 계정 로그인 필요 처리가 실행될 수 있다.
+main의 반복 표시 정책과 10초 제한도 창을 숨기거나 닫을 수 있다.
+
+런타임 상태의 소유자는 main이다. 카카오 세션의 읽기 전용 응답 관찰로 판정하고,
+webContents·작업·탐색 세대에 묶는다. 창 표시 사유는 기존 forced visibility와
+독립적으로 보존한다. 확인 중에는 기존 validation mode를 바꾸지 않는다.
+정상 최상위 문서가 commit된 뒤 preload가 새 문서의 핸들러를 실행하며, 핸들러의
+기존 제한시간(-1 포함)을 적용한다. 이전 문서의 지연 IPC는 재개시키지 않는다.
+기존 passkey 차단 리스너를 덮어쓰지 않는다. 서드파티 DOM 셀렉터는 추가하지 않는다.
+
+## 구현 순서와 DoD
+
+1. `src/main/kakao/cloudflare-challenge.ts`와 집중 테스트: 헤더 판정, 문서 commit,
+   오래된 응답·문서 IPC 무시, 팝업 소유권, 종료 정리.
+   - [x] [Windows-pwsh] 실패 테스트 확인 후 구현, 정상/403/iframe/XHR 음성 사례 통과.
+2. `session.ts`, `main.ts`, `preload.ts`: 읽기 전용 세션 관찰, 표시 사유, 제한시간
+   일시정지, 핸들러 실행 전 문서 확인, 중복 계정 확인 방지.
+   - [x] [Windows-pwsh] 격리한 실제 Electron에서 10초 이상 유지 및 정상 문서 재개.
+   - [x] [Windows-pwsh] 집중 테스트·lint·타입 검사·빌드 통과.
+3. 분리 리뷰 및 사용자 검증.
+   - [x] 리뷰어에게 변경 diff와 이 문서를 전달해 판정 기록.
+   - [ ] [사용자] Windows PoE1/PoE2 게임 실행·계정 확인에서 실제 Cloudflare 확인 후 재개.
+   - [ ] [사용자] 일반 로그인/MOTP 표시, 취소·창 닫기 정상 동작.
+
+검증 명령: `node node_modules/vitest/vitest.mjs run src/main/tests/kakao-cloudflare-challenge.test.ts src/main/tests/kakao-cloudflare-preload.test.ts src/main/tests/kakao-login-observer.test.ts src/main/tests/kakao-visibility-policy.test.ts src/main/tests/game-status-ipc.test.ts src/main/tests/kakao-account-validation-dom.test.ts`, 대상 ESLint, `npm.cmd run build:check`.
+실제 사이트 검증은 유닛/빌드 또는 로컬 모의 문서로 대체하지 않는다.
+사용자는 Cloudflare 확인을 임의로 발생시킬 수 없음을 설명한 뒤 “PR 상신해”로
+커밋/PR 진행을 명시적으로 승인했다. 미실시 사용자 검증은 위에 그대로 남기며
+master 머지는 별도 승인 대상이다.
+
+## 분리 설계 리뷰
+
+- `/root/update_shutdown_review`: 응답 헤더·main 표시 상태·preload 실행 보류를 함께
+  구현할 것. 일반 hide IPC가 확인 창을 숨기지 못하게 하고 원래 작업/타이머 정책을
+  유지할 것. 팝업과 늦은 응답을 구분하며 중복 계정 확인이 확인 창을 reload하지
+  못하게 할 것. 실제 Windows 사용자 플로우를 최종 검증으로 유지.
+
+## 근거
+
+- [Cloudflare 공식 감지 문서](https://developers.cloudflare.com/cloudflare-challenges/challenge-types/challenge-pages/detect-response/)
+- preload의 URL 분기: git blame 37faf215 / bb6853bd. 최근 계정 확인 변경 7db1c86.
+- Electron 43 설치 타입의 webRequest 응답·탐색 이벤트 계약.
+
+## 구현 및 검증 결과
+
+- main의 별도 challenge 상태와 문서 ID로 hide/result/status/timeout IPC의 오래된
+  요청을 거부한다. 새 작업으로 교체된 팝업 문서는 무효화한다.
+- `automation-clock.ts`는 preload 지연 시간에서 수동 확인 시간을 제외한다.
+  이미 관찰 중인 부모 문서도 pause/resume하며 해제 시 DOM을 다시 확인한다.
+  일반/QR 로그인 핸들러가 동적 UI 관찰을 유지하는 기존 disconnect 계약은 보존한다.
+- opener를 닫으면 재사용할 자식도 닫히는 Electron 기본 동작을 실제로 재현했다.
+  이전 문서는 pause → stop → about:blank → 숨김 처리하고 successor 종료 후 닫는다.
+  전역 `outlivesOpener` 설정은 바꾸지 않았다. 명시적 새 작업 창의 참조가 우선하며
+  폐기된 창으로 fallback하지 않는다. 이전 정리가 새 작업 상태를 초기화하지 않는다.
+- 집중 테스트 6파일 48개 통과. 대상 ESLint, `git diff --check`, `build:check` 통과.
+  빌드의 기존 번들 크기 경고는 남아 있다.
+- Windows Electron 43.4.1, 격리 프로필과 로컬 HTTPS fixture로 실제 webRequest →
+  commit → preload 순서를 검증했다. 창의 show/hide/focus는 계측으로 대체하여
+  모든 실제 창은 숨김 유지했다. 따라서 화면 노출/실제 CAPTCHA 해결 검증은 아니다.
+- 실행 증거 루트: `%TEMP%/poe2-unofficial-launcher-codex-qa/`.
+  - `cloudflare-1788531200001`: PoE1/PoE2 실행 및 계정 확인 11초 이상 유지·정상
+    문서 재개. 정상 캐시 응답(`fromCache: true`)에서 확인 상태 해제.
+  - `cloudflare-1788531569777`: 기존 부모 observer 11초 이상 대기 후 계정 DOM
+    감지 재개. 이 실행의 팝업 보존 검사는 다음 항목에서 추가로 강화했다.
+  - `cloudflare-1788531709432`: 이전 빈 opener로 새 계정 확인이 향하는 실패 재현.
+  - `cloudflare-1788531743798`: 수정 후 동일 successor popup에서 계정 확인하고
+    이전 opener까지 정상 정리. PID 89148 정상 종료.
+  - 초기 helper의 `passed.cases`는 모드별 실행 수를 반영하지 못했다. 위 경로의
+    개별 scenario 이벤트를 근거로 삼는다. 최신 retire 실행은 1개 시나리오이며
+    전체 실행들에서 검증한 서로 다른 시나리오는 6개다.
+- 모의 UI는 기존 selector에 맞춘 테스트 문서이며 실제 사이트 selector를 추가하거나
+  교체하지 않았다. 개인 계정/프로필/쿠키는 사용하지 않았다.
+- 다른 작업 문서 SHA256은 최초 값 그대로 보존:
+  `76256EE114AB15C3B9EFC1E44F06D0ADBDC5BBD32BEE520E987116CDE2DAB426`.
+
+## 코드 리뷰 기록
+
+1. 반려: sibling 보류 문서 재개 누락, 이전 task popup 유효성, 트레이 복귀 표시,
+   첫 challenge 응답 취소 복구. 해제 알림·문서/작업 무효화·복귀 표시·committed
+   상태 복원으로 보완했다.
+2. 반려: ensureGameWindow closed의 전역 참조와 기존 부모 observer 타이머 만료.
+   생성 창 캡처/참조 동일성 검사와 AutomationClock으로 보완했다.
+3. 통과: 동적 로그인 UI의 관찰 종료 소유권을 회귀 테스트로 복원했다. native QA에서
+   발견한 opener 생존과 명시적 작업 창 소유권까지 보완 후 분리 리뷰어가 최종 통과.
+   잔여 코드 blocker 없음. 실제 Windows 사용자 확인은 미실시 상태로 기록한다.
+
+## 전달 상태
+
+초기 검증용 패키징에서 무시된 로컬 설정 `.tmp/cloudflare-qa/builder.cjs`의
+`files` 목록을 별도로 제한하여 `dist/icon.ico`와 `dist/icon.png`가 누락되었다.
+사용자가 23:32 KST 트레이 아이콘 오류를 보고했고, 이는 제품 코드 변경이 아닌
+잘못 만든 로컬 설치 파일의 문제로 확인했다. 해당 파일 목록 재정의를 제거했다.
+
+사용자의 기본 빌드 요청에 따라 저장소의 기본 패키징 설정과 출력 경로로 다시
+빌드했다. 최종 설치 파일은
+`D:/project_poe2/POE2-unofficial-launcher/dist/POE2 Unofficial Launcher Setup 1.6.5.exe`이며
+2026-09-04 23:36:09 KST, 244824959 bytes다. 로컬 Electron 버전 불일치를 피하기
+위해 패키징 실행 시 43.4.1 캐시 런타임만 지정했다. app.asar 안의 두 아이콘이
+빌드 원본과 바이트 단위로 일치함을 확인했다. 설치 후 실제 트레이 생성까지
+확인한 것은 아니다. 제품 패키징 설정 및 `.tmp` 도구는 PR 변경에 포함하지 않는다.
+
+사용자 요청에 따라 이 변경의 PR을 제출한다. 실제 사이트에서의 Cloudflare 확인,
+이후 게임 실행/계정 확인, 일반 로그인/MOTP, 트레이 복귀·취소는 미실시다.
+따라서 작업 문서는 `docs/work/`에 유지하고 검증 완료로 표시하지 않는다.
+위키 raw 노트는 `/home/nerdhead/project_llm_wiki/raw/projects/poe2-launcher/2026-09-04-cloudflare-challenge-visibility.md`에 보존한다.
+위키 AGENTS.md는 영향 페이지 승인 후 ingest를 요구하므로 이번 PR에서는 위키
+페이지를 수정하지 않는다.

--- a/src/main/ipc/game-status-ipc.ts
+++ b/src/main/ipc/game-status-ipc.ts
@@ -13,12 +13,17 @@ interface RegisterGameStatusIpcOptions {
   getAppContext: () => AppContext | undefined;
   getActiveSessionContext: () => SessionContext | null;
   getWindowContext: (webContentsId: number) => SessionContext | undefined;
+  acceptsPage?: (
+    event: Electron.IpcMainEvent,
+    documentId?: number | null,
+  ) => boolean;
 }
 
 export function registerGameStatusIpc({
   getAppContext,
   getActiveSessionContext,
   getWindowContext,
+  acceptsPage,
 }: RegisterGameStatusIpcOptions) {
   ipcMain.handle(
     "game:get-status",
@@ -36,7 +41,9 @@ export function registerGameStatusIpc({
         gameId: AppConfig["activeGame"];
         serviceId: AppConfig["serviceChannel"];
       } | null,
+      documentId?: number | null,
     ) => {
+      if (acceptsPage && !acceptsPage(event, documentId)) return;
       const appContext = getAppContext();
       if (!appContext) {
         return;

--- a/src/main/kakao/automation-clock.ts
+++ b/src/main/kakao/automation-clock.ts
@@ -1,0 +1,61 @@
+interface PendingTimer {
+  callback: () => void;
+  remaining: number;
+  started: number;
+  nativeId?: number;
+}
+
+/** Excludes manual verification time from this document's automation delays. */
+export class AutomationClock {
+  paused = false;
+  private sequence = 0;
+  private timers = new Map<number, PendingTimer>();
+  private resumeListeners = new Set<() => void>();
+
+  setTimeout(callback: () => void, delay: number): number {
+    const id = ++this.sequence;
+    const timer = { callback, remaining: delay, started: Date.now() };
+    this.timers.set(id, timer);
+    if (!this.paused) this.arm(id, timer);
+    return id;
+  }
+
+  clearTimeout(id: number) {
+    const timer = this.timers.get(id);
+    if (timer?.nativeId !== undefined) window.clearTimeout(timer.nativeId);
+    this.timers.delete(id);
+  }
+
+  private arm(id: number, timer: PendingTimer) {
+    timer.started = Date.now();
+    timer.nativeId = window.setTimeout(() => {
+      this.timers.delete(id);
+      timer.callback();
+    }, timer.remaining);
+  }
+
+  pause() {
+    if (this.paused) return;
+    this.paused = true;
+    for (const timer of this.timers.values()) {
+      window.clearTimeout(timer.nativeId);
+      timer.nativeId = undefined;
+      timer.remaining = Math.max(
+        0,
+        timer.remaining - (Date.now() - timer.started),
+      );
+    }
+  }
+
+  resume() {
+    if (!this.paused) return;
+    this.paused = false;
+    for (const [id, timer] of this.timers) this.arm(id, timer);
+    for (const listener of this.resumeListeners) listener();
+  }
+
+  onResume(listener: () => void) {
+    this.resumeListeners.add(listener);
+    return () => this.resumeListeners.delete(listener);
+  }
+}

--- a/src/main/kakao/cloudflare-challenge.ts
+++ b/src/main/kakao/cloudflare-challenge.ts
@@ -1,0 +1,204 @@
+import { isKakaoPoeHomeUrl } from "../../shared/kakao-url-policy";
+
+interface Request {
+  id: number;
+  webContentsId?: number;
+  url: string;
+  resourceType: string;
+}
+
+interface WindowState {
+  trigger: string;
+  task: number;
+  challenge: boolean;
+  documentId: number | null;
+  committed: { challenge: boolean; documentId: number | null };
+  request?: { id: number; response?: { url: string; challenge: boolean } };
+}
+
+const TRIGGERS = new Set([
+  "ACCOUNT_VALIDATION",
+  "ACCOUNT_MANUAL_LOGIN",
+  "GAME_START_POE1",
+  "GAME_START_POE2",
+]);
+
+function documentUrl(value: string) {
+  return value.split("#")[0];
+}
+
+/** Main owns challenge state; neither a preload hide request nor a redirect releases it. */
+export class KakaoChallengeGate {
+  private windows = new Map<number, WindowState>();
+  private retired = new Set<number>();
+  private sequence = 0;
+
+  constructor(
+    private readonly onChallenge: (id: number) => void,
+    private readonly onResumed: (ids: number[]) => void = () => {},
+    private readonly onRetired: (
+      ids: number[],
+      successorId: number,
+    ) => void = () => {},
+  ) {}
+
+  setTrigger(id: number, trigger: string | null, parentId?: number) {
+    if (!trigger || !TRIGGERS.has(trigger)) {
+      this.remove(id);
+      return;
+    }
+    const oldTask = this.windows.get(id)?.task;
+    if (parentId === undefined && oldTask !== undefined) {
+      const retired: number[] = [];
+      for (const [windowId, state] of this.windows) {
+        if (state.task === oldTask) {
+          this.windows.delete(windowId);
+          this.retired.add(windowId);
+          if (windowId !== id) retired.push(windowId);
+        }
+      }
+      this.onRetired(retired, id);
+    }
+    this.retired.delete(id);
+    this.windows.set(id, {
+      trigger,
+      task:
+        (parentId === undefined
+          ? undefined
+          : this.windows.get(parentId)?.task) ?? ++this.sequence,
+      challenge: false,
+      documentId: null,
+      committed: { challenge: false, documentId: null },
+    });
+  }
+
+  beginNavigation(id: number) {
+    const state = this.windows.get(id);
+    if (!state) return;
+    state.documentId = null;
+    state.request = undefined;
+  }
+
+  requestStarted(details: Request) {
+    if (details.resourceType !== "mainFrame") return;
+    const state = this.windows.get(details.webContentsId ?? -1);
+    if (!state) return;
+    state.request = { id: details.id };
+  }
+
+  responseStarted(
+    details: Request & {
+      statusCode: number;
+      responseHeaders?: Record<string, string[]>;
+    },
+  ) {
+    if (details.resourceType !== "mainFrame") return;
+    const id = details.webContentsId ?? -1;
+    const state = this.windows.get(id);
+    if (!state?.request || state.request.id !== details.id) return;
+    // Redirect headers are not a committed document (including challenge redirects).
+    if (details.statusCode >= 300 && details.statusCode < 400) return;
+    let challenge = false;
+    try {
+      const url = new URL(details.url);
+      challenge =
+        url.protocol === "https:" &&
+        isKakaoPoeHomeUrl(url) &&
+        Object.entries(details.responseHeaders ?? {}).some(
+          ([name, values]) =>
+            name.toLowerCase() === "cf-mitigated" &&
+            values.some((value) => value.trim().toLowerCase() === "challenge"),
+        );
+    } catch {
+      /* A malformed URL cannot authorize showing a window. */
+    }
+    state.request.response = { url: documentUrl(details.url), challenge };
+    if (challenge && !state.challenge) {
+      state.challenge = true;
+      this.onChallenge(id);
+    }
+  }
+
+  requestFailed(details: { id: number; webContentsId?: number }) {
+    const state = this.windows.get(details.webContentsId ?? -1);
+    if (state?.request?.id !== details.id) return;
+    state.request = undefined;
+    const wasChallenged = state.challenge;
+    state.challenge = state.committed.challenge;
+    state.documentId = state.committed.documentId;
+    if (wasChallenged && !state.challenge) this.resumeTask(state.task);
+  }
+
+  commit(id: number, url: string) {
+    const state = this.windows.get(id);
+    if (!state) return;
+    const response = state.request?.response;
+    const wasChallenged = state.challenge;
+    if (response?.url === documentUrl(url))
+      state.challenge = response.challenge;
+    state.documentId = ++this.sequence;
+    state.committed = {
+      challenge: state.challenge,
+      documentId: state.documentId,
+    };
+    if (wasChallenged && !state.challenge) this.resumeTask(state.task);
+  }
+
+  remove(id: number) {
+    const state = this.windows.get(id);
+    this.windows.delete(id);
+    this.retired.delete(id);
+    if (state?.challenge) this.resumeTask(state.task);
+  }
+
+  private resumeTask(task: number) {
+    const members = [...this.windows].filter(
+      ([, state]) => state.task === task,
+    );
+    if (!members.some(([, state]) => state.challenge))
+      this.onResumed(members.map(([id]) => id));
+  }
+
+  isVisible(id: number) {
+    return this.windows.get(id)?.challenge === true;
+  }
+
+  taskBlocked(id: number) {
+    const task = this.windows.get(id)?.task;
+    return (
+      task !== undefined &&
+      [...this.windows.values()].some(
+        (state) => state.task === task && state.challenge,
+      )
+    );
+  }
+
+  taskMembers(id: number) {
+    const task = this.windows.get(id)?.task;
+    return [...this.windows]
+      .filter(([, state]) => state.task === task)
+      .map(([id]) => id);
+  }
+
+  hasChallenge(trigger: string) {
+    return [...this.windows.values()].some(
+      (state) => state.trigger === trigger && state.challenge,
+    );
+  }
+
+  pageState(id: number) {
+    const state = this.windows.get(id);
+    return {
+      blocked:
+        this.retired.has(id) ||
+        this.taskBlocked(id) ||
+        (state !== undefined && state.documentId === null),
+      documentId: state?.documentId ?? null,
+    };
+  }
+
+  accepts(id: number, documentId: number | null | undefined) {
+    const page = this.pageState(id);
+    return !page.blocked && page.documentId === documentId;
+  }
+}

--- a/src/main/kakao/preload.ts
+++ b/src/main/kakao/preload.ts
@@ -4,6 +4,7 @@ import {
   findKakaoAccountValidationElements,
   getElementText,
 } from "./account-validation-dom";
+import { AutomationClock } from "./automation-clock";
 import {
   hasVisibleKakaoLoginForm,
   hasVisibleKakaoQrLoginPrompt,
@@ -124,6 +125,15 @@ const SELECTORS = {
 
 // --- Global State ---
 let isValidationMode = false;
+let automationDocumentId: number | null = null;
+let pageDeferred = false;
+let pageStarted = false;
+const automationClock = new AutomationClock();
+
+function sendPageMessage(channel: string, ...args: unknown[]) {
+  if (automationClock.paused) return;
+  ipcRenderer.send(channel, ...args, automationDocumentId);
+}
 
 /**
  * Helper to request visibility with automatic sizing
@@ -137,7 +147,7 @@ function requestWindowVisibility(visible: boolean) {
     return;
   }
 
-  ipcRenderer.send("window-visibility-request", visible);
+  sendPageMessage("window-visibility-request", visible);
 }
 
 function createVisibilityRequest(context: HandlerContext, description: string) {
@@ -172,7 +182,7 @@ function serializeAutomationError(error: unknown) {
 
 function reportAutomationFailure(handlerName: string, error: unknown) {
   const serialized = serializeAutomationError(error);
-  ipcRenderer.send("kakao:automation-failure", {
+  sendPageMessage("kakao:automation-failure", {
     errorCode: "KAKAO_AUTOMATION_HANDLER_FAILURE",
     handlerName,
     url: window.location.href,
@@ -183,7 +193,7 @@ function reportAutomationFailure(handlerName: string, error: unknown) {
 
 function reportStartButtonTimeout(handlerName: string) {
   const message = `${handlerName} timed out while waiting for the Kakao game start button.`;
-  ipcRenderer.send("kakao:automation-failure", {
+  sendPageMessage("kakao:automation-failure", {
     errorCode: "KAKAO_START_BUTTON_TIMEOUT",
     handlerName,
     url: window.location.href,
@@ -204,7 +214,7 @@ function scheduleStableVisibilityReveal(options: {
   const initialUrl = window.location.href;
   const delayMs = options.delayMs ?? USER_REQUIRED_PAGE_REVEAL_DELAY_MS;
 
-  const timeoutId = window.setTimeout(() => {
+  const timeoutId = automationClock.setTimeout(() => {
     if (window.location.href !== initialUrl) {
       logger.log(
         `[Visibility] ${options.description} reveal skipped: URL changed before ${delayMs}ms.`,
@@ -227,14 +237,14 @@ function scheduleStableVisibilityReveal(options: {
     );
   }, delayMs);
 
-  return () => window.clearTimeout(timeoutId);
+  return () => automationClock.clearTimeout(timeoutId);
 }
 
 function safeClick(
   element: HTMLElement | null,
   description: string = "element",
 ) {
-  if (!element) return false;
+  if (!element || automationClock.paused) return false;
 
   const identity = element.id
     ? `#${element.id}`
@@ -289,25 +299,39 @@ function observeAndInteract(
   timeoutMs: number = 10000,
   onTimeout?: () => void,
 ) {
-  if (checkFn()) return;
+  if (!automationClock.paused && checkFn()) return;
 
   logger.log(
     "[Game Window] Target not found immediately. Starting observer...",
   );
 
   let completed = false;
-  const observer = new MutationObserver((_mutations, obs) => {
-    if (checkFn(obs)) {
+  let timeoutId: number | undefined;
+  const check = () => {
+    if (automationClock.paused) return;
+    if (checkFn(observer)) {
       completed = true;
+      if (timeoutId !== undefined) automationClock.clearTimeout(timeoutId);
     }
-  });
+  };
+  const observer = new MutationObserver(check);
+  const unsubscribe = automationClock.onResume(check);
+  const disconnect = observer.disconnect.bind(observer);
+  // Some login handlers keep observing after a successful match for dynamic UI.
+  // Preserve the handler's explicit disconnect decision while cleaning up our clock.
+  observer.disconnect = () => {
+    disconnect();
+    unsubscribe();
+    if (timeoutId !== undefined) automationClock.clearTimeout(timeoutId);
+  };
 
   observer.observe(document.body, { childList: true, subtree: true });
 
   if (timeoutMs > 0) {
-    setTimeout(() => {
+    timeoutId = automationClock.setTimeout(() => {
       if (completed) return;
       observer.disconnect();
+      unsubscribe();
       logger.log("[Game Window] Observer timed out.");
       onTimeout?.();
     }, timeoutMs);
@@ -393,7 +417,7 @@ const AccountValidationHandler: PageHandler = {
         logger.log(
           `[AccountValidationHandler] Tier 2 Success: Found POE Account ID: ${accountId}`,
         );
-        ipcRenderer.send("kakao:account-id-fetched", accountId);
+        sendPageMessage("kakao:account-id-fetched", accountId);
         if (obs) obs.disconnect();
         return true;
       }
@@ -427,7 +451,7 @@ const DaumGameLoginValidationHandler: PageHandler = {
 
     ctx.setVisible(false);
 
-    window.setTimeout(() => {
+    automationClock.setTimeout(() => {
       if (
         !shouldSignalDaumGameLoginRequired(initialHref, window.location.href)
       ) {
@@ -437,7 +461,7 @@ const DaumGameLoginValidationHandler: PageHandler = {
         return;
       }
 
-      ipcRenderer.send("kakao:login-required", { url: initialHref });
+      sendPageMessage("kakao:login-required", { url: initialHref });
       logger.log("[Validator] Validation stopped at Daum login redirect.");
     }, DAUM_GAME_LOGIN_REDIRECT_GRACE_MS);
   },
@@ -490,7 +514,7 @@ const Poe2MainHandler: PageHandler = {
           } else if (closeBtn && safeClick(closeBtn as HTMLElement)) {
             logger.log('[Poe2MainHandler] Clicked "Close X"');
           }
-          await new Promise((r) => setTimeout(r, 500)); // Small delay after close
+          await new Promise<void>((r) => automationClock.setTimeout(r, 500)); // Small delay after close
         }
       }
     };
@@ -820,7 +844,7 @@ const KakaoQRLoginHandler: PageHandler = {
           // Also listen for clicks on label since that's how it's often toggled
           checkboxLabel.addEventListener("click", () => {
             // Delay to let the input state update
-            setTimeout(() => {
+            automationClock.setTimeout(() => {
               warningMsg.style.display = checkboxInput.checked
                 ? "none"
                 : "block";
@@ -945,14 +969,14 @@ const SecurityCenterHandler: PageHandler = {
   triggeredBy: ["GAME_START_POE1", "GAME_START_POE2"],
   execute: (context) => {
     logger.log(`[Handler] Executing ${SecurityCenterHandler.name}`);
-    ipcRenderer.send("game-status-update", "authenticating", activeGameContext);
+    sendPageMessage("game-status-update", "authenticating", activeGameContext);
 
     const reveal = createVisibilityRequest(context, "Security Center");
     let delayTimeoutId: number | null = null;
 
     const clearDelayedReveal = () => {
       if (delayTimeoutId === null) return;
-      window.clearTimeout(delayTimeoutId);
+      automationClock.clearTimeout(delayTimeoutId);
       delayTimeoutId = null;
     };
 
@@ -960,7 +984,7 @@ const SecurityCenterHandler: PageHandler = {
       if (delayTimeoutId !== null) return;
 
       const initialUrl = window.location.href;
-      delayTimeoutId = window.setTimeout(() => {
+      delayTimeoutId = automationClock.setTimeout(() => {
         delayTimeoutId = null;
 
         if (window.location.href !== initialUrl) {
@@ -1064,7 +1088,7 @@ const LauncherCompletionHandler: PageHandler = {
   triggeredBy: ["GAME_START_POE1", "GAME_START_POE2"],
   execute: () => {
     logger.log(`[Handler] Executing ${LauncherCompletionHandler.name}`);
-    ipcRenderer.send("game-status-update", "ready", activeGameContext);
+    sendPageMessage("game-status-update", "ready", activeGameContext);
 
     observeAndInteract((obs) => {
       for (const sel of SELECTORS.LAUNCHER.GAME_START_BUTTONS) {
@@ -1151,7 +1175,7 @@ const KakaoLoginValidationHandler: PageHandler = {
     ctx.setVisible(false);
 
     // Notify main process: Login is required, here is the context URL to resume later
-    ipcRenderer.send("kakao:login-required", { url: window.location.href });
+    sendPageMessage("kakao:login-required", { url: window.location.href });
 
     // Stop validation since user interaction is needed
     logger.log("[Validator] Validation stuck at Login. Signalling failure.");
@@ -1174,9 +1198,9 @@ const KakaoManualValidationHandler: PageHandler = {
     // 1. Hide Window
     ctx.setVisible(false);
     // 2. Clear Context so we don't accidentally match this again
-    ipcRenderer.send("account:clear-trigger");
+    sendPageMessage("account:clear-trigger");
     // 3. Trigger immediate re-validation to refresh Account ID in UI
-    ipcRenderer.send("account:trigger-validation", "Kakao Games");
+    sendPageMessage("account:trigger-validation", "Kakao Games");
   },
 };
 
@@ -1206,6 +1230,19 @@ const HANDLERS: PageHandler[] = [
 // --- Core Dispatcher ---
 
 async function dispatchPageLogic(triggerContext?: string) {
+  if (pageStarted) return;
+  const page = await ipcRenderer.invoke("kakao:get-page-state");
+  if (page.blocked) {
+    pageDeferred = true;
+    logger.log(
+      "[Cloudflare] Page automation deferred until verification finishes.",
+    );
+    return;
+  }
+  if (pageStarted) return;
+  pageStarted = true;
+  pageDeferred = false;
+  automationDocumentId = page.documentId;
   const currentUrl = new URL(window.location.href);
   logger.log(`[Game Window] Logic Dispatcher: ${currentUrl.href}`);
 
@@ -1252,6 +1289,15 @@ async function dispatchPageLogic(triggerContext?: string) {
         requestWindowVisibility(false);
       }
 
+      // Apply the new document's policy before a handler can navigate or await input.
+      const timeout = handler.timeoutMs ?? 10000;
+      sendPageMessage(
+        isValidationMode
+          ? "account:update-timeout"
+          : "automation:update-timeout",
+        timeout,
+      );
+
       // 2. Execute Handler with Context
       try {
         const context: HandlerContext = {
@@ -1266,15 +1312,6 @@ async function dispatchPageLogic(triggerContext?: string) {
         return;
       }
 
-      // 3. Update Timeout in Main Process
-      const timeout =
-        handler.timeoutMs !== undefined ? handler.timeoutMs : 10000;
-
-      if (isValidationMode) {
-        ipcRenderer.send("account:update-timeout", timeout);
-      } else {
-        ipcRenderer.send("automation:update-timeout", timeout);
-      }
       return;
     }
   }
@@ -1288,7 +1325,7 @@ async function dispatchPageLogic(triggerContext?: string) {
       `[Game Window] Unhandled page candidate during automated flow: ${initialHref}. Waiting ${UNHANDLED_PAGE_REVEAL_DELAY_MS}ms before showing.`,
     );
 
-    window.setTimeout(() => {
+    automationClock.setTimeout(() => {
       if (window.location.href !== initialHref) {
         logger.log(
           `[Game Window] Unhandled page reveal skipped: URL changed from ${initialHref} to ${window.location.href}.`,
@@ -1300,7 +1337,7 @@ async function dispatchPageLogic(triggerContext?: string) {
         `[Game Window] UNHANDLED PAGE DETECTED during automated flow: ${initialHref}`,
       );
       // Explicitly bypass local visibility helpers and force main process to show
-      ipcRenderer.send("window-visibility-request", true);
+      sendPageMessage("window-visibility-request", true);
     }, UNHANDLED_PAGE_REVEAL_DELAY_MS);
   }
 }
@@ -1328,6 +1365,13 @@ try {
 }
 
 // --- IPC Listeners ---
+
+ipcRenderer.on("kakao:page-resumed", () => {
+  automationClock.resume();
+  if (pageDeferred) void dispatchPageLogic();
+});
+
+ipcRenderer.on("kakao:page-paused", () => automationClock.pause());
 
 ipcRenderer.on("execute-game-start", (_event, context: GameSessionContext) => {
   logger.log('[Game Window] IPC "execute-game-start" RECEIVED!', context);
@@ -1363,7 +1407,7 @@ window.addEventListener("DOMContentLoaded", async () => {
     logger.log("[Game Window] Background validation mode ACTIVE.");
   }
 
-  dispatchPageLogic(triggerContext);
+  await dispatchPageLogic(triggerContext);
 });
 
 logger.log("[Game Window] Preload Loaded");

--- a/src/main/kakao/session.ts
+++ b/src/main/kakao/session.ts
@@ -2,15 +2,28 @@ import { session } from "electron";
 
 import { setupSessionSecurity } from "../security/permissions";
 
+import type { KakaoChallengeGate } from "./cloudflare-challenge";
+
 export const KAKAO_PARTITION = "persist:kakao_game";
 
 /**
  * Initializes the Kakao Game session partition.
  * Applies security policies and other necessary configurations.
  */
-export function initKakaoSession() {
+export function initKakaoSession(challengeGate: KakaoChallengeGate) {
   const sess = session.fromPartition(KAKAO_PARTITION);
   setupSessionSecurity(sess, KAKAO_PARTITION);
+
+  // Read-only events; keep the independent passkey cancellation listener below.
+  sess.webRequest.onSendHeaders((details) =>
+    challengeGate.requestStarted(details),
+  );
+  sess.webRequest.onResponseStarted((details) =>
+    challengeGate.responseStarted(details),
+  );
+  sess.webRequest.onErrorOccurred((details) =>
+    challengeGate.requestFailed(details),
+  );
 
   // --- FINAL SECURITY: Block Passkey API requests (Kakao Specific) ---
   // This prevents the Kakao login page from even attempting to start the Passkey auth sequence.

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -89,6 +89,7 @@ import {
   startAutomationDumpSession,
   type AutomationDumpArchiveResult,
 } from "./kakao/automation-page-dump";
+import { KakaoChallengeGate } from "./kakao/cloudflare-challenge";
 import { isExpectedNavigationAbort } from "./kakao/navigation-error";
 import { initKakaoSession, KAKAO_PARTITION } from "./kakao/session";
 import { shouldHideReleasedAutomationWindow } from "./kakao/visibility-policy";
@@ -252,15 +253,133 @@ let validationTimeout: NodeJS.Timeout | null = null;
 const VALIDATION_TIMEOUT_MS = 10000; // 10s
 let automationTimeout: NodeJS.Timeout | null = null;
 let lastActiveAutomationWebContentsId: number | null = null; // [New] Track which window last updated the timeout
+let validationOwnerWebContentsId: number | null = null;
+let suspendedValidationOwner: number | null = null;
+let automationTimeoutMs = VALIDATION_TIMEOUT_MS;
+let suspendedAutomation: { id: number; ms: number } | null = null;
+const retiredAutomationWindows = new WeakSet<BrowserWindow>();
+
+const kakaoChallengeGate = new KakaoChallengeGate(
+  (id) => {
+    for (const memberId of kakaoChallengeGate.taskMembers(id)) {
+      const member = webContents.fromId(memberId);
+      if (member && !member.isDestroyed()) member.send("kakao:page-paused");
+    }
+    if (
+      validationOwnerWebContentsId !== null &&
+      kakaoChallengeGate.taskBlocked(validationOwnerWebContentsId)
+    ) {
+      if (validationTimeout) {
+        suspendedValidationOwner = validationOwnerWebContentsId;
+        clearTimeout(validationTimeout);
+      }
+      validationTimeout = null;
+    }
+    if (
+      lastActiveAutomationWebContentsId !== null &&
+      kakaoChallengeGate.taskBlocked(lastActiveAutomationWebContentsId)
+    ) {
+      if (automationTimeout)
+        suspendedAutomation = {
+          id: lastActiveAutomationWebContentsId,
+          ms: automationTimeoutMs,
+        };
+      clearAutomationTimeout(true);
+    }
+    const wc = webContents.fromId(id);
+    const win = wc && BrowserWindow.fromWebContents(wc);
+    if (!win || win.isDestroyed()) return;
+    logger.log(
+      `[Cloudflare] Waiting for user verification in window ${win.id}.`,
+    );
+    win.show();
+    win.focus();
+  },
+  (ids) => {
+    if (
+      suspendedValidationOwner !== null &&
+      ids.includes(suspendedValidationOwner) &&
+      validationModeActive
+    ) {
+      suspendedValidationOwner = null;
+      setValidationMode(true);
+    }
+    if (suspendedAutomation && ids.includes(suspendedAutomation.id)) {
+      startAutomationTimeout(suspendedAutomation.ms);
+    }
+    for (const id of ids) {
+      const wc = webContents.fromId(id);
+      if (!wc || wc.isDestroyed()) continue;
+      wc.send("kakao:page-resumed");
+      const win = BrowserWindow.fromWebContents(wc);
+      if (
+        win &&
+        !forcedVisibleWindows.has(win.id) &&
+        getEffectiveConfig("show_inactive_windows") !== true &&
+        process.env.VITE_SHOW_GAME_WINDOW !== "true"
+      ) {
+        hideAutomationWindow(win, "cloudflare-verification-finished");
+      }
+    }
+  },
+  (ids, successorId) => {
+    const successorContents = webContents.fromId(successorId);
+    const successor =
+      successorContents && BrowserWindow.fromWebContents(successorContents);
+    for (const id of ids) {
+      const wc = webContents.fromId(id);
+      const win = wc && BrowserWindow.fromWebContents(wc);
+      if (win && !win.isDestroyed()) {
+        retiredAutomationWindows.add(win);
+        wc!.send("kakao:page-paused");
+        wc!.stop();
+        hideAutomationWindow(win, "automation-task-replaced");
+        // window.open children normally die with their opener. Empty the retired
+        // document now, and close its window only after the successor is finished.
+        void wc!.loadURL("about:blank").catch(() => {
+          logger.warn(`[Cloudflare] Could not empty retired window ${win.id}.`);
+        });
+        const closeRetired = () => {
+          if (!win.isDestroyed() && retiredAutomationWindows.has(win))
+            win.close();
+        };
+        if (successor && !successor.isDestroyed())
+          successor.once("closed", closeRetired);
+        else closeRetired();
+      }
+    }
+  },
+);
+
+function acceptsKakaoPage(
+  event: Electron.IpcMainEvent | Electron.IpcMainInvokeEvent,
+  documentId?: number | null,
+) {
+  if (event.sender.session !== session.fromPartition(KAKAO_PARTITION))
+    return true;
+  return (
+    event.senderFrame === event.sender.mainFrame &&
+    kakaoChallengeGate.accepts(event.sender.id, documentId)
+  );
+}
 
 // [New] Safety Cleanup for Automation Tracking
 app.on("web-contents-created", (_, wc) => {
+  wc.on("did-start-navigation", (_event, _url, isInPlace, isMainFrame) => {
+    if (isMainFrame && !isInPlace) kakaoChallengeGate.beginNavigation(wc.id);
+  });
+  wc.on("did-navigate", (_event, url) => kakaoChallengeGate.commit(wc.id, url));
   wc.on("destroyed", () => {
+    if (validationOwnerWebContentsId === wc.id) {
+      setValidationMode(false);
+      validationOwnerWebContentsId = null;
+    }
     if (lastActiveAutomationWebContentsId === wc.id) {
       logger.log(
         `[Main] Clearing lastActiveAutomationWebContentsId ${wc.id} (Destroyed)`,
       );
       lastActiveAutomationWebContentsId = null;
+      clearAutomationTimeout();
     }
     // navigationTriggerContexts is not globally available here but we can use the helper
     setNavigationTrigger(wc.id, null);
@@ -315,13 +434,25 @@ async function resizeToFitContent(win: BrowserWindow) {
 
 function setValidationMode(active: boolean) {
   validationModeActive = active;
+  if (!active) suspendedValidationOwner = null;
   if (validationTimeout) {
     clearTimeout(validationTimeout);
     validationTimeout = null;
   }
 
-  if (active) {
+  if (
+    active &&
+    !(
+      validationOwnerWebContentsId !== null &&
+      kakaoChallengeGate.taskBlocked(validationOwnerWebContentsId)
+    )
+  ) {
     validationTimeout = setTimeout(() => {
+      if (
+        validationOwnerWebContentsId !== null &&
+        kakaoChallengeGate.taskBlocked(validationOwnerWebContentsId)
+      )
+        return;
       const currentUrl =
         gameWindow && !gameWindow.isDestroyed()
           ? gameWindow.webContents.getURL()
@@ -345,7 +476,8 @@ function setValidationMode(active: boolean) {
   }
 }
 
-function clearAutomationTimeout() {
+function clearAutomationTimeout(preserveSuspension = false) {
+  if (!preserveSuspension) suspendedAutomation = null;
   if (automationTimeout) {
     clearTimeout(automationTimeout);
     automationTimeout = null;
@@ -354,6 +486,13 @@ function clearAutomationTimeout() {
 
 function startAutomationTimeout(ms: number = VALIDATION_TIMEOUT_MS) {
   clearAutomationTimeout();
+  automationTimeoutMs = ms;
+
+  if (
+    lastActiveAutomationWebContentsId !== null &&
+    kakaoChallengeGate.taskBlocked(lastActiveAutomationWebContentsId)
+  )
+    return;
 
   if (ms === -1) {
     logger.log("[Automation] Process timer DISABLED (infinite wait).");
@@ -361,6 +500,11 @@ function startAutomationTimeout(ms: number = VALIDATION_TIMEOUT_MS) {
   }
 
   automationTimeout = setTimeout(async () => {
+    if (
+      lastActiveAutomationWebContentsId !== null &&
+      kakaoChallengeGate.taskBlocked(lastActiveAutomationWebContentsId)
+    )
+      return;
     // [Getter Logic] Determine which window to show for the timeout
     let targetWindow = gameWindow;
 
@@ -448,6 +592,7 @@ registerGameStatusIpc({
   getAppContext: () => appContext,
   getActiveSessionContext: () => gameSessionTracker.getActiveSessionContext(),
   getWindowContext: (webContentsId) => windowContextMap.get(webContentsId),
+  acceptsPage: acceptsKakaoPage,
 });
 
 // --- Single Instance Lock ---
@@ -643,7 +788,12 @@ ipcMain.on("debug-log:send", (_event, log: DebugLogPayload) => {
 
 ipcMain.on(
   "kakao:automation-failure",
-  async (event, payload: KakaoAutomationFailurePayload) => {
+  async (
+    event,
+    payload: KakaoAutomationFailurePayload,
+    documentId?: number | null,
+  ) => {
+    if (!acceptsKakaoPage(event, documentId)) return;
     if (!appContext) return;
 
     const senderId = event.sender.id;
@@ -1383,7 +1533,19 @@ const navigationTriggerContexts = new Map<number, string>();
 function setNavigationTrigger(
   webContentsId: number,
   trigger: string | null | undefined,
+  parentId?: number,
 ) {
+  if (trigger && parentId === undefined) {
+    const wc = webContents.fromId(webContentsId);
+    const selectedWindow = wc && BrowserWindow.fromWebContents(wc);
+    if (selectedWindow && !selectedWindow.isDestroyed()) {
+      // An explicit new task owns this window, including a reused popup.
+      retiredAutomationWindows.delete(selectedWindow);
+      gameWindow = selectedWindow;
+      if (appContext) appContext.gameWindow = selectedWindow;
+    }
+  }
+  kakaoChallengeGate.setTrigger(webContentsId, trigger ?? null, parentId);
   if (trigger) {
     logger.log(`[Context] WebContents ${webContentsId} marked as: ${trigger}`);
     navigationTriggerContexts.set(webContentsId, trigger);
@@ -1411,6 +1573,16 @@ ipcMain.handle("account:get-trigger-context", (event) => {
   return context;
 });
 
+ipcMain.handle("kakao:get-page-state", (event) => {
+  if (
+    event.sender.session !== session.fromPartition(KAKAO_PARTITION) ||
+    event.senderFrame !== event.sender.mainFrame
+  ) {
+    return { blocked: true, documentId: null };
+  }
+  return kakaoChallengeGate.pageState(event.sender.id);
+});
+
 // Cache for specific login URLs encountered during validation
 const pendingLoginUrls = new Map<string, string>(); // ServiceId -> URL
 
@@ -1424,7 +1596,8 @@ ipcMain.on("account:clear-pending-login", (_event, serviceId?: string) => {
   }
 });
 
-ipcMain.on("account:clear-trigger", (event) => {
+ipcMain.on("account:clear-trigger", (event, documentId?: number | null) => {
+  if (!acceptsKakaoPage(event, documentId)) return;
   logger.log(`[Context] Clearing trigger context for ${event.sender.id}`);
   navigationTriggerContexts.delete(event.sender.id);
 });
@@ -1437,7 +1610,10 @@ const isNavigating = new Set<string>();
 async function runAccountValidation(serviceId: AppConfig["serviceChannel"]) {
   if (serviceId !== "Kakao Games") return; // GGG not implemented yet
 
-  if (isNavigating.has(serviceId)) {
+  if (
+    isNavigating.has(serviceId) ||
+    kakaoChallengeGate.hasChallenge("ACCOUNT_VALIDATION")
+  ) {
     logger.log(
       `[Account] Validation already in progress for ${serviceId}. Ignoring.`,
     );
@@ -1446,7 +1622,6 @@ async function runAccountValidation(serviceId: AppConfig["serviceChannel"]) {
 
   logger.log(`[Account] Triggering validation for ${serviceId}...`);
   isNavigating.add(serviceId);
-  setValidationMode(true);
 
   if (!appContext) {
     isNavigating.delete(serviceId);
@@ -1462,6 +1637,8 @@ async function runAccountValidation(serviceId: AppConfig["serviceChannel"]) {
   // Mark the game window for validation
   if (gw && !gw.isDestroyed()) {
     setNavigationTrigger(gw.webContents.id, "ACCOUNT_VALIDATION");
+    validationOwnerWebContentsId = gw.webContents.id;
+    setValidationMode(true);
 
     try {
       // DO NOT show window yet
@@ -1491,7 +1668,12 @@ async function runAccountValidation(serviceId: AppConfig["serviceChannel"]) {
 
 ipcMain.on(
   "account:trigger-validation",
-  (_event, serviceId: AppConfig["serviceChannel"]) => {
+  (
+    event,
+    serviceId: AppConfig["serviceChannel"],
+    documentId?: number | null,
+  ) => {
+    if (!acceptsKakaoPage(event, documentId)) return;
     runAccountValidation(serviceId).catch((err) =>
       logger.error("[Account] Error running validation:", err),
     );
@@ -1556,78 +1738,94 @@ ipcMain.on(
   },
 );
 
-ipcMain.on("kakao:account-id-fetched", (_event, id: string) => {
-  logger.log(`[Account] Fetched ID for Kakao: ${id}`);
-  setValidationMode(false);
+ipcMain.on(
+  "kakao:account-id-fetched",
+  (event, id: string, documentId?: number | null) => {
+    if (!acceptsKakaoPage(event, documentId)) return;
+    logger.log(`[Account] Fetched ID for Kakao: ${id}`);
+    setValidationMode(false);
 
-  // Update Config Cache
-  const config = getConfig() as AppConfig;
-  config.kakaoAccountId = id;
-  setConfigWithEvent("kakaoAccountId", id);
+    // Update Config Cache
+    const config = getConfig() as AppConfig;
+    config.kakaoAccountId = id;
+    setConfigWithEvent("kakaoAccountId", id);
 
-  // Notify Renderer
-  if (mainWindow && !mainWindow.isDestroyed()) {
-    mainWindow.webContents.send("account:updated", { id });
-  }
+    // Notify Renderer
+    if (mainWindow && !mainWindow.isDestroyed()) {
+      mainWindow.webContents.send("account:updated", { id });
+    }
 
-  // Close hidden window if successful
-  if (gameWindow && !gameWindow.isDestroyed()) {
-    gameWindow.close();
-  }
-});
-
-ipcMain.on("kakao:login-required", (event, data?: { url?: string }) => {
-  logger.log("[Account] Login required for Kakao.");
-
-  // If URL is provided during validation failure, 'keep' it for later
-  if (data?.url) {
-    logger.log(`[Account] Caching redirect URL for sync login: ${data.url}`);
-    pendingLoginUrls.set("Kakao Games", data.url);
-  }
-
-  if (mainWindow && !mainWindow.isDestroyed()) {
-    mainWindow.webContents.send("account:updated", { loginRequired: true });
-  }
-
-  // Explicitly disable timeout when login is required to allow user to interact
-  setValidationMode(false);
-
-  // [Refinement] Close the background validation window if it's no longer needed
-  // (User will explicitly open it via "Login" button if they want to)
-  if (gameWindow && !gameWindow.isDestroyed()) {
-    const context = getNavigationTrigger(gameWindow.webContents.id);
-    if (context === "ACCOUNT_VALIDATION") {
-      logger.log(
-        "[Account] Closing background validation window (Login Required).",
-      );
+    // Close hidden window if successful
+    if (gameWindow && !gameWindow.isDestroyed()) {
       gameWindow.close();
     }
-  }
-});
+  },
+);
 
-ipcMain.on("automation:update-timeout", (event, timeoutMs: number) => {
-  lastActiveAutomationWebContentsId = event.sender.id; // Correctly track the caller
-  startAutomationTimeout(timeoutMs);
-  logger.log(
-    `[Automation] Timer updated: ${timeoutMs}ms (Caller: ${event.sender.id})`,
-  );
-});
+ipcMain.on(
+  "kakao:login-required",
+  (event, data?: { url?: string }, documentId?: number | null) => {
+    if (!acceptsKakaoPage(event, documentId)) return;
+    logger.log("[Account] Login required for Kakao.");
 
-ipcMain.on("account:update-timeout", (event, timeoutMs: number) => {
-  if (validationModeActive) {
-    lastActiveAutomationWebContentsId = event.sender.id; // Track even in validation
-    if (timeoutMs === -1) {
-      if (validationTimeout) {
-        clearTimeout(validationTimeout);
-        validationTimeout = null;
-      }
-      logger.log("[Account] Background validation timer paused.");
-    } else {
-      setValidationMode(true);
-      logger.log("[Account] Background validation timer refreshed.");
+    // If URL is provided during validation failure, 'keep' it for later
+    if (data?.url) {
+      logger.log(`[Account] Caching redirect URL for sync login: ${data.url}`);
+      pendingLoginUrls.set("Kakao Games", data.url);
     }
-  }
-});
+
+    if (mainWindow && !mainWindow.isDestroyed()) {
+      mainWindow.webContents.send("account:updated", { loginRequired: true });
+    }
+
+    // Explicitly disable timeout when login is required to allow user to interact
+    setValidationMode(false);
+
+    // [Refinement] Close the background validation window if it's no longer needed
+    // (User will explicitly open it via "Login" button if they want to)
+    if (gameWindow && !gameWindow.isDestroyed()) {
+      const context = getNavigationTrigger(gameWindow.webContents.id);
+      if (context === "ACCOUNT_VALIDATION") {
+        logger.log(
+          "[Account] Closing background validation window (Login Required).",
+        );
+        gameWindow.close();
+      }
+    }
+  },
+);
+
+ipcMain.on(
+  "automation:update-timeout",
+  (event, timeoutMs: number, documentId?: number | null) => {
+    if (!acceptsKakaoPage(event, documentId)) return;
+    lastActiveAutomationWebContentsId = event.sender.id; // Correctly track the caller
+    startAutomationTimeout(timeoutMs);
+    logger.log(
+      `[Automation] Timer updated: ${timeoutMs}ms (Caller: ${event.sender.id})`,
+    );
+  },
+);
+
+ipcMain.on(
+  "account:update-timeout",
+  (event, timeoutMs: number, documentId?: number | null) => {
+    if (!acceptsKakaoPage(event, documentId)) return;
+    if (validationModeActive) {
+      validationOwnerWebContentsId = event.sender.id;
+      if (timeoutMs === -1) {
+        if (validationTimeout) {
+          clearTimeout(validationTimeout);
+          validationTimeout = null;
+        }
+        logger.log("[Account] Background validation timer paused.");
+      } else {
+        setValidationMode(true);
+        logger.log("[Account] Background validation timer refreshed.");
+      }
+    }
+  },
+);
 
 // --- Shared Window Open Handler Factory ---
 const createHandleWindowOpen =
@@ -1673,6 +1871,7 @@ const forcedVisibleWindows = new Set<number>();
 
 function hideAutomationWindow(window: BrowserWindow, reason: string) {
   if (!window || window.isDestroyed()) return;
+  if (kakaoChallengeGate.isVisible(window.webContents.id)) return;
 
   const isMainWindow =
     context.mainWindow && context.mainWindow.id === window.id;
@@ -1697,68 +1896,72 @@ function hideAutomationWindow(window: BrowserWindow, reason: string) {
 }
 
 // [IPC] Dynamic Visibility Request from Preload
-ipcMain.on("window-visibility-request", async (event, isVisible: boolean) => {
-  const window = BrowserWindow.fromWebContents(event.sender);
-  if (!window || window.isDestroyed()) return;
+ipcMain.on(
+  "window-visibility-request",
+  async (event, isVisible: boolean, documentId?: number | null) => {
+    if (!acceptsKakaoPage(event, documentId)) return;
+    const window = BrowserWindow.fromWebContents(event.sender);
+    if (!window || window.isDestroyed()) return;
 
-  const showInactive = getEffectiveConfig("show_inactive_windows") === true;
-  const isDebugEnv = process.env.VITE_SHOW_GAME_WINDOW === "true";
-  const triggerContext = getNavigationTrigger(event.sender.id);
-  const isValidation = triggerContext === "ACCOUNT_VALIDATION";
+    const showInactive = getEffectiveConfig("show_inactive_windows") === true;
+    const isDebugEnv = process.env.VITE_SHOW_GAME_WINDOW === "true";
+    const triggerContext = getNavigationTrigger(event.sender.id);
+    const isValidation = triggerContext === "ACCOUNT_VALIDATION";
 
-  if (isVisible) {
-    if (isValidation) {
-      logger.log(
-        `[Main] Window ${window.id} requested visibility but SUPPRESSED (Validation Mode).`,
-      );
-      return;
-    }
-
-    if (!forcedVisibleWindows.has(window.id)) {
-      forcedVisibleWindows.add(window.id);
-      logger.log(`[Main] Window ${window.id} requested FORCED VISIBILITY.`);
-    }
-
-    if (!window.isVisible()) {
-      window.show();
-    }
-    // [v22] Adjust size with 0.1s delay
-    await resizeToFitContent(window);
-    window.center();
-    window.focus();
-    window.moveTop();
-    await dumpAutomationPage(window, {
-      reason: "window-visibility-request",
-      triggerContext: triggerContext ?? undefined,
-      mainWindow,
-      debugWindow,
-    });
-  } else {
-    if (forcedVisibleWindows.has(window.id)) {
-      forcedVisibleWindows.delete(window.id);
-      logger.log(`[Main] Window ${window.id} released FORCED VISIBILITY.`);
-
-      const isMainWindow =
-        context.mainWindow && context.mainWindow.id === window.id;
-      const isDebugWindow =
-        context.debugWindow && context.debugWindow.id === window.id;
-
-      if (
-        shouldHideReleasedAutomationWindow({
-          showInactive,
-          isDebugEnv,
-          isMainWindow: Boolean(isMainWindow),
-          isDebugWindow: Boolean(isDebugWindow),
-        })
-      ) {
+    if (isVisible) {
+      if (isValidation) {
         logger.log(
-          `[Main] Hiding window ${window.id} (Visibility released & inactive display disabled)`,
+          `[Main] Window ${window.id} requested visibility but SUPPRESSED (Validation Mode).`,
         );
-        window.hide();
+        return;
+      }
+
+      if (!forcedVisibleWindows.has(window.id)) {
+        forcedVisibleWindows.add(window.id);
+        logger.log(`[Main] Window ${window.id} requested FORCED VISIBILITY.`);
+      }
+
+      if (!window.isVisible()) {
+        window.show();
+      }
+      // [v22] Adjust size with 0.1s delay
+      await resizeToFitContent(window);
+      window.center();
+      window.focus();
+      window.moveTop();
+      await dumpAutomationPage(window, {
+        reason: "window-visibility-request",
+        triggerContext: triggerContext ?? undefined,
+        mainWindow,
+        debugWindow,
+      });
+    } else {
+      if (forcedVisibleWindows.has(window.id)) {
+        forcedVisibleWindows.delete(window.id);
+        logger.log(`[Main] Window ${window.id} released FORCED VISIBILITY.`);
+
+        const isMainWindow =
+          context.mainWindow && context.mainWindow.id === window.id;
+        const isDebugWindow =
+          context.debugWindow && context.debugWindow.id === window.id;
+
+        if (
+          shouldHideReleasedAutomationWindow({
+            showInactive,
+            isDebugEnv,
+            isMainWindow: Boolean(isMainWindow),
+            isDebugWindow: Boolean(isDebugWindow),
+          })
+        ) {
+          logger.log(
+            `[Main] Hiding window ${window.id} (Visibility released & inactive display disabled)`,
+          );
+          window.hide();
+        }
       }
     }
-  }
-});
+  },
+);
 
 // Global Context
 let appContext: AppContext;
@@ -1801,10 +2004,12 @@ const ensureGameWindow = (options?: { service: string }) => {
     if (appContext) appContext.gameWindow = gameWindow;
 
     // Handle closing
-    gameWindow.on("closed", () => {
-      resetGameStatusIfInterrupted(gameWindow!);
-      gameWindow = null;
-      if (appContext) appContext.gameWindow = null;
+    const createdWindow = gameWindow;
+    createdWindow.on("closed", () => {
+      resetGameStatusIfInterrupted(createdWindow);
+      if (gameWindow === createdWindow) gameWindow = null;
+      if (appContext?.gameWindow === createdWindow)
+        appContext.gameWindow = null;
     });
   }
   return gameWindow!;
@@ -1818,7 +2023,11 @@ const context: AppContext = {
 
   store,
   serviceManager: serviceManager as IServiceManager,
-  isForcedVisible: (windowId: number) => forcedVisibleWindows.has(windowId),
+  isForcedVisible: (windowId: number) =>
+    forcedVisibleWindows.has(windowId) ||
+    kakaoChallengeGate.isVisible(
+      BrowserWindow.fromId(windowId)?.webContents.id ?? -1,
+    ),
   hideAutomationWindow,
   ensureGameWindow: ensureGameWindow,
   getConfig: (key?: string) => getEffectiveConfig(key),
@@ -1840,6 +2049,7 @@ const context: AppContext = {
 };
 
 function resetGameStatusIfInterrupted(_win: BrowserWindow) {
+  if (retiredAutomationWindows.has(_win)) return;
   const resetStatus = gameSessionTracker.getInterruptedResetStatus(appContext);
 
   if (!resetStatus) {
@@ -2273,7 +2483,9 @@ async function createWindow() {
 
       if (visible) {
         // Removed isUserFacingPage: Visibility is now controlled by Preload IPC or Inactive Config
-        const shouldShowWindow = isDebugMode && showInactiveWindows;
+        const shouldShowWindow =
+          (isDebugMode && showInactiveWindows) ||
+          kakaoChallengeGate.isVisible(win.webContents.id);
 
         if (shouldShowWindow && !win.isVisible()) {
           win.show();
@@ -2370,7 +2582,7 @@ async function createWindow() {
   setupSessionSecurity(session.defaultSession, "default");
 
   // Initialize Kakao Partition (Security & Config)
-  initKakaoSession();
+  initKakaoSession(kakaoChallengeGate);
 
   // Apply to GGG Partition (if exists)
   if (PARTITIONS.GGG) {
@@ -3089,7 +3301,9 @@ app.on("browser-window-created", (_, window) => {
         );
         // Fallback to previous window if it's still alive, otherwise null
         const fallbackWindow =
-          previousGameWindow && !previousGameWindow.isDestroyed()
+          previousGameWindow &&
+          !previousGameWindow.isDestroyed() &&
+          !retiredAutomationWindows.has(previousGameWindow)
             ? previousGameWindow
             : null;
 
@@ -3133,7 +3347,9 @@ app.on("browser-window-created", (_, window) => {
 
     // 1. Determine if window should be shown (Central Policy)
     // Removed isUserFacingPage: Visibility is now controlled by Preload IPC or Inactive Config
-    const isForcedVisible = forcedVisibleWindows.has(window.id);
+    const isForcedVisible =
+      forcedVisibleWindows.has(window.id) ||
+      kakaoChallengeGate.isVisible(window.webContents.id);
 
     // Priority: Forced > DebugEnv > InactiveConfig
     // Note: ForcedVisible might not be set yet during initial load (Preload not run yet)
@@ -3212,7 +3428,7 @@ app.on("web-contents-created", (_, wc) => {
       logger.log(
         `[Context] Propagating trigger '${parentContext}' from ${wc.id} -> ${window.webContents.id}`,
       );
-      setNavigationTrigger(window.webContents.id, parentContext);
+      setNavigationTrigger(window.webContents.id, parentContext, wc.id);
     }
   });
 });

--- a/src/main/tests/game-status-ipc.test.ts
+++ b/src/main/tests/game-status-ipc.test.ts
@@ -35,6 +35,22 @@ describe("registerGameStatusIpc", () => {
     vi.clearAllMocks();
   });
 
+  it("does not accept game status from a deferred or stale Kakao document", () => {
+    registerGameStatusIpc({
+      getAppContext: () => ({}) as AppContext,
+      getActiveSessionContext: () => null,
+      getWindowContext: () => undefined,
+      acceptsPage: () => false,
+    });
+    getRegisteredListener("game-status-update")(
+      { sender: { id: 42 } } as IpcMainEvent,
+      "ready",
+      null,
+      7,
+    );
+    expect(eventBus.emit).not.toHaveBeenCalled();
+  });
+
   it("registers game status IPC channels", () => {
     registerGameStatusIpc({
       getAppContext: () => ({}) as AppContext,

--- a/src/main/tests/kakao-cloudflare-challenge.test.ts
+++ b/src/main/tests/kakao-cloudflare-challenge.test.ts
@@ -1,0 +1,228 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { KakaoChallengeGate } from "../kakao/cloudflare-challenge";
+
+const url = "https://poe.kakaogames.com/#validateLogin";
+const challenge = { "Cf-Mitigated": ["challenge"] };
+
+function setup(trigger = "ACCOUNT_VALIDATION") {
+  const onChallenge = vi.fn();
+  const gate = new KakaoChallengeGate(onChallenge);
+  gate.setTrigger(1, trigger);
+  return { gate, onChallenge };
+}
+
+function respond(
+  gate: KakaoChallengeGate,
+  id: number,
+  headers: Record<string, string[]> = challenge,
+  webContentsId = 1,
+  target = url,
+) {
+  gate.requestStarted({
+    id,
+    webContentsId,
+    url: target,
+    resourceType: "mainFrame",
+  });
+  gate.responseStarted({
+    id,
+    webContentsId,
+    url: target,
+    resourceType: "mainFrame",
+    statusCode: 403,
+    responseHeaders: headers,
+  });
+}
+
+describe("Kakao Cloudflare challenge gate", () => {
+  it("resumes a waiting sibling when the last challenge in its task finishes", () => {
+    const resumed = vi.fn();
+    const gate = new KakaoChallengeGate(vi.fn(), resumed);
+    gate.setTrigger(1, "GAME_START_POE1");
+    respond(gate, 1, {});
+    gate.commit(1, url);
+    gate.setTrigger(2, "GAME_START_POE1", 1);
+    respond(gate, 2, challenge, 2);
+    gate.commit(2, url);
+    expect(gate.pageState(1).blocked).toBe(true);
+    gate.beginNavigation(2);
+    respond(gate, 3, {}, 2);
+    gate.commit(2, url);
+    expect(resumed).toHaveBeenCalledExactlyOnceWith([1, 2]);
+    expect(gate.pageState(1).blocked).toBe(false);
+  });
+
+  it("retires the previous task's popups when a new task takes over", () => {
+    const { gate } = setup();
+    gate.setTrigger(2, "ACCOUNT_VALIDATION", 1);
+    respond(gate, 1, {}, 2);
+    gate.commit(2, url);
+    const oldDocument = gate.pageState(2).documentId;
+    gate.setTrigger(3, "ACCOUNT_VALIDATION", 1);
+    respond(gate, 2, challenge, 3);
+    gate.setTrigger(1, "GAME_START_POE2");
+    expect(gate.hasChallenge("ACCOUNT_VALIDATION")).toBe(false);
+    expect(gate.accepts(2, oldDocument)).toBe(false);
+    expect(gate.pageState(2).blocked).toBe(true);
+    expect(gate.isVisible(3)).toBe(false);
+  });
+
+  it("restores the committed normal document if the first challenge response is cancelled", () => {
+    const { gate } = setup();
+    respond(gate, 1, {});
+    gate.commit(1, url);
+    const documentId = gate.pageState(1).documentId;
+    gate.beginNavigation(1);
+    respond(gate, 2);
+    gate.requestFailed({ id: 2, webContentsId: 1 });
+    expect(gate.isVisible(1)).toBe(false);
+    expect(gate.accepts(1, documentId)).toBe(true);
+  });
+  it("blocks a challenge before page handlers and notifies only once", () => {
+    const { gate, onChallenge } = setup();
+    respond(gate, 10);
+    gate.commit(1, url);
+    expect(gate.pageState(1).blocked).toBe(true);
+    expect(gate.isVisible(1)).toBe(true);
+    respond(gate, 11);
+    expect(onChallenge).toHaveBeenCalledExactlyOnceWith(1);
+  });
+
+  it.each(["GAME_START_POE1", "GAME_START_POE2", "ACCOUNT_MANUAL_LOGIN"])(
+    "covers %s",
+    (trigger) => {
+      const { gate } = setup(trigger);
+      respond(
+        gate,
+        1,
+        challenge,
+        1,
+        "https://pathofexile2.kakaogames.com/main#autoStart",
+      );
+      expect(gate.isVisible(1)).toBe(true);
+    },
+  );
+
+  it("does not treat a plain 403 or a title as a challenge", () => {
+    const { gate } = setup();
+    respond(gate, 1, { server: ["cloudflare"], title: ["Just a moment..."] });
+    gate.commit(1, url);
+    expect(gate.isVisible(1)).toBe(false);
+    expect(gate.pageState(1).blocked).toBe(false);
+  });
+
+  it.each(["subFrame", "xhr"])("ignores %s challenges", (resourceType) => {
+    const { gate } = setup();
+    gate.requestStarted({ id: 1, webContentsId: 1, url, resourceType });
+    gate.responseStarted({
+      id: 1,
+      webContentsId: 1,
+      url,
+      resourceType,
+      statusCode: 403,
+      responseHeaders: challenge,
+    });
+    expect(gate.isVisible(1)).toBe(false);
+  });
+
+  it.each([
+    "https://unrelated.example/",
+    "https://poe.kakaogames.com.evil.example/",
+    "http://poe.kakaogames.com/",
+  ])("ignores unapproved host/protocol %s", (target) => {
+    const { gate } = setup();
+    respond(gate, 1, challenge, 1, target);
+    expect(gate.isVisible(1)).toBe(false);
+  });
+
+  it("does not reveal a window without an automation trigger", () => {
+    const gate = new KakaoChallengeGate(vi.fn());
+    respond(gate, 1);
+    expect(gate.isVisible(1)).toBe(false);
+  });
+
+  it("keeps the challenge through navigation, redirects and headers until normal document commit", () => {
+    const { gate } = setup();
+    respond(gate, 1);
+    gate.commit(1, url);
+    gate.beginNavigation(1);
+    gate.requestStarted({
+      id: 2,
+      webContentsId: 1,
+      url,
+      resourceType: "mainFrame",
+    });
+    gate.responseStarted({
+      id: 2,
+      webContentsId: 1,
+      url,
+      resourceType: "mainFrame",
+      statusCode: 302,
+      responseHeaders: {},
+    });
+    gate.commit(1, url);
+    expect(gate.isVisible(1)).toBe(true);
+    respond(gate, 2, {});
+    expect(gate.isVisible(1)).toBe(true);
+    gate.commit(1, url);
+    expect(gate.isVisible(1)).toBe(false);
+    expect(gate.pageState(1).blocked).toBe(false);
+  });
+
+  it("ignores late responses and document messages from an older navigation or task", () => {
+    const { gate } = setup();
+    respond(gate, 1, {});
+    gate.commit(1, url);
+    const oldDocument = gate.pageState(1).documentId;
+    expect(gate.accepts(1, oldDocument)).toBe(true);
+    gate.beginNavigation(1);
+    respond(gate, 2);
+    gate.responseStarted({
+      id: 1,
+      webContentsId: 1,
+      url,
+      resourceType: "mainFrame",
+      statusCode: 200,
+      responseHeaders: {},
+    });
+    gate.commit(1, url);
+    expect(gate.isVisible(1)).toBe(true);
+    expect(gate.accepts(1, oldDocument)).toBe(false);
+    gate.setTrigger(1, "GAME_START_POE2");
+    gate.responseStarted({
+      id: 2,
+      webContentsId: 1,
+      url,
+      resourceType: "mainFrame",
+      statusCode: 403,
+      responseHeaders: challenge,
+    });
+    expect(gate.isVisible(1)).toBe(false);
+    expect(gate.accepts(1, oldDocument)).toBe(false);
+  });
+
+  it("pauses a popup's task without affecting another task and cleans up closed windows", () => {
+    const { gate } = setup();
+    gate.setTrigger(2, "ACCOUNT_VALIDATION", 1);
+    gate.setTrigger(3, "GAME_START_POE2");
+    respond(gate, 10, challenge, 2);
+    expect(gate.taskBlocked(1)).toBe(true);
+    expect(gate.taskBlocked(3)).toBe(false);
+    expect(gate.hasChallenge("ACCOUNT_VALIDATION")).toBe(true);
+    gate.remove(2);
+    expect(gate.taskBlocked(1)).toBe(false);
+    expect(gate.hasChallenge("ACCOUNT_VALIDATION")).toBe(false);
+  });
+
+  it("preserves a displayed challenge when a replacement request is cancelled", () => {
+    const { gate } = setup();
+    respond(gate, 1);
+    gate.commit(1, url);
+    gate.beginNavigation(1);
+    respond(gate, 2, {});
+    gate.requestFailed({ id: 2, webContentsId: 1 });
+    gate.commit(1, url);
+    expect(gate.isVisible(1)).toBe(true);
+  });
+});

--- a/src/main/tests/kakao-cloudflare-preload.test.ts
+++ b/src/main/tests/kakao-cloudflare-preload.test.ts
@@ -1,0 +1,153 @@
+// @vitest-environment-options {"url":"https://poe.kakaogames.com/"}
+import { ipcRenderer } from "electron";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("electron", () => ({
+  ipcRenderer: { send: vi.fn(), invoke: vi.fn(), on: vi.fn() },
+}));
+vi.mock("../utils/preload-logger", () => ({
+  logger: { log: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+async function loadPage(trigger: string, blocked: boolean) {
+  vi.mocked(ipcRenderer.invoke).mockImplementation(async (channel) => {
+    if (channel === "kakao:get-page-state") return { blocked, documentId: 7 };
+    if (channel === "account:get-trigger-context") return trigger;
+  });
+  let ready: (() => Promise<void>) | undefined;
+  vi.spyOn(window, "addEventListener").mockImplementation((event, listener) => {
+    if (event === "DOMContentLoaded") ready = listener as () => Promise<void>;
+  });
+  await import("../kakao/preload");
+  await ready?.();
+  await vi.advanceTimersByTimeAsync(0);
+}
+
+describe("Cloudflare preload dispatch", () => {
+  it("pauses an existing parent's account observer while a child needs verification", async () => {
+    window.history.replaceState({}, "", "/#validateLogin");
+    await loadPage("ACCOUNT_VALIDATION", false);
+    const paused = vi
+      .mocked(ipcRenderer.on)
+      .mock.calls.find(([channel]) => channel === "kakao:page-paused")?.[1];
+    const resumed = vi
+      .mocked(ipcRenderer.on)
+      .mock.calls.find(([channel]) => channel === "kakao:page-resumed")?.[1];
+    paused?.({} as Electron.IpcRendererEvent);
+    await vi.advanceTimersByTimeAsync(20000);
+    document.body.innerHTML =
+      '<div class="kg-ggb__btn--my-info"><em>fixture</em></div><div id="statusBar"><div class="statusItem loggedInStatus"><div class="profile-link"><a>fixture-account</a></div></div></div>';
+    await vi.advanceTimersByTimeAsync(0);
+    expect(ipcRenderer.send).not.toHaveBeenCalledWith(
+      "kakao:account-id-fetched",
+      "fixture-account",
+      7,
+    );
+    resumed?.({} as Electron.IpcRendererEvent);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(ipcRenderer.send).toHaveBeenCalledWith(
+      "kakao:account-id-fetched",
+      "fixture-account",
+      7,
+    );
+  });
+
+  it("excludes verification time from an already scheduled login-required delay", async () => {
+    window.history.replaceState({}, "", "/login");
+    await loadPage("ACCOUNT_VALIDATION", false);
+    await vi.advanceTimersByTimeAsync(3000);
+    vi.mocked(ipcRenderer.on).mock.calls.find(
+      ([channel]) => channel === "kakao:page-paused",
+    )?.[1]({} as Electron.IpcRendererEvent);
+    await vi.advanceTimersByTimeAsync(20000);
+    expect(
+      vi
+        .mocked(ipcRenderer.send)
+        .mock.calls.some(([channel]) => channel === "kakao:login-required"),
+    ).toBe(false);
+    vi.mocked(ipcRenderer.on).mock.calls.find(
+      ([channel]) => channel === "kakao:page-resumed",
+    )?.[1]({} as Electron.IpcRendererEvent);
+    await vi.advanceTimersByTimeAsync(4999);
+    expect(
+      vi
+        .mocked(ipcRenderer.send)
+        .mock.calls.some(([channel]) => channel === "kakao:login-required"),
+    ).toBe(false);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(
+      vi
+        .mocked(ipcRenderer.send)
+        .mock.calls.some(([channel]) => channel === "kakao:login-required"),
+    ).toBe(true);
+  });
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    document.body.innerHTML = "";
+  });
+  afterEach(async () => {
+    await vi.advanceTimersByTimeAsync(11000);
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it.each([
+    ["GAME_START_POE1", "/#autoStart"],
+    ["ACCOUNT_VALIDATION", "/login?__cf_chl_rt_tk=fixture"],
+    ["ACCOUNT_MANUAL_LOGIN", "/"],
+  ])(
+    "defers %s handlers and their timers while challenged",
+    async (trigger, path) => {
+      window.history.replaceState({}, "", path);
+      await loadPage(trigger, true);
+      await vi.advanceTimersByTimeAsync(20000);
+      expect(ipcRenderer.send).not.toHaveBeenCalled();
+    },
+  );
+
+  it("runs the original game handler on the next normal document", async () => {
+    window.history.replaceState({}, "", "/#autoStart");
+    document.body.innerHTML = '<button id="signupButton">시작</button>';
+    const clicked = vi.fn();
+    document.querySelector("button")!.addEventListener("click", clicked);
+    await loadPage("GAME_START_POE1", false);
+    expect(clicked).toHaveBeenCalledOnce();
+    expect(ipcRenderer.send).toHaveBeenCalledWith(
+      "automation:update-timeout",
+      10000,
+      7,
+    );
+  });
+
+  it("keeps a normal account validation handler's disabled timeout", async () => {
+    window.history.replaceState({}, "", "/#validateLogin");
+    await loadPage("ACCOUNT_VALIDATION", false);
+    expect(ipcRenderer.send).toHaveBeenCalledWith(
+      "account:update-timeout",
+      -1,
+      7,
+    );
+  });
+
+  it("retries a deferred document when a sibling is verified, without executing twice", async () => {
+    window.history.replaceState({}, "", "/#autoStart");
+    document.body.innerHTML = '<button id="signupButton">시작</button>';
+    const clicked = vi.fn();
+    document.querySelector("button")!.addEventListener("click", clicked);
+    await loadPage("GAME_START_POE1", true);
+    vi.mocked(ipcRenderer.invoke).mockImplementation(async (channel) =>
+      channel === "kakao:get-page-state"
+        ? { blocked: false, documentId: 7 }
+        : "GAME_START_POE1",
+    );
+    const resume = vi
+      .mocked(ipcRenderer.on)
+      .mock.calls.find(([channel]) => channel === "kakao:page-resumed")?.[1];
+    resume?.({} as Electron.IpcRendererEvent);
+    resume?.({} as Electron.IpcRendererEvent);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(clicked).toHaveBeenCalledOnce();
+  });
+});

--- a/src/main/tests/kakao-login-observer.test.ts
+++ b/src/main/tests/kakao-login-observer.test.ts
@@ -1,0 +1,70 @@
+// @vitest-environment-options {"url":"https://accounts.kakao.com/login"}
+import { ipcRenderer } from "electron";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+
+vi.mock("electron", () => ({
+  ipcRenderer: { send: vi.fn(), invoke: vi.fn(), on: vi.fn() },
+}));
+vi.mock("../utils/preload-logger", () => ({
+  logger: { log: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+const observers: MutationObserver[] = [];
+beforeEach(() => {
+  vi.resetModules();
+  vi.clearAllMocks();
+  vi.useFakeTimers();
+  document.body.innerHTML = "";
+  const NativeObserver = MutationObserver;
+  vi.stubGlobal(
+    "MutationObserver",
+    class extends NativeObserver {
+      constructor(callback: MutationCallback) {
+        super(callback);
+        observers.push(this);
+      }
+    },
+  );
+});
+afterEach(() => {
+  observers.splice(0).forEach((observer) => observer.disconnect());
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+it.each([
+  [
+    "/login",
+    '<div class="item_choice"><input type="checkbox" name="saveSignedIn"></div>',
+  ],
+  [
+    "/qr_login",
+    '<div class="item_choice"><input id="qr" type="checkbox" name="staySignedIn"><label id="label-staySignedIn" for="qr">유지</label></div>',
+  ],
+])(
+  "keeps observing dynamic login UI after the first match: %s",
+  async (path, markup) => {
+    window.history.replaceState({}, "", path);
+    vi.mocked(ipcRenderer.invoke).mockImplementation(async (channel) =>
+      channel === "kakao:get-page-state"
+        ? { blocked: false, documentId: 7 }
+        : "GAME_START_POE1",
+    );
+    let ready: (() => Promise<void>) | undefined;
+    vi.spyOn(window, "addEventListener").mockImplementation(
+      (event, listener) => {
+        if (event === "DOMContentLoaded")
+          ready = listener as () => Promise<void>;
+      },
+    );
+    await import("../kakao/preload");
+    await ready?.();
+    document.body.innerHTML = markup;
+    await vi.advanceTimersByTimeAsync(0);
+    expect(document.querySelector(".launcher-warning-msg")).not.toBeNull();
+    document.body.innerHTML = markup;
+    await vi.advanceTimersByTimeAsync(0);
+    expect(document.querySelector(".launcher-warning-msg")).not.toBeNull();
+  },
+);


### PR DESCRIPTION
## Summary

- 카카오 게임 실행·계정 확인·수동 로그인 중 Cloudflare 보안 확인 응답이 오면 확인 창을 표시하고 유지합니다.
- 사용자가 확인하는 동안 자동화와 제한시간을 멈추고, 정상 페이지로 돌아오면 원래 작업을 재개합니다.
- 팝업 작업 교체와 이전 문서의 지연 메시지를 구분하고, 기존 일반·QR 로그인 화면의 동적 UI 관찰을 유지합니다.

집중 테스트 6파일 48개, 대상 lint, 타입 검사·빌드 및 분리 리뷰를 통과했습니다. Windows Electron 43.4.1의 격리 프로필과 로컬 HTTPS 문서로 대기·재개를 검증했습니다. 실제 사이트의 Cloudflare 확인은 임의로 발생시킬 수 없어 아직 재현하지 못했으며, 실제 화면 표시·확인 완료 후의 사용자 동작 검증은 남아 있습니다.

## Motivation

기존에는 같은 URL에 표시된 Cloudflare 문서를 일반 게임·계정 페이지로 처리해 자동화가 실패하거나, 창 표시 정책과 제한시간 때문에 사용자가 확인을 마치기 전에 창이 숨겨지거나 닫힐 수 있었습니다. 보안 확인 상태를 일반 자동화와 구분해 사용자가 확인을 완료하고 진행 중인 작업을 이어갈 수 있도록 개선합니다.
