### PR TITLE
fix: 이벤트 알림 관리의 아이콘을 주요 소식과 통일

### DIFF
--- a/src/renderer/components/PromotionIcon.tsx
+++ b/src/renderer/components/PromotionIcon.tsx
@@ -1,0 +1,28 @@
+import type { PromotionEvent } from "../../shared/promotions";
+
+export default function PromotionIcon({
+  kind,
+}: {
+  kind: PromotionEvent["kind"];
+}) {
+  return kind === "twitch-drops" ? (
+    <svg viewBox="0 0 24 24" aria-hidden="true">
+      <path
+        fill="currentColor"
+        d="M4 2 1 5v15h5v3l4-3h5l7-7V2H4zm16 10-4 4h-5l-3 3v-3H4V4h16v8z"
+      />
+      <path fill="currentColor" d="M10 6h2v6h-2zm5 0h2v6h-2z" />
+    </svg>
+  ) : (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.6"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="m3 7 9-4 9 4v12l-9 3-9-3V7Zm0 0 9 4 9-4M12 11v11M7.5 5l9 4v5l-3 1" />
+    </svg>
+  );
+}

--- a/src/renderer/components/PromotionStatus.tsx
+++ b/src/renderer/components/PromotionStatus.tsx
@@ -1,5 +1,6 @@
 import { useId } from "react";
 
+import PromotionIcon from "./PromotionIcon";
 import {
   STASH_LINKS,
   TWITCH_LINKS,
@@ -30,29 +31,6 @@ const dateTime = new Intl.DateTimeFormat("ko-KR", {
 const period = (event: PromotionEvent) =>
   `${dateTime.format(new Date(event.startsAt))} ~ ${dateTime.format(new Date(event.endsAt))}`;
 
-function BuffIcon({ kind }: { kind: PromotionEvent["kind"] }) {
-  return kind === "twitch-drops" ? (
-    <svg viewBox="0 0 24 24" aria-hidden="true">
-      <path
-        fill="currentColor"
-        d="M4 2 1 5v15h5v3l4-3h5l7-7V2H4zm16 10-4 4h-5l-3 3v-3H4V4h16v8z"
-      />
-      <path fill="currentColor" d="M10 6h2v6h-2zm5 0h2v6h-2z" />
-    </svg>
-  ) : (
-    <svg
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.6"
-      strokeLinejoin="round"
-      aria-hidden="true"
-    >
-      <path d="m3 7 9-4 9 4v12l-9 3-9-3V7Zm0 0 9 4 9-4M12 11v11M7.5 5l9 4v5l-3 1" />
-    </svg>
-  );
-}
-
 function EventBuff({
   kind,
   events,
@@ -73,7 +51,7 @@ function EventBuff({
   const active = events.length > 0;
   const icon = (
     <span className={`promotion-buff ${active ? "active" : ""}`}>
-      <BuffIcon kind={kind} />
+      <PromotionIcon kind={kind} />
     </span>
   );
   return (

--- a/src/renderer/components/modals/EventNotificationModal.css
+++ b/src/renderer/components/modals/EventNotificationModal.css
@@ -117,9 +117,20 @@
   accent-color: var(--theme-accent);
   cursor: pointer;
 }
-.event-notification-option .material-symbols-outlined {
+.event-notification-option .material-symbols-outlined,
+.event-notification-option-icon {
   color: #c9bd96;
   font-size: 21px;
+}
+.event-notification-option-icon {
+  display: inline-flex;
+  flex-shrink: 0;
+  width: 21px;
+  height: 21px;
+}
+.event-notification-option-icon svg {
+  width: 100%;
+  height: 100%;
 }
 .event-notification-error {
   margin: 18px 0 0;

--- a/src/renderer/components/modals/EventNotificationModal.tsx
+++ b/src/renderer/components/modals/EventNotificationModal.tsx
@@ -4,6 +4,7 @@ import {
   normalizeEventPreferences,
   type EventNotificationPreferences,
 } from "../../../shared/promotions";
+import PromotionIcon from "../PromotionIcon";
 
 import "./EventNotificationModal.css";
 
@@ -12,8 +13,16 @@ const GROUPS = [
     id: "types",
     name: "알림 종류",
     options: [
-      { id: "twitch", name: "트위치 드롭스", icon: "live_tv" },
-      { id: "stash", name: "보관함 할인", icon: "inventory_2" },
+      {
+        id: "twitch",
+        name: "트위치 드롭스",
+        icon: <PromotionIcon kind="twitch-drops" />,
+      },
+      {
+        id: "stash",
+        name: "보관함 할인",
+        icon: <PromotionIcon kind="stash-sale" />,
+      },
     ],
   },
   {
@@ -162,7 +171,11 @@ export default function EventNotificationModal({
                       }}
                     />
                     <span
-                      className="material-symbols-outlined"
+                      className={
+                        typeof option.icon === "string"
+                          ? "material-symbols-outlined"
+                          : "event-notification-option-icon"
+                      }
                       aria-hidden="true"
                     >
                       {option.icon}


### PR DESCRIPTION
## Summary

이벤트 알림 관리의 트위치 드롭스·보관함 할인 아이콘을 이달의 주요 소식에서 사용하던 SVG로 통일합니다. 기존 SVG를 공용 `PromotionIcon` 컴포넌트로 분리해 두 화면이 같은 아이콘을 재사용하며, 각 화면의 기존 크기와 색상을 유지합니다.

기존 관련 테스트 11개, 타입 검사, 대상 lint와 독립 리뷰를 통과했습니다. 실제 React 컴포넌트의 브라우저 렌더링으로 두 화면의 SVG 일치와 주요 소식 16px·알림 관리 21px 표시를 확인했습니다.

## Motivation

같은 이벤트가 주요 소식에서는 전용 SVG로, 알림 관리에서는 다른 글꼴 아이콘으로 표시되고 있었습니다. 화면을 오갈 때 트위치 드롭스와 보관함 할인을 일관된 아이콘으로 알아볼 수 있도록 맞춥니다.
