### PR TITLE
fix: 카카오 보안 확인이 자동 완료될 때 창이 잠깐 뜨는 문제 개선

### DIFF
--- a/docs/work/2026-09-05-cloudflare-reveal-delay.md
+++ b/docs/work/2026-09-05-cloudflare-reveal-delay.md
@@ -1,0 +1,46 @@
+# Cloudflare 보안 확인 창의 5초 표시 유예
+
+> 작성일: 2026-09-05 · 상태: 구현·분리 리뷰 완료, PR 제출 · 브랜치: fix/cloudflare-reveal-delay
+
+## 승인과 근거
+
+사용자가 앞선 분석의 5초 유예 방안을 바탕으로 최신 master pull, fix 브랜치 수정 및 PR 상신을 명시 승인했다. 기준 master는 `b627976`(1.7.0)이다. master 머지·릴리스는 이번 범위에 포함하지 않는다.
+
+설치 앱의 2026-09-05 로그에서 보안 확인 감지/표시 00:55:22.097 → 정상 문서 복귀/숨김 00:55:26.845(4.748초) → 계정 확인 성공 00:55:28.426을 확인했다. 클릭 여부 자체는 로그에 없다. 기존 `e375084`는 challenge 헤더 수신과 창 표시를 동일 상태로 처리했다.
+
+## 설계와 영향 범위
+
+- Main의 `KakaoChallengeGate`가 challenge와 표시 자격을 각각 소유한다. 감지 즉시 기존 자동화·제한시간을 일시정지하고, 동일 challenge가 5초 유지될 때 표시 콜백을 호출한다.
+- `isVisible()`은 지연 후 표시 자격만 반환한다. 탐색 완료·트레이 복귀·설정 변경 등 기존 표시 경로가 같은 판정을 사용한다. 사용자가 요청한 일반 로그인/MOTP/디버그 표시 정책은 유지한다.
+- 정상 문서 commit, 첫 challenge 응답 취소, 창 제거, 작업 교체는 타이머를 취소한다. 반복 challenge/redirect와 기존 challenge 문서로의 실패 복원은 최초 대기시간을 유지한다. 정상 복귀 후 새 challenge는 다시 5초 기다린다.
+- 창 상태 객체 동일성으로 오래된 콜백을 막는다. 형제 창별 표시는 독립이며 task 전체의 pause/resume 계약은 보존한다.
+- DOM 셀렉터, IPC payload, AppConfig, UA/쿠키, 의존성 및 배포 흐름은 변경하지 않는다. 수동 확인이 필요한 경우에는 화면 표시가 최대 약 5초 늦어진다.
+
+## M1 — 구현과 검증
+
+대상: `src/main/kakao/cloudflare-challenge.ts`, `src/main/main.ts`, 기존 gate 테스트와 새 지연 테스트.
+
+- [x] [Windows-pwsh] 지연 테스트를 먼저 작성하고 현재 구현에서 실패함을 확인한다.
+- [x] [Windows-pwsh] 4.748초 자동 통과 시 미노출, 4,999/5,000ms 경계, 최초 타이머 유지, 정상 복귀 후 재도전, 취소/닫힘/작업 교체 및 형제 작업 격리를 검증한다.
+- [x] [Windows-pwsh] 감지 즉시 page/task 차단과 기존 preload pause/resume·로그인 observer 회귀 검사를 통과한다.
+- [x] [Windows-pwsh] lint, build:check 및 숨김 실제 Electron에서 표시 호출 시점과 정상 문서 재개를 확인한다. 로컬 모의 문서 검증은 실제 사이트 확인을 대체하지 않는다.
+- [x] 분리 리뷰 통과.
+- [ ] 커밋·push·PR 제출 및 최종 head CI 확인.
+- [ ] [사용자] 설치 앱에서 자동 확인 시 창 미노출, 5초 이상 확인 시 창 표시와 수동 확인 후 재개, 일반 로그인/MOTP 동작 확인.
+
+명령: `npm test -- --run src/main/tests/kakao-cloudflare-reveal-delay.test.ts src/main/tests/kakao-cloudflare-challenge.test.ts src/main/tests/kakao-cloudflare-preload.test.ts src/main/tests/kakao-login-observer.test.ts src/main/tests/kakao-visibility-policy.test.ts src/main/tests/game-status-ipc.test.ts src/main/tests/kakao-account-validation-dom.test.ts`, `npm run lint`, `npm run build:check`.
+
+## 분리 설계 검토
+
+`cloudflare_delay_review`: 통과. 상태 객체 타이머 guard, 취소·교체·실패 복원, 형제 창 격리 및 표시 직전 생존/자격 재검사를 요구했다. 추가 owner 결정 없음. 부모 세션이 유일한 구현자다.
+
+## 검증 결과와 코드 리뷰
+
+- RED: 새 13개 테스트 중 9개 실패·4개 통과. 기존 즉시 표시와 지연 콜백 부재를 확인했다.
+- GREEN: 위 집중 명령에서 25개 파일·205개 테스트 통과. `npm run lint`, `npm run build:check`, `git diff --check` 통과. 기존 Vite 설정/번들 크기 경고는 유지했다.
+- Windows Node 24.18.0, Electron 44.1.0. 최신 lockfile로 `npm ci` 후 Electron 공식 설치 스크립트로 실행 바이너리를 준비했다. 첫 런타임 시도는 바이너리 미설치로 ENOENT였으며 앱 프로세스는 시작하지 못했다. 제품 변경 없이 의존성 설치를 완료한 후 재검증했다.
+- 로컬 HTTPS 모의 문서를 사용하는 실제 Main/webRequest/preload 런타임 4사례 통과: PoE1 빠른 자동 확인 시 show/focus 미호출, PoE2 확인이 지속되면 5,016ms에 표시 호출하고 정상 문서에서 게임 핸들러 재개, 계정 확인 자동 통과·정상 결과 수신, 닫힌 창의 지연 표시 미호출.
+- 실행 `cloudflare-delay-1788538341957`, Electron PID 77500, 종료 코드 0. 격리 프로필을 사용하고 실제 show/focus는 계측으로 대체했다. 초기·최종 실제 Electron 창 가시성은 false였다. 원시 OS 창/포커스 연속 샘플 검사는 하지 않았으며 실제 화면 표시·실사이트 CAPTCHA 검증으로 간주하지 않는다. 종료 뒤 해당 PID/직계 자식 및 실행 프로필에 속한 Electron 프로세스 없음 확인.
+- 로그와 런타임 스크립트: `.tmp/cloudflare-reveal-delay/`. 네이티브 Windows PowerShell 세션에서 실행했으며 WSL 전용 runner는 사용하지 않았다. 기존 QA 원본은 수정하지 않았다.
+- R1 `cloudflare_delay_review`: **통과**. 타이머 상태 객체 guard, 정상 복귀/취소/교체 정리, committed challenge 실패 복원, 형제 작업 격리, 모든 기존 표시 경로와 즉시 pause 경로 분리 및 테스트/런타임 로그를 확인했다. 코드 지적 없음.
+- 사용자 실사이트 검증은 미실시다. 해당 DoD와 원래 Cloudflare 작업 문서는 유지하며 완료 아카이브로 옮기지 않는다. 기존 이벤트 작업 문서의 SHA256 `76256EE114AB15C3B9EFC1E44F06D0ADBDC5BBD32BEE520E987116CDE2DAB426`을 보존했다.

--- a/src/main/kakao/cloudflare-challenge.ts
+++ b/src/main/kakao/cloudflare-challenge.ts
@@ -11,6 +11,8 @@ interface WindowState {
   trigger: string;
   task: number;
   challenge: boolean;
+  visible: boolean;
+  revealTimer?: ReturnType<typeof setTimeout>;
   documentId: number | null;
   committed: { challenge: boolean; documentId: number | null };
   request?: { id: number; response?: { url: string; challenge: boolean } };
@@ -22,6 +24,8 @@ const TRIGGERS = new Set([
   "GAME_START_POE1",
   "GAME_START_POE2",
 ]);
+
+export const CLOUDFLARE_REVEAL_DELAY_MS = 5000;
 
 function documentUrl(value: string) {
   return value.split("#")[0];
@@ -40,6 +44,7 @@ export class KakaoChallengeGate {
       ids: number[],
       successorId: number,
     ) => void = () => {},
+    private readonly onReveal: (id: number) => void = () => {},
   ) {}
 
   setTrigger(id: number, trigger: string | null, parentId?: number) {
@@ -52,6 +57,7 @@ export class KakaoChallengeGate {
       const retired: number[] = [];
       for (const [windowId, state] of this.windows) {
         if (state.task === oldTask) {
+          this.cancelReveal(state);
           this.windows.delete(windowId);
           this.retired.add(windowId);
           if (windowId !== id) retired.push(windowId);
@@ -59,6 +65,8 @@ export class KakaoChallengeGate {
       }
       this.onRetired(retired, id);
     }
+    const previous = this.windows.get(id);
+    if (previous) this.cancelReveal(previous);
     this.retired.delete(id);
     this.windows.set(id, {
       trigger,
@@ -67,6 +75,7 @@ export class KakaoChallengeGate {
           ? undefined
           : this.windows.get(parentId)?.task) ?? ++this.sequence,
       challenge: false,
+      visible: false,
       documentId: null,
       committed: { challenge: false, documentId: null },
     });
@@ -115,6 +124,12 @@ export class KakaoChallengeGate {
     state.request.response = { url: documentUrl(details.url), challenge };
     if (challenge && !state.challenge) {
       state.challenge = true;
+      state.revealTimer = setTimeout(() => {
+        state.revealTimer = undefined;
+        if (this.windows.get(id) !== state || !state.challenge) return;
+        state.visible = true;
+        this.onReveal(id);
+      }, CLOUDFLARE_REVEAL_DELAY_MS);
       this.onChallenge(id);
     }
   }
@@ -126,6 +141,7 @@ export class KakaoChallengeGate {
     const wasChallenged = state.challenge;
     state.challenge = state.committed.challenge;
     state.documentId = state.committed.documentId;
+    if (!state.challenge) this.cancelReveal(state);
     if (wasChallenged && !state.challenge) this.resumeTask(state.task);
   }
 
@@ -141,14 +157,22 @@ export class KakaoChallengeGate {
       challenge: state.challenge,
       documentId: state.documentId,
     };
+    if (!state.challenge) this.cancelReveal(state);
     if (wasChallenged && !state.challenge) this.resumeTask(state.task);
   }
 
   remove(id: number) {
     const state = this.windows.get(id);
+    if (state) this.cancelReveal(state);
     this.windows.delete(id);
     this.retired.delete(id);
     if (state?.challenge) this.resumeTask(state.task);
+  }
+
+  private cancelReveal(state: WindowState) {
+    clearTimeout(state.revealTimer);
+    state.revealTimer = undefined;
+    state.visible = false;
   }
 
   private resumeTask(task: number) {
@@ -160,7 +184,7 @@ export class KakaoChallengeGate {
   }
 
   isVisible(id: number) {
-    return this.windows.get(id)?.challenge === true;
+    return this.windows.get(id)?.visible === true;
   }
 
   taskBlocked(id: number) {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -89,7 +89,10 @@ import {
   startAutomationDumpSession,
   type AutomationDumpArchiveResult,
 } from "./kakao/automation-page-dump";
-import { KakaoChallengeGate } from "./kakao/cloudflare-challenge";
+import {
+  CLOUDFLARE_REVEAL_DELAY_MS,
+  KakaoChallengeGate,
+} from "./kakao/cloudflare-challenge";
 import { isExpectedNavigationAbort } from "./kakao/navigation-error";
 import { initKakaoSession, KAKAO_PARTITION } from "./kakao/session";
 import { shouldHideReleasedAutomationWindow } from "./kakao/visibility-policy";
@@ -290,10 +293,8 @@ const kakaoChallengeGate = new KakaoChallengeGate(
     const win = wc && BrowserWindow.fromWebContents(wc);
     if (!win || win.isDestroyed()) return;
     logger.log(
-      `[Cloudflare] Waiting for user verification in window ${win.id}.`,
+      `[Cloudflare] Verification detected in window ${win.id}; delaying display for ${CLOUDFLARE_REVEAL_DELAY_MS}ms.`,
     );
-    win.show();
-    win.focus();
   },
   (ids) => {
     if (
@@ -348,6 +349,16 @@ const kakaoChallengeGate = new KakaoChallengeGate(
         else closeRetired();
       }
     }
+  },
+  (id) => {
+    const wc = webContents.fromId(id);
+    const win = wc && BrowserWindow.fromWebContents(wc);
+    if (!win || win.isDestroyed() || !kakaoChallengeGate.isVisible(id)) return;
+    logger.log(
+      `[Cloudflare] Verification still pending; showing window ${win.id}.`,
+    );
+    win.show();
+    win.focus();
   },
 );
 

--- a/src/main/tests/kakao-cloudflare-challenge.test.ts
+++ b/src/main/tests/kakao-cloudflare-challenge.test.ts
@@ -65,7 +65,7 @@ describe("Kakao Cloudflare challenge gate", () => {
     expect(gate.hasChallenge("ACCOUNT_VALIDATION")).toBe(false);
     expect(gate.accepts(2, oldDocument)).toBe(false);
     expect(gate.pageState(2).blocked).toBe(true);
-    expect(gate.isVisible(3)).toBe(false);
+    expect(gate.taskBlocked(3)).toBe(false);
   });
 
   it("restores the committed normal document if the first challenge response is cancelled", () => {
@@ -76,7 +76,7 @@ describe("Kakao Cloudflare challenge gate", () => {
     gate.beginNavigation(1);
     respond(gate, 2);
     gate.requestFailed({ id: 2, webContentsId: 1 });
-    expect(gate.isVisible(1)).toBe(false);
+    expect(gate.taskBlocked(1)).toBe(false);
     expect(gate.accepts(1, documentId)).toBe(true);
   });
   it("blocks a challenge before page handlers and notifies only once", () => {
@@ -84,7 +84,7 @@ describe("Kakao Cloudflare challenge gate", () => {
     respond(gate, 10);
     gate.commit(1, url);
     expect(gate.pageState(1).blocked).toBe(true);
-    expect(gate.isVisible(1)).toBe(true);
+    expect(gate.taskBlocked(1)).toBe(true);
     respond(gate, 11);
     expect(onChallenge).toHaveBeenCalledExactlyOnceWith(1);
   });
@@ -100,7 +100,7 @@ describe("Kakao Cloudflare challenge gate", () => {
         1,
         "https://pathofexile2.kakaogames.com/main#autoStart",
       );
-      expect(gate.isVisible(1)).toBe(true);
+      expect(gate.taskBlocked(1)).toBe(true);
     },
   );
 
@@ -108,7 +108,7 @@ describe("Kakao Cloudflare challenge gate", () => {
     const { gate } = setup();
     respond(gate, 1, { server: ["cloudflare"], title: ["Just a moment..."] });
     gate.commit(1, url);
-    expect(gate.isVisible(1)).toBe(false);
+    expect(gate.taskBlocked(1)).toBe(false);
     expect(gate.pageState(1).blocked).toBe(false);
   });
 
@@ -123,7 +123,7 @@ describe("Kakao Cloudflare challenge gate", () => {
       statusCode: 403,
       responseHeaders: challenge,
     });
-    expect(gate.isVisible(1)).toBe(false);
+    expect(gate.taskBlocked(1)).toBe(false);
   });
 
   it.each([
@@ -133,13 +133,13 @@ describe("Kakao Cloudflare challenge gate", () => {
   ])("ignores unapproved host/protocol %s", (target) => {
     const { gate } = setup();
     respond(gate, 1, challenge, 1, target);
-    expect(gate.isVisible(1)).toBe(false);
+    expect(gate.taskBlocked(1)).toBe(false);
   });
 
   it("does not reveal a window without an automation trigger", () => {
     const gate = new KakaoChallengeGate(vi.fn());
     respond(gate, 1);
-    expect(gate.isVisible(1)).toBe(false);
+    expect(gate.taskBlocked(1)).toBe(false);
   });
 
   it("keeps the challenge through navigation, redirects and headers until normal document commit", () => {
@@ -162,11 +162,11 @@ describe("Kakao Cloudflare challenge gate", () => {
       responseHeaders: {},
     });
     gate.commit(1, url);
-    expect(gate.isVisible(1)).toBe(true);
+    expect(gate.taskBlocked(1)).toBe(true);
     respond(gate, 2, {});
-    expect(gate.isVisible(1)).toBe(true);
+    expect(gate.taskBlocked(1)).toBe(true);
     gate.commit(1, url);
-    expect(gate.isVisible(1)).toBe(false);
+    expect(gate.taskBlocked(1)).toBe(false);
     expect(gate.pageState(1).blocked).toBe(false);
   });
 
@@ -187,7 +187,7 @@ describe("Kakao Cloudflare challenge gate", () => {
       responseHeaders: {},
     });
     gate.commit(1, url);
-    expect(gate.isVisible(1)).toBe(true);
+    expect(gate.taskBlocked(1)).toBe(true);
     expect(gate.accepts(1, oldDocument)).toBe(false);
     gate.setTrigger(1, "GAME_START_POE2");
     gate.responseStarted({
@@ -198,7 +198,7 @@ describe("Kakao Cloudflare challenge gate", () => {
       statusCode: 403,
       responseHeaders: challenge,
     });
-    expect(gate.isVisible(1)).toBe(false);
+    expect(gate.taskBlocked(1)).toBe(false);
     expect(gate.accepts(1, oldDocument)).toBe(false);
   });
 
@@ -215,7 +215,7 @@ describe("Kakao Cloudflare challenge gate", () => {
     expect(gate.hasChallenge("ACCOUNT_VALIDATION")).toBe(false);
   });
 
-  it("preserves a displayed challenge when a replacement request is cancelled", () => {
+  it("preserves a committed challenge when a replacement request is cancelled", () => {
     const { gate } = setup();
     respond(gate, 1);
     gate.commit(1, url);
@@ -223,6 +223,6 @@ describe("Kakao Cloudflare challenge gate", () => {
     respond(gate, 2, {});
     gate.requestFailed({ id: 2, webContentsId: 1 });
     gate.commit(1, url);
-    expect(gate.isVisible(1)).toBe(true);
+    expect(gate.taskBlocked(1)).toBe(true);
   });
 });

--- a/src/main/tests/kakao-cloudflare-reveal-delay.test.ts
+++ b/src/main/tests/kakao-cloudflare-reveal-delay.test.ts
@@ -1,0 +1,193 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { KakaoChallengeGate } from "../kakao/cloudflare-challenge";
+
+const url = "https://poe.kakaogames.com/#validateLogin";
+
+function response(
+  gate: KakaoChallengeGate,
+  requestId: number,
+  id = 1,
+  challenge = true,
+) {
+  const request = {
+    id: requestId,
+    webContentsId: id,
+    url,
+    resourceType: "mainFrame",
+  };
+  gate.requestStarted(request);
+  gate.responseStarted({
+    ...request,
+    statusCode: challenge ? 403 : 200,
+    responseHeaders: challenge ? { "cf-mitigated": ["challenge"] } : {},
+  });
+}
+
+function setup(trigger = "ACCOUNT_VALIDATION") {
+  const paused = vi.fn();
+  const resumed = vi.fn();
+  const reveal = vi.fn();
+  const gate = new KakaoChallengeGate(paused, resumed, vi.fn(), reveal);
+  gate.setTrigger(1, trigger);
+  return { gate, paused, resumed, reveal };
+}
+
+describe("Cloudflare reveal grace period", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it.each([
+    "ACCOUNT_VALIDATION",
+    "ACCOUNT_MANUAL_LOGIN",
+    "GAME_START_POE1",
+    "GAME_START_POE2",
+  ])("pauses %s immediately but reveals only after five seconds", (trigger) => {
+    const { gate, paused, reveal } = setup(trigger);
+    response(gate, 1);
+    gate.commit(1, url);
+    expect(paused).toHaveBeenCalledExactlyOnceWith(1);
+    expect(gate.pageState(1).blocked).toBe(true);
+    expect(gate.taskBlocked(1)).toBe(true);
+    expect(gate.isVisible(1)).toBe(false);
+    vi.advanceTimersByTime(4999);
+    expect(reveal).not.toHaveBeenCalled();
+    expect(gate.isVisible(1)).toBe(false);
+    vi.advanceTimersByTime(1);
+    expect(gate.isVisible(1)).toBe(true);
+    expect(reveal).toHaveBeenCalledExactlyOnceWith(1);
+  });
+
+  it("never reveals the observed 4.748-second automatic verification", () => {
+    const { gate, reveal, resumed } = setup();
+    response(gate, 1);
+    gate.commit(1, url);
+    vi.advanceTimersByTime(4748);
+    expect(gate.isVisible(1)).toBe(false);
+    gate.beginNavigation(1);
+    response(gate, 2, 1, false);
+    gate.commit(1, url);
+    vi.advanceTimersByTime(6000);
+    expect(reveal).not.toHaveBeenCalled();
+    expect(gate.isVisible(1)).toBe(false);
+    expect(gate.pageState(1).blocked).toBe(false);
+    expect(resumed).toHaveBeenCalledExactlyOnceWith([1]);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("keeps the original deadline across challenge reloads and redirects", () => {
+    const { gate, reveal, paused } = setup();
+    response(gate, 1);
+    gate.commit(1, url);
+    vi.advanceTimersByTime(3000);
+    gate.beginNavigation(1);
+    response(gate, 2);
+    gate.responseStarted({
+      id: 2,
+      webContentsId: 1,
+      url,
+      resourceType: "mainFrame",
+      statusCode: 302,
+    });
+    gate.commit(1, url);
+    vi.advanceTimersByTime(2000);
+    expect(paused).toHaveBeenCalledOnce();
+    expect(reveal).toHaveBeenCalledExactlyOnceWith(1);
+    vi.advanceTimersByTime(5000);
+    expect(reveal).toHaveBeenCalledOnce();
+  });
+
+  it("cancels a first challenge response when navigation fails", () => {
+    const { gate, reveal } = setup();
+    response(gate, 1, 1, false);
+    gate.commit(1, url);
+    const documentId = gate.pageState(1).documentId;
+    gate.beginNavigation(1);
+    response(gate, 2);
+    vi.advanceTimersByTime(4000);
+    gate.requestFailed({ id: 2, webContentsId: 1 });
+    vi.advanceTimersByTime(5000);
+    expect(reveal).not.toHaveBeenCalled();
+    expect(gate.accepts(1, documentId)).toBe(true);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("keeps a committed challenge's deadline and visibility when replacement fails", () => {
+    const { gate, reveal } = setup();
+    response(gate, 1);
+    gate.commit(1, url);
+    vi.advanceTimersByTime(3000);
+    gate.beginNavigation(1);
+    response(gate, 2, 1, false);
+    gate.requestFailed({ id: 2, webContentsId: 1 });
+    vi.advanceTimersByTime(2000);
+    expect(reveal).toHaveBeenCalledExactlyOnceWith(1);
+    gate.beginNavigation(1);
+    response(gate, 3, 1, false);
+    gate.requestFailed({ id: 3, webContentsId: 1 });
+    expect(gate.isVisible(1)).toBe(true);
+    expect(gate.taskBlocked(1)).toBe(true);
+  });
+
+  it.each(["close", "replace-task", "replace-child"])(
+    "cancels stale timers on %s",
+    (action) => {
+      const { gate, reveal } = setup();
+      gate.setTrigger(2, "ACCOUNT_VALIDATION", 1);
+      response(gate, 1, 2);
+      gate.commit(2, url);
+      vi.advanceTimersByTime(4000);
+      if (action === "close") gate.remove(2);
+      else if (action === "replace-task") gate.setTrigger(1, "GAME_START_POE2");
+      else gate.setTrigger(2, "GAME_START_POE2", 1);
+      vi.advanceTimersByTime(5000);
+      expect(reveal).not.toHaveBeenCalled();
+      expect(gate.isVisible(2)).toBe(false);
+      expect(vi.getTimerCount()).toBe(0);
+    },
+  );
+
+  it("starts a new grace period after normal navigation resolves a shown challenge", () => {
+    const { gate, reveal } = setup();
+    response(gate, 1);
+    gate.commit(1, url);
+    vi.advanceTimersByTime(5000);
+    response(gate, 2, 1, false);
+    expect(gate.isVisible(1)).toBe(true);
+    gate.commit(1, url);
+    expect(gate.isVisible(1)).toBe(false);
+    response(gate, 3);
+    vi.advanceTimersByTime(4999);
+    expect(gate.isVisible(1)).toBe(false);
+    expect(reveal).toHaveBeenCalledTimes(1);
+    vi.advanceTimersByTime(1);
+    expect(reveal).toHaveBeenCalledTimes(2);
+  });
+
+  it("cancels only the resolved sibling and resumes after the last challenge", () => {
+    const { gate, reveal, resumed } = setup();
+    gate.setTrigger(2, "ACCOUNT_VALIDATION", 1);
+    gate.setTrigger(3, "GAME_START_POE2");
+    response(gate, 1);
+    gate.commit(1, url);
+    vi.advanceTimersByTime(1000);
+    response(gate, 2, 2);
+    gate.commit(2, url);
+    response(gate, 3, 3, false);
+    gate.commit(3, url);
+    vi.advanceTimersByTime(3000);
+    response(gate, 4, 1, false);
+    gate.commit(1, url);
+    expect(gate.taskBlocked(1)).toBe(true);
+    expect(gate.taskBlocked(3)).toBe(false);
+    expect(resumed).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(2000);
+    expect(reveal).toHaveBeenCalledExactlyOnceWith(2);
+    gate.remove(2);
+    expect(resumed).toHaveBeenCalledExactlyOnceWith([1]);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

- 카카오 게임 실행·계정 확인에서 Cloudflare 확인이 5초 이상 지속될 때만 보안 확인 창을 표시합니다. 5초 안에 자동으로 완료되면 창을 표시하지 않고 원래 작업을 재개합니다.
- 확인을 감지하는 즉시 자동화와 제한시간은 일시정지합니다. 정상 페이지 복귀, 취소, 창 닫기와 작업 교체 시 표시 예약을 취소하고, 반복 확인·리다이렉트는 최초 대기시간을 유지합니다.
- 탐색 완료·트레이 복귀 등 기존 표시 경로도 같은 유예 판정을 사용합니다. 일반 로그인/MOTP, 설정·세션·업데이트 정책은 유지합니다.

관련 테스트 205개, lint, build:check 및 분리 리뷰를 통과했습니다. 격리한 실제 Electron 44.1의 로컬 HTTPS 모의 문서에서 빠른 게임·계정 확인의 표시 미호출, 5,016ms 후 표시 호출과 정상 재개, 닫힌 창의 표시 예약 취소를 확인했습니다. 창 표시·포커스는 계측으로 대체했으며, 실제 사이트에서 자동·수동 확인과 일반 로그인/MOTP 검증은 사용자 확인이 남아 있습니다.

## Motivation

설치 앱에서 사용자 조작 없이 넘어가는 보안 확인 창도 잠깐 노출됐습니다. 로그에서 감지 후 정상 복귀까지 4.748초인 사례를 확인했습니다. 기존 구현은 모든 Cloudflare 확인 응답을 즉시 표시했으므로, 자동 확인이 끝날 시간을 주면서 오래 지속되는 확인은 사용자에게 표시하도록 개선합니다.
