### PR TITLE
fix: 특정 상황에서 게임이 실행되지 않을 때 진단 로그 보강

### DIFF
--- a/docs/work/2026-09-05-kakao-automation-diagnostics.md
+++ b/docs/work/2026-09-05-kakao-automation-diagnostics.md
@@ -1,0 +1,95 @@
+# 카카오 인증·창 표시 진단 로그 보강
+
+> 작성일: 2026-09-05 · 갱신: 2026-09-05 · 상태: 구현·자동 검증·분리 리뷰 통과, 실동작 미검증 상태로 PR 제출 승인 · 브랜치: fix/kakao-automation-diagnostics
+
+## 승인과 기준점
+
+사용자가 release-please 완료 후 master pull, 브랜치 생성, 추후 로그 반출로 원인을 분석할 수 있는 로그 개선 구현을 승인했다. 앞선 대화에서 제시한 표시 요청 거절 사유, 페이지 이동 전후 상태, 실제 창 표시 결과를 구현한다. 추가 구현 승인을 반복 요청하지 않는다.
+
+release-please `33968016387` 성공을 확인한 뒤 master를 `b627976`에서 `ec8be1d`(1.7.1)로 fast-forward했다. 기존 비추적 `2026-09-04-event-notification-ui.md`의 SHA256 `76256EE114AB15C3B9EFC1E44F06D0ADBDC5BBD32BEE520E987116CDE2DAB426`을 보존한다.
+
+## 설계와 범위
+
+목표는 기존 `launcher-YYYY-MM-DD.NNN.log` 반출만으로 한 번의 실행에서 표시 요청이 생성·전송·거절·적용된 지점을 구분하는 것이다. 구조화된 `[KakaoDiag]` 레코드를 기존 logger/저장소로 전달한다. 별도 로그 파일이나 설정은 추가하지 않는다.
+
+- main은 실행 ID, task, webContents, 창, 현재 문서/확정 문서/request 상태를 소유한다. preload의 원래 문서 ID와 main의 수신 시점 문서 ID를 구분한다.
+- 기존 `debug-log:send`로 전송된 새 진단 레코드만 main에서 정규화하고 sender 연결 정보를 보강한다. IPC 채널·인자·타입 계약은 그대로 유지한다.
+- gate snapshot은 읽기 전용이다. 기존 허용/거절 판단·페이지 이동·5초 Cloudflare 노출 지연·보안센터 무제한 대기·10초 observer 종료·DOM 셀렉터를 바꾸지 않는다.
+- navigation 시작/완료/실패/종료, HTTP 요청 실패 복구 여부, 창 show/hide/close, 표시 요청 정책, 보안센터 state 변화와 observer 종료를 기록한다.
+- URL은 알려진 호스트/경로와 프로토콜 종류로 분류한다. 사용자정보, 임의 경로, 쿼리, fragment, DOM, input, HTTP header, raw error는 기록하지 않는다. 숫자/boolean/고정 식별자만 허용하고 반복 기록은 제한한다.
+- 런타임 진단만 추가한다. AppConfig, 서비스 lifecycle, 이벤트/IPC 경계, 의존성, 사용자 데이터, 업데이트/배포 동작 변경은 없다. 기존 전체 로그 마스킹을 재설계하지 않는다.
+
+대안인 모든 이벤트 원문 기록은 개인정보와 로그 용량 문제가 있고, 실패 결과 한 줄만 추가하면 전송 전 억제와 페이지 복구를 구별하지 못하므로 위 구조화된 경계 진단을 선택한다.
+
+## M1 구현과 DoD
+
+대상: `src/shared/kakao-diagnostics.ts`, `src/main/kakao/{cloudflare-challenge,session,preload}.ts`, `src/main/main.ts`, 집중 테스트. main과 preload는 작은 진단 호출만 추가한다.
+
+1. [x] [Windows-pwsh] 먼저 실패하는 테스트로 URL/필드 허용 목록, 반복 억제, 기존 로그 저장·반출 보존을 검증한다.
+2. [x] [Windows-pwsh] gate의 문서 미확정/이전 문서/작업 challenge/retired 상태와 request 실패 복구·무시를 연결 ID로 구별한다.
+3. [x] [Windows-pwsh] preload의 pause/validation 억제, 보안센터 state 전환, observer 실제 종료와 표시 요청을 고정 fixture로 확인한다.
+4. [x] [Windows-pwsh] 기존 카카오 관련 테스트, 집중 진단 테스트, lint, build:check 통과. 기존 동작·타이밍과 IPC 인자 유지.
+5. [x] [Windows-pwsh] 실제 Windows Electron의 숨김·격리 fixture에서 navigation/요청 거절/창 상태 진단이 로그로 연결되는지 확인한다. 실제 사이트 장애 재현과 구별한다.
+6. [x] [Windows-pwsh] 구현과 분리된 리뷰 통과, 기존 사용자 변경 보존.
+7. [ ] [사용자] 실제 카카오 로그인·게임 실행·필요한 인증창 처리가 종전대로 동작하는지 확인. 자연 장애 재현이나 과거 원인 확정을 자동 테스트로 대체하지 않는다.
+
+구현 순서: 포맷/보존 실패 테스트 → 최소 helper → gate/main/session 계측 → preload 계측과 fixture → 자동 검증 → 분리 리뷰. writer는 현 세션 하나다. master 머지·릴리스는 별도 사용자 승인 대상이다.
+
+## 사전 분리 설계 검토
+
+`kakao_log_design_review`: 진행 가능. owner 추가 결정 없음. 기존 webRequest listener를 추가 등록해 교체하지 말 것, main 진단에서 preload 원래 문서와 현재 문서를 혼동하지 말 것, 표시 결과는 비동기 resize 이후에만 기록하지 말 것, paused 상태의 전송 누락도 남길 것을 반영한다.
+
+## 검증 결과
+
+- Windows Vitest: 진단 3개 파일, challenge/reveal-delay/preload/login-observer/visibility-policy/game-status-ipc 및 DiagnosticLogStore 선택 실행으로 총 28개 파일 262개 테스트 통과. 필터가 관련 파일도 선택한 실제 결과다.
+- 전체 `eslint src`, `npm run build:check`, `git diff --check` 통과. Vite의 기존 설정/청크 크기 경고는 유지된다.
+- 실제 빌드 산출물을 Electron 44.1.0으로 실행하고, 임시 프로필과 로컬 HTTPS 보안센터 fixture를 사용했다. 사용자에게 창이 보이지 않도록 QA 주입에서 show/focus를 억제하고 실제 `isVisible()` 값은 유지했다. 실제 인증창 표시 성공 검증과는 구분한다.
+- 1차 통과 QA: `C:\Users\nerdl\AppData\Local\Temp\kakao-diagnostics-qa-7GYQqG\result.json`, `diagnostics.jsonl`. 기존 launcher 로그 파일에 54개 구조화 레코드 저장, observer 종료 `timeout` 사유 보존, 이동 중 문서 요청 `document-uncommitted` 거절, 취소 후 `restored`, 표시 적용 요청, 실행/창/문서 연결 정보 및 fixture 민감 값 제외 확인. 소유 Electron PID 84124 정상 종료(code 0), visible 위반 0. 아래 2차 리뷰에서 실제 closed 관측 검증을 추가했다.
+- 최초 QA `kakao-diagnostics-qa-XABXtX`는 감시 종료 사유 검사만 실패했다. 실행 중 게임 감지로 첫 시험 창이 about:blank로 정리되었고 두 번째 창도 감시 종료 전 닫은 fixture 문제였다. 두 번째 창을 10초 감시 종료까지 유지하도록 수정한 뒤 위 최종 QA가 통과했다. 제품 감시 시간은 변경하지 않았다.
+- 최종 보완 QA: `C:\Users\nerdl\AppData\Local\Temp\kakao-diagnostics-qa-CqdPjq\result.json`, `diagnostics.jsonl`. 56개 진단 레코드와 두 창의 실제 `visibility.observed/closed` 기록을 확인했다. 위 observer/거절/복구/표시 요청/연결/민감 값 제외 검사도 모두 통과했다. PID 84448 정상 종료(code 0), visible 위반 0. 최종 변경 후 main lint/format, build:check, diff 검사도 통과했다.
+- QA 스크립트는 ignored `.tmp/kakao-diagnostics-qa/runtime.cjs`에 보존한다. 실사이트 계정 인증과 게임 실행 회귀는 사용자 DoD로 남는다. 과거 제보의 원인은 여전히 가설이며 이 작업은 원인 수정이 아닌 진단 개선이다.
+
+## 분리 리뷰 이력
+
+### 1차 — 반려 (P2 2건)
+
+1. 반복 제한기가 같은 상태의 누적 횟수로 판단해 A → B → A 복귀 전환을 빠뜨릴 수 있음. 직전 동일 상태의 연속 횟수만 제한하도록 수정하고, 복귀 전환 테스트 실패 → 통과를 확인했다.
+2. main context의 `reason: undefined`가 preload의 종료/억제 사유를 덮어씀. context에서 reason 키를 제거하도록 수정했다. 실제 저장된 QA 로그에서 `observer.stopped`의 `timeout` 사유 보존을 확인했다.
+
+### 2차 — 창 이벤트 관측 보완 후 통과
+
+1차 두 지적은 해소됐으나 실제 로그의 `visibility.observed`가 0건임을 리뷰어가 발견했다. QA를 강화한 `kakao-diagnostics-qa-8ZDOHU`에서 `getWebPreferences`가 undefined이고 `partition`을 얻지 못하는 반면 공개 `webContents.session`은 카카오 세션과 일치함을 확인했다. 이 실행에서 `closedObserved`만 실패했고, 소유 PID 6880은 정상 종료했다.
+
+새 진단 listener 등록 조건만 공개 session identity 비교로 수정했다. 닫힌 창도 window ID를 보존하도록 생성 시 ID를 캡처한다. 기존 코드의 다른 partition 사용은 범위 밖 발견으로 남기고 변경하지 않는다. 변경 후 main lint/format, build:check, diff 검사 통과. `kakao-diagnostics-qa-CqdPjq`에서 두 시험 창의 실제 closed 레코드 확인을 포함한 QA가 통과했다.
+
+리뷰어 `kakao_log_design_review`가 최종 diff, QA 결과와 반출 레코드를 직접 확인하고 **통과** 판정했다. 남은 코드 blocker 없음. 설정·IPC 인자·상태 전환·셀렉터·시간 제한 변경 없음, 최초 두 지적과 창 관측 지적 해소, 사용자 비추적 문서 SHA256 보존 확인. 이 판정은 구현·자동 검증 범위이며 사용자 실동작 검증이나 master 머지 승인을 대신하지 않는다.
+
+사용자는 실사이트 로그인·게임 실행 검증 미실시 설명을 들은 뒤 PR 제출을 명시적으로 승인했다. 사용자 DoD를 통과로 바꾸지 않고 현재 검증 범위를 명시해 PR을 제출한다. master 머지·릴리스 승인은 포함하지 않는다. 제품 커밋은 `3fbba9d`이며 기존 사용자 비추적 문서는 커밋에서 제외했다.
+
+## 사용자 검증용 설치 파일
+
+사용자 요청으로 `npm run build -- --publish never`를 실행해 Windows x64 NSIS 빌드를 완료했다(exit 0). 버전 표기는 1.7.1이며 현 브랜치의 미커밋 진단 개선을 포함한다.
+
+- 경로: `D:\project_poe2\POE2-unofficial-launcher\dist\POE2 Unofficial Launcher Setup 1.7.1.exe`
+- 크기: 259,298,289 bytes
+- SHA256: `e272b2cea2cb0618e7f15a7e2b97c63f0161a0dfb2877e3fad846344fe87e930`
+- 빌드 로그와 영수증: `.tmp/kakao-diagnostics-qa/installer-20260905-225430/`
+- 패키지 내부 main/preload가 현재 빌드 산출물과 바이트 단위로 일치함을 확인했다. 최초 ASAR 확인은 Windows 경로 구분자 때문에 실패했으며 `path.normalize()` 적용 후 일치 확인했다.
+- 기존 Vite 청크 크기, duplicate dependency references, `src/main/assets` 부재 경고가 있었으나 패키징은 성공했다. 실사이트 사용자 검증은 계속 미실시다.
+
+PR 제목: `fix: 특정 상황에서 게임이 실행되지 않을 때 진단 로그 보강`. 본문에서 재발 시 반출 로그를 통한 분석 목적이며 실행 불가 원인 조치는 포함하지 않음을 명시한다.
+
+## 마무리 기록
+
+위키 raw 노트는 실제 WSL 위키의 `/home/nerdhead/project_llm_wiki/raw/projects/poe2-launcher/2026-09-05-kakao-automation-diagnostics.md`에 신규 보존한다. 위키는 기존 네 파일에 사용자 변경이 있고, 해당 저장소의 ingest 규칙은 영향 페이지 승인 후 갱신하도록 요구한다. 이번에는 raw 보존까지 수행하고 기존 wiki 변경은 건드리지 않는다. ingest와 사용자 실동작 검증이 미완료이므로 작업 문서도 `docs/work/`에 유지한다. 이 후속 기록은 승인된 PR 제출을 차단하지 않는다.
+
+## 추후 반출 로그 분석 순서
+
+기존 로그의 `content`가 `[KakaoDiag] `로 시작하는 레코드를 추출하고, 외부 `timestamp`와 내부 `runId` → `taskId` → `webContentsId`로 흐름을 연결한다. 문서가 바뀌므로 preload의 `documentId`/main의 `receivedDocumentId`와 main 현재 상태 `gateDocumentId`/`committedDocumentId`를 구별한다.
+
+1. `page.dispatch`, `security.state`, `security.reveal-*`, `observer.stopped`로 어떤 페이지 처리와 감시가 진행됐는지 확인한다.
+2. `ipc.suppressed`/`visibility.suppressed`는 보내기 전 또는 검증 정책에 의한 억제다. `ipc.sent`와 `visibility.request`는 전송/수신, `ipc.rejected`는 main의 거절 사유다.
+3. `navigation.start/commit/failed/stopped`와 `request.sent/response/failed`를 연결한다. `no-request`/`request-mismatch`는 복구하지 못한 실패, `restored`는 기존 확정 문서로 복구한 결과다. 복구된 문서 ID가 null인지도 함께 본다.
+4. `visibility.applied`는 표시 정책 처리 지점을 뜻한다. 실제 표시 여부는 같은 레코드의 `visible`과 `visibility.observed`를 확인한다. 요청값만으로 창이 실제 보였다고 판단하지 않는다.
+
+`occurrences`는 같은 이벤트/handler/channel에서 직전 동일 상태가 연속된 횟수다. 1, 2, 4, 8…회만 기록하고 상태 변경 시 다시 1부터 남긴다. 따라서 레코드 개수는 실제 발생 횟수가 아니며, 레코드 부재만으로 특정 원인을 확정하지 않는다.

--- a/src/main/kakao/cloudflare-challenge.ts
+++ b/src/main/kakao/cloudflare-challenge.ts
@@ -225,4 +225,34 @@ export class KakaoChallengeGate {
     const page = this.pageState(id);
     return !page.blocked && page.documentId === documentId;
   }
+
+  /** Read-only snapshot; diagnostics never authorize or restore a document. */
+  diagnosticState(id: number, receivedDocumentId?: number | null) {
+    const state = this.windows.get(id);
+    const retired = this.retired.has(id);
+    const taskBlocked = this.taskBlocked(id);
+    const page = this.pageState(id);
+    const reason = retired
+      ? "retired"
+      : taskBlocked
+        ? "task-challenged"
+        : state && state.documentId === null
+          ? "document-uncommitted"
+          : page.documentId !== receivedDocumentId
+            ? "document-mismatch"
+            : "accepted";
+    return {
+      tracked: Boolean(state),
+      retired,
+      taskId: state?.task ?? null,
+      trigger: state?.trigger,
+      gateDocumentId: page.documentId,
+      committedDocumentId: state?.committed.documentId ?? null,
+      requestId: state?.request?.id ?? null,
+      challenge: state?.challenge ?? false,
+      taskBlocked,
+      revealPending: state?.revealTimer !== undefined,
+      reason,
+    };
+  }
 }

--- a/src/main/kakao/preload.ts
+++ b/src/main/kakao/preload.ts
@@ -20,6 +20,11 @@ import {
   USER_REQUIRED_PAGE_REVEAL_DELAY_MS,
 } from "./visibility-policy";
 import {
+  formatKakaoDiagnostic,
+  KakaoDiagnosticLimiter,
+  type KakaoDiagnosticFields,
+} from "../../shared/kakao-diagnostics";
+import {
   isKakaoGamesAgreementUrl,
   isKakaoGamesMemberLoginUrl,
   isKakaoLauncherUrl,
@@ -129,9 +134,40 @@ let automationDocumentId: number | null = null;
 let pageDeferred = false;
 let pageStarted = false;
 const automationClock = new AutomationClock();
+const diagnosticLimiter = new KakaoDiagnosticLimiter();
+let diagnosticHandler: string | undefined;
+
+function diagnosePage(event: string, fields: KakaoDiagnosticFields = {}) {
+  try {
+    const data = {
+      documentId: automationDocumentId,
+      handler: diagnosticHandler,
+      url: window.location.href,
+      paused: automationClock.paused,
+      validation: isValidationMode,
+      ...fields,
+    };
+    const occurrences = diagnosticLimiter.include(event, data);
+    if (occurrences)
+      logger.log(formatKakaoDiagnostic(event, { ...data, occurrences }));
+  } catch {
+    /* Diagnostic failures must not affect page automation. */
+  }
+}
 
 function sendPageMessage(channel: string, ...args: unknown[]) {
-  if (automationClock.paused) return;
+  const fields = {
+    channel,
+    requestedVisible:
+      channel === "window-visibility-request" ? args[0] : undefined,
+    status: channel === "game-status-update" ? args[0] : undefined,
+    timeoutMs: channel.endsWith(":update-timeout") ? args[0] : undefined,
+  };
+  if (automationClock.paused) {
+    diagnosePage("ipc.suppressed", { ...fields, reason: "paused" });
+    return;
+  }
+  diagnosePage("ipc.sent", fields);
   ipcRenderer.send(channel, ...args, automationDocumentId);
 }
 
@@ -141,6 +177,10 @@ function sendPageMessage(channel: string, ...args: unknown[]) {
 function requestWindowVisibility(visible: boolean) {
   // Suppress visibility requests if in validation mode and window is not already shown
   if (isValidationMode && visible) {
+    diagnosePage("visibility.suppressed", {
+      requestedVisible: visible,
+      reason: "validation",
+    });
     logger.log(
       "[Game Window] Background validation mode, auto-show suppressed.",
     );
@@ -154,7 +194,13 @@ function createVisibilityRequest(context: HandlerContext, description: string) {
   let didRequest = false;
 
   return (reason: string) => {
-    if (didRequest) return;
+    if (didRequest) {
+      diagnosePage("visibility.suppressed", {
+        reason: "already-requested",
+        requestedVisible: true,
+      });
+      return;
+    }
     didRequest = true;
 
     logger.log(
@@ -301,6 +347,10 @@ function observeAndInteract(
 ) {
   if (!automationClock.paused && checkFn()) return;
 
+  const startedAt = Date.now();
+  const handler = diagnosticHandler;
+  diagnosePage("observer.started", { handler, timeoutMs });
+
   logger.log(
     "[Game Window] Target not found immediately. Starting observer...",
   );
@@ -317,9 +367,16 @@ function observeAndInteract(
   const observer = new MutationObserver(check);
   const unsubscribe = automationClock.onResume(check);
   const disconnect = observer.disconnect.bind(observer);
+  let stopReason = "disconnected";
   // Some login handlers keep observing after a successful match for dynamic UI.
   // Preserve the handler's explicit disconnect decision while cleaning up our clock.
   observer.disconnect = () => {
+    diagnosePage("observer.stopped", {
+      handler,
+      reason: stopReason,
+      elapsedMs: Date.now() - startedAt,
+      timeoutMs,
+    });
     disconnect();
     unsubscribe();
     if (timeoutId !== undefined) automationClock.clearTimeout(timeoutId);
@@ -330,6 +387,7 @@ function observeAndInteract(
   if (timeoutMs > 0) {
     timeoutId = automationClock.setTimeout(() => {
       if (completed) return;
+      stopReason = "timeout";
       observer.disconnect();
       unsubscribe();
       logger.log("[Game Window] Observer timed out.");
@@ -976,18 +1034,26 @@ const SecurityCenterHandler: PageHandler = {
 
     const clearDelayedReveal = () => {
       if (delayTimeoutId === null) return;
+      diagnosePage("security.reveal-cancelled");
       automationClock.clearTimeout(delayTimeoutId);
       delayTimeoutId = null;
     };
 
     const scheduleUnresolvedReveal = () => {
       if (delayTimeoutId !== null) return;
+      diagnosePage("security.reveal-scheduled", {
+        timeoutMs: SECURITY_CENTER_UNRESOLVED_REVEAL_DELAY_MS,
+      });
 
       const initialUrl = window.location.href;
       delayTimeoutId = automationClock.setTimeout(() => {
         delayTimeoutId = null;
+        diagnosePage("security.reveal-fired", {
+          state: getSecurityCenterVisibilityState(document),
+        });
 
         if (window.location.href !== initialUrl) {
+          diagnosePage("security.reveal-cancelled", { reason: "url-changed" });
           logger.log(
             `[SecurityCenter] Delayed reveal skipped: URL changed before ${SECURITY_CENTER_UNRESOLVED_REVEAL_DELAY_MS}ms.`,
           );
@@ -996,6 +1062,10 @@ const SecurityCenterHandler: PageHandler = {
 
         const state = getSecurityCenterVisibilityState(document);
         if (state === "auto-progress") {
+          diagnosePage("visibility.suppressed", {
+            reason: "auto-progress",
+            requestedVisible: true,
+          });
           logger.log(
             "[SecurityCenter] Delayed reveal skipped: auto-progress UI is still active.",
           );
@@ -1014,8 +1084,13 @@ const SecurityCenterHandler: PageHandler = {
       }, SECURITY_CENTER_UNRESOLVED_REVEAL_DELAY_MS);
     };
 
+    let lastDiagnosticState: string | undefined;
     observeAndInteract((obs) => {
       const state = getSecurityCenterVisibilityState(document);
+      if (state !== lastDiagnosticState) {
+        lastDiagnosticState = state;
+        diagnosePage("security.state", { state });
+      }
 
       if (state === "user-required") {
         clearDelayedReveal();
@@ -1040,6 +1115,7 @@ const SecurityCenterHandler: PageHandler = {
           ));
 
       if (clickedPcInfoButton) {
+        diagnosePage("security.pc-info-click", { clicked: true, state });
         logger.log("[SecurityCenter] Clicked PC Info Button");
         clearDelayedReveal();
         context.setVisible(false);
@@ -1233,6 +1309,7 @@ async function dispatchPageLogic(triggerContext?: string) {
   if (pageStarted) return;
   const page = await ipcRenderer.invoke("kakao:get-page-state");
   if (page.blocked) {
+    diagnosePage("page.deferred", { documentId: page.documentId });
     pageDeferred = true;
     logger.log(
       "[Cloudflare] Page automation deferred until verification finishes.",
@@ -1272,6 +1349,8 @@ async function dispatchPageLogic(triggerContext?: string) {
       // Note: If handler.triggeredBy is undefined, it's global.
 
       logger.log(`[Game Window] Matched Handler: ${handler.name}`);
+      diagnosticHandler = handler.name;
+      diagnosePage("page.dispatch", { trigger: triggerContext });
 
       // 1. Check Visibility Requirement
       const shouldShowOnMatch = shouldRequestVisibilityOnHandlerMatch(
@@ -1368,10 +1447,14 @@ try {
 
 ipcRenderer.on("kakao:page-resumed", () => {
   automationClock.resume();
+  diagnosePage("page.resumed");
   if (pageDeferred) void dispatchPageLogic();
 });
 
-ipcRenderer.on("kakao:page-paused", () => automationClock.pause());
+ipcRenderer.on("kakao:page-paused", () => {
+  automationClock.pause();
+  diagnosePage("page.paused");
+});
 
 ipcRenderer.on("execute-game-start", (_event, context: GameSessionContext) => {
   logger.log('[Game Window] IPC "execute-game-start" RECEIVED!', context);

--- a/src/main/kakao/session.ts
+++ b/src/main/kakao/session.ts
@@ -3,6 +3,7 @@ import { session } from "electron";
 import { setupSessionSecurity } from "../security/permissions";
 
 import type { KakaoChallengeGate } from "./cloudflare-challenge";
+import type { KakaoDiagnosticSink } from "../../shared/kakao-diagnostics";
 
 export const KAKAO_PARTITION = "persist:kakao_game";
 
@@ -10,20 +11,49 @@ export const KAKAO_PARTITION = "persist:kakao_game";
  * Initializes the Kakao Game session partition.
  * Applies security policies and other necessary configurations.
  */
-export function initKakaoSession(challengeGate: KakaoChallengeGate) {
+export function initKakaoSession(
+  challengeGate: KakaoChallengeGate,
+  diagnostic: KakaoDiagnosticSink = () => {},
+) {
   const sess = session.fromPartition(KAKAO_PARTITION);
   setupSessionSecurity(sess, KAKAO_PARTITION);
 
   // Read-only events; keep the independent passkey cancellation listener below.
-  sess.webRequest.onSendHeaders((details) =>
-    challengeGate.requestStarted(details),
-  );
-  sess.webRequest.onResponseStarted((details) =>
-    challengeGate.responseStarted(details),
-  );
-  sess.webRequest.onErrorOccurred((details) =>
-    challengeGate.requestFailed(details),
-  );
+  sess.webRequest.onSendHeaders((details) => {
+    challengeGate.requestStarted(details);
+    if (details.resourceType === "mainFrame")
+      diagnostic(details.webContentsId ?? -1, "request.sent", {
+        url: details.url,
+        eventRequestId: details.id,
+      });
+  });
+  sess.webRequest.onResponseStarted((details) => {
+    challengeGate.responseStarted(details);
+    if (details.resourceType === "mainFrame")
+      diagnostic(details.webContentsId ?? -1, "request.response", {
+        url: details.url,
+        eventRequestId: details.id,
+        statusCode: details.statusCode,
+      });
+  });
+  sess.webRequest.onErrorOccurred((details) => {
+    const id = details.webContentsId ?? -1;
+    const before = challengeGate.diagnosticState(id);
+    challengeGate.requestFailed(details);
+    if (details.resourceType === "mainFrame")
+      diagnostic(id, "request.failed", {
+        ...challengeGate.diagnosticState(id),
+        url: details.url,
+        eventRequestId: details.id,
+        reason: !before.tracked
+          ? "untracked"
+          : before.requestId === null
+            ? "no-request"
+            : before.requestId !== details.id
+              ? "request-mismatch"
+              : "restored",
+      });
+  });
 
   // --- FINAL SECURITY: Block Passkey API requests (Kakao Specific) ---
   // This prevents the Kakao login page from even attempting to start the Passkey auth sequence.

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -95,6 +95,12 @@ import {
 } from "./kakao/cloudflare-challenge";
 import { isExpectedNavigationAbort } from "./kakao/navigation-error";
 import { initKakaoSession, KAKAO_PARTITION } from "./kakao/session";
+import {
+  formatKakaoDiagnostic,
+  KakaoDiagnosticLimiter,
+  parseKakaoDiagnostic,
+  type KakaoDiagnosticFields,
+} from "../shared/kakao-diagnostics";
 import { shouldHideReleasedAutomationWindow } from "./kakao/visibility-policy";
 import { trayManager } from "./managers/TrayManager";
 import {
@@ -362,24 +368,119 @@ const kakaoChallengeGate = new KakaoChallengeGate(
   },
 );
 
+const kakaoDiagnosticRunId = `${Date.now().toString(36)}-${process.pid}`;
+const kakaoDiagnosticLimiter = new KakaoDiagnosticLimiter();
+
+function kakaoDiagnosticContext(id: number) {
+  const state: KakaoDiagnosticFields = {
+    ...kakaoChallengeGate.diagnosticState(id),
+  };
+  delete state.reason;
+  const wc = webContents.fromId(id);
+  const win =
+    wc && !wc.isDestroyed() ? BrowserWindow.fromWebContents(wc) : null;
+  return {
+    ...state,
+    runId: kakaoDiagnosticRunId,
+    appVersion: app.getVersion(),
+    webContentsId: id,
+    windowId: win?.id ?? null,
+    visible: win && !win.isDestroyed() ? win.isVisible() : false,
+    focused: win && !win.isDestroyed() ? win.isFocused() : false,
+    minimized: win && !win.isDestroyed() ? win.isMinimized() : false,
+  };
+}
+
+function logKakaoDiagnostic(
+  id: number,
+  event: string,
+  fields: KakaoDiagnosticFields = {},
+) {
+  try {
+    const data = { ...kakaoDiagnosticContext(id), ...fields };
+    const occurrences = kakaoDiagnosticLimiter.include(event, data);
+    if (occurrences)
+      logger.log(formatKakaoDiagnostic(event, { ...data, occurrences }));
+  } catch {
+    /* Diagnostics must not interrupt authentication or window handling. */
+  }
+}
+
 function acceptsKakaoPage(
   event: Electron.IpcMainEvent | Electron.IpcMainInvokeEvent,
   documentId?: number | null,
+  channel?: string,
 ) {
   if (event.sender.session !== session.fromPartition(KAKAO_PARTITION))
     return true;
-  return (
+  const accepted =
     event.senderFrame === event.sender.mainFrame &&
-    kakaoChallengeGate.accepts(event.sender.id, documentId)
+    kakaoChallengeGate.accepts(event.sender.id, documentId);
+  logKakaoDiagnostic(
+    event.sender.id,
+    accepted ? "ipc.accepted" : "ipc.rejected",
+    {
+      channel,
+      receivedDocumentId: documentId ?? null,
+      reason:
+        event.senderFrame !== event.sender.mainFrame
+          ? "frame-mismatch"
+          : kakaoChallengeGate.diagnosticState(event.sender.id, documentId)
+              .reason,
+      isMainFrame: event.senderFrame === event.sender.mainFrame,
+    },
   );
+  return accepted;
 }
 
 // [New] Safety Cleanup for Automation Tracking
 app.on("web-contents-created", (_, wc) => {
-  wc.on("did-start-navigation", (_event, _url, isInPlace, isMainFrame) => {
+  wc.on("did-start-navigation", (_event, url, isInPlace, isMainFrame) => {
+    const previousDocumentId = kakaoChallengeGate.pageState(wc.id).documentId;
     if (isMainFrame && !isInPlace) kakaoChallengeGate.beginNavigation(wc.id);
+    if (wc.session === session.fromPartition(KAKAO_PARTITION))
+      logKakaoDiagnostic(wc.id, "navigation.start", {
+        url,
+        isMainFrame,
+        isSameDocument: isInPlace,
+        previousDocumentId,
+      });
   });
-  wc.on("did-navigate", (_event, url) => kakaoChallengeGate.commit(wc.id, url));
+  wc.on("did-navigate", (_event, url) => {
+    kakaoChallengeGate.commit(wc.id, url);
+    if (wc.session === session.fromPartition(KAKAO_PARTITION))
+      logKakaoDiagnostic(wc.id, "navigation.commit", { url });
+  });
+  wc.on(
+    "did-fail-provisional-load",
+    (_event, errorCode, _description, url, isMainFrame) => {
+      if (wc.session === session.fromPartition(KAKAO_PARTITION))
+        logKakaoDiagnostic(wc.id, "navigation.failed", {
+          errorCode,
+          url,
+          isMainFrame,
+        });
+    },
+  );
+  wc.on(
+    "did-fail-load",
+    (_event, errorCode, _description, url, isMainFrame) => {
+      if (wc.session === session.fromPartition(KAKAO_PARTITION))
+        logKakaoDiagnostic(wc.id, "navigation.failed", {
+          errorCode,
+          url,
+          isMainFrame,
+        });
+    },
+  );
+  wc.on("did-navigate-in-page", (_event, url, isMainFrame) => {
+    if (wc.session === session.fromPartition(KAKAO_PARTITION))
+      logKakaoDiagnostic(wc.id, "navigation.in-page", { url, isMainFrame });
+  });
+  wc.on("did-stop-loading", () => {
+    if (wc.session === session.fromPartition(KAKAO_PARTITION))
+      logKakaoDiagnostic(wc.id, "navigation.stopped", { url: wc.getURL() });
+  });
   wc.on("destroyed", () => {
     if (validationOwnerWebContentsId === wc.id) {
       setValidationMode(false);
@@ -394,6 +495,7 @@ app.on("web-contents-created", (_, wc) => {
     }
     // navigationTriggerContexts is not globally available here but we can use the helper
     setNavigationTrigger(wc.id, null);
+    kakaoDiagnosticLimiter.forget(wc.id);
   });
 });
 
@@ -603,7 +705,8 @@ registerGameStatusIpc({
   getAppContext: () => appContext,
   getActiveSessionContext: () => gameSessionTracker.getActiveSessionContext(),
   getWindowContext: (webContentsId) => windowContextMap.get(webContentsId),
-  acceptsPage: acceptsKakaoPage,
+  acceptsPage: (event, documentId) =>
+    acceptsKakaoPage(event, documentId, "game-status-update"),
 });
 
 // --- Single Instance Lock ---
@@ -790,7 +893,24 @@ ipcMain.handle("config:is-forced", (_event, key: string) => {
   return FORCE_DEBUG && DEBUG_KEYS.includes(key);
 });
 
-ipcMain.on("debug-log:send", (_event, log: DebugLogPayload) => {
+ipcMain.on("debug-log:send", (event, log: DebugLogPayload) => {
+  const diagnostic = parseKakaoDiagnostic(log.content);
+  if (diagnostic) {
+    try {
+      // The sender owns its original documentId; main owns the current gate/window IDs.
+      const data = {
+        ...diagnostic,
+        ...kakaoDiagnosticContext(event.sender.id),
+      };
+      // Preload already limits repeats; retain its count instead of sampling twice.
+      log = {
+        ...log,
+        content: formatKakaoDiagnostic(String(diagnostic.event), data),
+      };
+    } catch {
+      return;
+    }
+  }
   recordDebugLogPayload(log);
   if (appContext) {
     eventBus.emit<DebugLogEvent>(EventType.DEBUG_LOG, appContext, log);
@@ -804,7 +924,8 @@ ipcMain.on(
     payload: KakaoAutomationFailurePayload,
     documentId?: number | null,
   ) => {
-    if (!acceptsKakaoPage(event, documentId)) return;
+    if (!acceptsKakaoPage(event, documentId, "kakao:automation-failure"))
+      return;
     if (!appContext) return;
 
     const senderId = event.sender.id;
@@ -1546,6 +1667,7 @@ function setNavigationTrigger(
   trigger: string | null | undefined,
   parentId?: number,
 ) {
+  if (!trigger) logKakaoDiagnostic(webContentsId, "task.removed");
   if (trigger && parentId === undefined) {
     const wc = webContents.fromId(webContentsId);
     const selectedWindow = wc && BrowserWindow.fromWebContents(wc);
@@ -1557,6 +1679,7 @@ function setNavigationTrigger(
     }
   }
   kakaoChallengeGate.setTrigger(webContentsId, trigger ?? null, parentId);
+  if (trigger) logKakaoDiagnostic(webContentsId, "task.bound", { parentId });
   if (trigger) {
     logger.log(`[Context] WebContents ${webContentsId} marked as: ${trigger}`);
     navigationTriggerContexts.set(webContentsId, trigger);
@@ -1608,7 +1731,7 @@ ipcMain.on("account:clear-pending-login", (_event, serviceId?: string) => {
 });
 
 ipcMain.on("account:clear-trigger", (event, documentId?: number | null) => {
-  if (!acceptsKakaoPage(event, documentId)) return;
+  if (!acceptsKakaoPage(event, documentId, "account:clear-trigger")) return;
   logger.log(`[Context] Clearing trigger context for ${event.sender.id}`);
   navigationTriggerContexts.delete(event.sender.id);
 });
@@ -1684,7 +1807,8 @@ ipcMain.on(
     serviceId: AppConfig["serviceChannel"],
     documentId?: number | null,
   ) => {
-    if (!acceptsKakaoPage(event, documentId)) return;
+    if (!acceptsKakaoPage(event, documentId, "account:trigger-validation"))
+      return;
     runAccountValidation(serviceId).catch((err) =>
       logger.error("[Account] Error running validation:", err),
     );
@@ -1752,7 +1876,8 @@ ipcMain.on(
 ipcMain.on(
   "kakao:account-id-fetched",
   (event, id: string, documentId?: number | null) => {
-    if (!acceptsKakaoPage(event, documentId)) return;
+    if (!acceptsKakaoPage(event, documentId, "kakao:account-id-fetched"))
+      return;
     logger.log(`[Account] Fetched ID for Kakao: ${id}`);
     setValidationMode(false);
 
@@ -1776,7 +1901,7 @@ ipcMain.on(
 ipcMain.on(
   "kakao:login-required",
   (event, data?: { url?: string }, documentId?: number | null) => {
-    if (!acceptsKakaoPage(event, documentId)) return;
+    if (!acceptsKakaoPage(event, documentId, "kakao:login-required")) return;
     logger.log("[Account] Login required for Kakao.");
 
     // If URL is provided during validation failure, 'keep' it for later
@@ -1809,7 +1934,8 @@ ipcMain.on(
 ipcMain.on(
   "automation:update-timeout",
   (event, timeoutMs: number, documentId?: number | null) => {
-    if (!acceptsKakaoPage(event, documentId)) return;
+    if (!acceptsKakaoPage(event, documentId, "automation:update-timeout"))
+      return;
     lastActiveAutomationWebContentsId = event.sender.id; // Correctly track the caller
     startAutomationTimeout(timeoutMs);
     logger.log(
@@ -1821,7 +1947,7 @@ ipcMain.on(
 ipcMain.on(
   "account:update-timeout",
   (event, timeoutMs: number, documentId?: number | null) => {
-    if (!acceptsKakaoPage(event, documentId)) return;
+    if (!acceptsKakaoPage(event, documentId, "account:update-timeout")) return;
     if (validationModeActive) {
       validationOwnerWebContentsId = event.sender.id;
       if (timeoutMs === -1) {
@@ -1910,7 +2036,12 @@ function hideAutomationWindow(window: BrowserWindow, reason: string) {
 ipcMain.on(
   "window-visibility-request",
   async (event, isVisible: boolean, documentId?: number | null) => {
-    if (!acceptsKakaoPage(event, documentId)) return;
+    logKakaoDiagnostic(event.sender.id, "visibility.request", {
+      receivedDocumentId: documentId ?? null,
+      requestedVisible: isVisible,
+    });
+    if (!acceptsKakaoPage(event, documentId, "window-visibility-request"))
+      return;
     const window = BrowserWindow.fromWebContents(event.sender);
     if (!window || window.isDestroyed()) return;
 
@@ -1921,6 +2052,10 @@ ipcMain.on(
 
     if (isVisible) {
       if (isValidation) {
+        logKakaoDiagnostic(event.sender.id, "visibility.suppressed", {
+          reason: "validation",
+          requestedVisible: isVisible,
+        });
         logger.log(
           `[Main] Window ${window.id} requested visibility but SUPPRESSED (Validation Mode).`,
         );
@@ -1935,6 +2070,10 @@ ipcMain.on(
       if (!window.isVisible()) {
         window.show();
       }
+      logKakaoDiagnostic(event.sender.id, "visibility.applied", {
+        requestedVisible: true,
+        forcedVisible: forcedVisibleWindows.has(window.id),
+      });
       // [v22] Adjust size with 0.1s delay
       await resizeToFitContent(window);
       window.center();
@@ -1970,6 +2109,10 @@ ipcMain.on(
           window.hide();
         }
       }
+      logKakaoDiagnostic(event.sender.id, "visibility.applied", {
+        requestedVisible: false,
+        forcedVisible: forcedVisibleWindows.has(window.id),
+      });
     }
   },
 );
@@ -2593,7 +2736,7 @@ async function createWindow() {
   setupSessionSecurity(session.defaultSession, "default");
 
   // Initialize Kakao Partition (Security & Config)
-  initKakaoSession(kakaoChallengeGate);
+  initKakaoSession(kakaoChallengeGate, logKakaoDiagnostic);
 
   // Apply to GGG Partition (if exists)
   if (PARTITIONS.GGG) {
@@ -3286,6 +3429,29 @@ app.on("browser-window-created", (_, window) => {
   const webContents = window.webContents as unknown as ExtendedWebContents;
   const webPrefs = webContents.getWebPreferences?.();
   const currentPartition = webPrefs?.partition;
+  if (window.webContents.session === session.fromPartition(KAKAO_PARTITION)) {
+    const diagnosticId = window.webContents.id;
+    const diagnosticWindowId = window.id;
+    window.on("show", () =>
+      logKakaoDiagnostic(diagnosticId, "visibility.observed", {
+        reason: "show",
+        windowId: diagnosticWindowId,
+      }),
+    );
+    window.on("hide", () =>
+      logKakaoDiagnostic(diagnosticId, "visibility.observed", {
+        reason: "hide",
+        windowId: diagnosticWindowId,
+      }),
+    );
+    window.on("closed", () =>
+      logKakaoDiagnostic(diagnosticId, "visibility.observed", {
+        reason: "closed",
+        windowId: diagnosticWindowId,
+        destroyed: true,
+      }),
+    );
+  }
 
   // Propagate the trigger context from opener to the new window
   window.webContents.setWindowOpenHandler(

--- a/src/main/tests/kakao-diagnostics.test.ts
+++ b/src/main/tests/kakao-diagnostics.test.ts
@@ -1,0 +1,176 @@
+// @vitest-environment node
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  formatKakaoDiagnostic,
+  KakaoDiagnosticLimiter,
+  parseKakaoDiagnostic,
+  summarizeKakaoDiagnosticUrl,
+} from "../../shared/kakao-diagnostics";
+import { KakaoChallengeGate } from "../kakao/cloudflare-challenge";
+import { DiagnosticLogStore } from "../services/DiagnosticLogStore";
+
+describe("exportable Kakao diagnostics", () => {
+  it("preserves every return to a state when security and visibility states alternate", () => {
+    const limiter = new KakaoDiagnosticLimiter();
+    for (let i = 0; i < 20; i++) {
+      expect(
+        limiter.include("security.state", {
+          webContentsId: 1,
+          state: i % 2 ? "user-required" : "auto-progress",
+        }),
+      ).toBe(1);
+      expect(
+        limiter.include("visibility.observed", {
+          webContentsId: 1,
+          reason: i % 2 ? "show" : "hide",
+        }),
+      ).toBe(1);
+    }
+  });
+  it("keeps only known URL routes and never credentials, queries, fragments or unknown paths", () => {
+    expect(
+      summarizeKakaoDiagnosticUrl(
+        "https://user:secret@security-center.kakaogames.com/auth?code=secret#secret",
+      ),
+    ).toBe("https://security-center.kakaogames.com/auth");
+    expect(
+      summarizeKakaoDiagnosticUrl(
+        "https://security-center.kakaogames.com/secret/account",
+      ),
+    ).toBe("https://security-center.kakaogames.com/[other]");
+    expect(
+      summarizeKakaoDiagnosticUrl("kakaogamestarter://secret?code=secret"),
+    ).toBe("kakaogamestarter:");
+    expect(summarizeKakaoDiagnosticUrl("https://secret.example/secret")).toBe(
+      "https:[other]",
+    );
+    expect(summarizeKakaoDiagnosticUrl("secret")).toBe("[invalid]");
+  });
+
+  it("normalizes fields before logs reach console, IPC or disk", () => {
+    const content = formatKakaoDiagnostic("ipc.rejected", {
+      receivedDocumentId: 7,
+      gateDocumentId: 8,
+      reason: "document-mismatch",
+      url: "https://security-center.kakaogames.com/auth?unknown=SECRET#SECRET",
+      password: "SECRET",
+      html: "SECRET",
+      error: "SECRET",
+      handler: "SECRET",
+    });
+    expect(content).not.toContain("SECRET");
+    expect(parseKakaoDiagnostic(content)).toMatchObject({
+      event: "ipc.rejected",
+      receivedDocumentId: 7,
+      gateDocumentId: 8,
+      reason: "document-mismatch",
+    });
+    expect(parseKakaoDiagnostic("ordinary log")).toBeNull();
+    expect(parseKakaoDiagnostic('[KakaoDiag] {"event":"SECRET"}')).toBeNull();
+  });
+
+  it("bounds repeated records while retaining changed documents and reasons", () => {
+    const limiter = new KakaoDiagnosticLimiter();
+    let count = 0;
+    for (let i = 0; i < 1000; i++)
+      if (
+        limiter.include("ipc.rejected", {
+          webContentsId: 1,
+          receivedDocumentId: 7,
+          reason: "document-mismatch",
+        })
+      )
+        count++;
+    expect(count).toBeLessThan(15);
+    expect(
+      limiter.include("ipc.rejected", {
+        webContentsId: 1,
+        receivedDocumentId: 8,
+        reason: "document-mismatch",
+      }),
+    ).toBe(1);
+    expect(
+      limiter.include("ipc.rejected", {
+        webContentsId: 1,
+        receivedDocumentId: 8,
+        reason: "document-uncommitted",
+      }),
+    ).toBe(1);
+    limiter.forget(1);
+    expect(
+      limiter.include("ipc.rejected", {
+        webContentsId: 1,
+        receivedDocumentId: 7,
+        reason: "document-mismatch",
+      }),
+    ).toBe(1);
+  });
+
+  it("reports the uncommitted document and ignored failure without changing gate acceptance", () => {
+    const gate = new KakaoChallengeGate(vi.fn());
+    gate.setTrigger(1, "GAME_START_POE2");
+    gate.commit(1, "https://security-center.kakaogames.com/auth");
+    const documentId = gate.pageState(1).documentId;
+    expect(gate.diagnosticState(1, documentId).reason).toBe("accepted");
+    gate.beginNavigation(1);
+    expect(gate.diagnosticState(1, documentId)).toMatchObject({
+      reason: "document-uncommitted",
+      gateDocumentId: null,
+      committedDocumentId: documentId,
+      requestId: null,
+    });
+    gate.requestFailed({ id: 100, webContentsId: 1 });
+    expect(gate.accepts(1, documentId)).toBe(false);
+    gate.requestStarted({
+      id: 101,
+      webContentsId: 1,
+      url: "https://security-center.kakaogames.com/auth",
+      resourceType: "mainFrame",
+    });
+    gate.requestFailed({ id: 101, webContentsId: 1 });
+    expect(gate.diagnosticState(1, documentId).reason).toBe("accepted");
+    expect(gate.accepts(1, documentId)).toBe(true);
+    expect(gate.diagnosticState(1, 999).reason).toBe("document-mismatch");
+  });
+
+  it("survives the existing log-store export with parseable correlation fields", () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), "kakao-diagnostic-test-"));
+    try {
+      const now = new Date(2026, 8, 5, 12).getTime();
+      const store = new DiagnosticLogStore({ now: () => now });
+      store.initialize(dir, []);
+      const content = formatKakaoDiagnostic("ipc.rejected", {
+        runId: "boot-123",
+        appVersion: "1.7.1",
+        taskId: 1,
+        webContentsId: 2,
+        receivedDocumentId: 3,
+        gateDocumentId: null,
+        reason: "document-uncommitted",
+      });
+      store.append({
+        type: "GENERAL",
+        content,
+        timestamp: now,
+        isError: false,
+      });
+      const exported = store.createDateSnapshot(now)!;
+      const payload = JSON.parse(
+        exported.segments[0].content.toString("utf8").trim(),
+      );
+      expect(parseKakaoDiagnostic(payload.content)).toMatchObject({
+        runId: "boot-123",
+        taskId: 1,
+        receivedDocumentId: 3,
+        gateDocumentId: null,
+      });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/main/tests/kakao-security-diagnostics.test.ts
+++ b/src/main/tests/kakao-security-diagnostics.test.ts
@@ -1,0 +1,119 @@
+// @vitest-environment-options {"url":"https://security-center.kakaogames.com/auth?code=SECRET#SECRET"}
+import { ipcRenderer } from "electron";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { parseKakaoDiagnostic } from "../../shared/kakao-diagnostics";
+import { logger } from "../utils/preload-logger";
+
+vi.mock("electron", () => ({
+  ipcRenderer: { send: vi.fn(), invoke: vi.fn(), on: vi.fn() },
+}));
+vi.mock("../utils/preload-logger", () => ({
+  logger: { log: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+async function loadSecurity() {
+  vi.mocked(ipcRenderer.invoke).mockImplementation(async (channel) =>
+    channel === "kakao:get-page-state"
+      ? { blocked: false, documentId: 7 }
+      : "GAME_START_POE2",
+  );
+  let ready: (() => Promise<void>) | undefined;
+  vi.spyOn(window, "addEventListener").mockImplementation((event, listener) => {
+    if (event === "DOMContentLoaded") ready = listener as () => Promise<void>;
+  });
+  await import("../kakao/preload");
+  await ready?.();
+  await vi.advanceTimersByTimeAsync(0);
+}
+function records() {
+  return vi.mocked(logger.log).mock.calls.flatMap(([content]) => {
+    const d = typeof content === "string" && parseKakaoDiagnostic(content);
+    return d ? [d] : [];
+  });
+}
+
+describe("Security Center diagnostics preserve automation", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    document.body.innerHTML = "<p>SECRET unknown page</p>";
+  });
+  afterEach(async () => {
+    await vi.advanceTimersByTimeAsync(11000);
+    vi.clearAllTimers();
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+  it("logs the unknown page, delayed request and observer timeout without exposing content or changing timings", async () => {
+    await loadSecurity();
+    expect(records()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          event: "security.state",
+          state: "unresolved",
+          documentId: 7,
+        }),
+      ]),
+    );
+    expect(ipcRenderer.send).toHaveBeenCalledWith(
+      "automation:update-timeout",
+      -1,
+      7,
+    );
+    await vi.advanceTimersByTimeAsync(7999);
+    expect(ipcRenderer.send).not.toHaveBeenCalledWith(
+      "window-visibility-request",
+      true,
+      7,
+    );
+    await vi.advanceTimersByTimeAsync(1);
+    expect(ipcRenderer.send).toHaveBeenCalledWith(
+      "window-visibility-request",
+      true,
+      7,
+    );
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(records()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          event: "observer.stopped",
+          handler: "SecurityCenterHandler",
+          reason: "timeout",
+          timeoutMs: 10000,
+        }),
+      ]),
+    );
+    expect(JSON.stringify(records())).not.toContain("SECRET");
+  });
+  it("records PC info and user-required state changes with bounded repeated mutation logs", async () => {
+    document.body.innerHTML = '<a ganame="PC정보수집안내_확인_버튼">확인</a>';
+    await loadSecurity();
+    expect(records()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          event: "security.pc-info-click",
+          clicked: true,
+        }),
+      ]),
+    );
+    document.body.innerHTML =
+      '<input class="device-name__input" value="SECRET" />';
+    await vi.advanceTimersByTimeAsync(0);
+    expect(records()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          event: "security.state",
+          state: "user-required",
+        }),
+      ]),
+    );
+    for (let i = 0; i < 100; i++) {
+      document.body.appendChild(document.createElement("span"));
+      await vi.advanceTimersByTimeAsync(0);
+    }
+    expect(records().length).toBeLessThan(35);
+    expect(JSON.stringify(records())).not.toContain("SECRET");
+  });
+});

--- a/src/main/tests/kakao-session-diagnostics.test.ts
+++ b/src/main/tests/kakao-session-diagnostics.test.ts
@@ -1,0 +1,72 @@
+// @vitest-environment node
+import { session } from "electron";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { KakaoChallengeGate } from "../kakao/cloudflare-challenge";
+import { initKakaoSession } from "../kakao/session";
+
+vi.mock("electron", () => ({ session: { fromPartition: vi.fn() } }));
+vi.mock("../security/permissions", () => ({ setupSessionSecurity: vi.fn() }));
+
+describe("Kakao request failure diagnostics", () => {
+  const webRequest = {
+    onSendHeaders: vi.fn(),
+    onResponseStarted: vi.fn(),
+    onErrorOccurred: vi.fn(),
+    onBeforeRequest: vi.fn(),
+  };
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(session.fromPartition).mockReturnValue({
+      webRequest,
+    } as unknown as Electron.Session);
+  });
+  it("distinguishes a failure before request headers, an old request and a restored document", () => {
+    const gate = new KakaoChallengeGate(vi.fn());
+    const log = vi.fn();
+    initKakaoSession(gate, log);
+    const sent = webRequest.onSendHeaders.mock.calls[0][0];
+    const failed = webRequest.onErrorOccurred.mock.calls[0][0];
+    gate.setTrigger(1, "GAME_START_POE2");
+    gate.commit(1, "https://security-center.kakaogames.com/auth");
+    const doc = gate.pageState(1).documentId;
+    gate.beginNavigation(1);
+    failed({
+      id: 11,
+      webContentsId: 1,
+      resourceType: "mainFrame",
+      url: "kakaogamestarter://private",
+      error: "net::ERR_ABORTED",
+    });
+    expect(log).toHaveBeenLastCalledWith(
+      1,
+      "request.failed",
+      expect.objectContaining({
+        reason: "no-request",
+        eventRequestId: 11,
+        gateDocumentId: null,
+      }),
+    );
+    sent({
+      id: 12,
+      webContentsId: 1,
+      resourceType: "mainFrame",
+      url: "https://security-center.kakaogames.com/auth",
+    });
+    failed({ id: 11, webContentsId: 1, resourceType: "mainFrame" });
+    expect(log).toHaveBeenLastCalledWith(
+      1,
+      "request.failed",
+      expect.objectContaining({ reason: "request-mismatch" }),
+    );
+    failed({ id: 12, webContentsId: 1, resourceType: "mainFrame" });
+    expect(log).toHaveBeenLastCalledWith(
+      1,
+      "request.failed",
+      expect.objectContaining({ reason: "restored", gateDocumentId: doc }),
+    );
+    expect(gate.accepts(1, doc)).toBe(true);
+    expect(webRequest.onSendHeaders).toHaveBeenCalledOnce();
+    expect(webRequest.onBeforeRequest).toHaveBeenCalledOnce();
+  });
+});

--- a/src/shared/kakao-diagnostics.ts
+++ b/src/shared/kakao-diagnostics.ts
@@ -1,0 +1,278 @@
+/** Allowlisted diagnostics: never pass page text, input values or raw errors. */
+export const KAKAO_DIAGNOSTIC_PREFIX = "[KakaoDiag] ";
+
+const EVENTS = new Set([
+  "ipc.sent",
+  "ipc.suppressed",
+  "ipc.accepted",
+  "ipc.rejected",
+  "visibility.request",
+  "visibility.suppressed",
+  "visibility.applied",
+  "visibility.observed",
+  "navigation.start",
+  "navigation.commit",
+  "navigation.failed",
+  "navigation.stopped",
+  "navigation.in-page",
+  "request.sent",
+  "request.response",
+  "request.failed",
+  "task.bound",
+  "task.removed",
+  "page.dispatch",
+  "page.deferred",
+  "page.paused",
+  "page.resumed",
+  "security.state",
+  "security.pc-info-click",
+  "security.reveal-scheduled",
+  "security.reveal-cancelled",
+  "security.reveal-fired",
+  "observer.started",
+  "observer.stopped",
+]);
+const ENUMS: Record<string, readonly string[]> = {
+  reason: [
+    "accepted",
+    "frame-mismatch",
+    "retired",
+    "task-challenged",
+    "document-uncommitted",
+    "document-mismatch",
+    "paused",
+    "validation",
+    "already-requested",
+    "timeout",
+    "matched",
+    "disconnected",
+    "url-changed",
+    "auto-progress",
+    "user-required",
+    "unresolved",
+    "restored",
+    "untracked",
+    "no-request",
+    "request-mismatch",
+    "show",
+    "hide",
+    "closed",
+  ],
+  state: ["auto-progress", "user-required", "unresolved"],
+  trigger: [
+    "ACCOUNT_VALIDATION",
+    "ACCOUNT_MANUAL_LOGIN",
+    "GAME_START_POE1",
+    "GAME_START_POE2",
+  ],
+  channel: [
+    "window-visibility-request",
+    "game-status-update",
+    "automation:update-timeout",
+    "account:update-timeout",
+    "kakao:automation-failure",
+    "account:clear-trigger",
+    "account:trigger-validation",
+    "kakao:account-id-fetched",
+    "kakao:login-required",
+  ],
+  handler: [
+    "PoeMainHandler",
+    "Poe2MainHandler",
+    "AccountValidationHandler",
+    "DaumGameLoginValidationHandler",
+    "SecurityCenterHandler",
+    "LauncherCompletionHandler",
+    "LauncherCheckHandler",
+    "KakaoLoginHandler",
+    "KakaoQRLoginHandler",
+    "DaumLoginHandler",
+    "KakaoGamesMemberLoginHandler",
+    "KakaoSimpleLoginHandler",
+    "KakaoGamesAgreementHandler",
+    "KakaoAuthHandler",
+    "StarterInstallPopupHandler",
+    "DaumMemberCertHandler",
+    "KCBAuthHandler",
+    "KCBCardAuthHandler",
+    "KakaoLoginValidationHandler",
+    "KakaoManualValidationHandler",
+  ],
+  status: [
+    "idle",
+    "preparing",
+    "processing",
+    "authenticating",
+    "ready",
+    "running",
+    "error",
+  ],
+};
+const NUMBERS = new Set([
+  "webContentsId",
+  "windowId",
+  "parentId",
+  "taskId",
+  "documentId",
+  "receivedDocumentId",
+  "gateDocumentId",
+  "committedDocumentId",
+  "requestId",
+  "eventRequestId",
+  "previousDocumentId",
+  "statusCode",
+  "errorCode",
+  "timeoutMs",
+  "elapsedMs",
+  "occurrences",
+]);
+const BOOLEANS = new Set([
+  "tracked",
+  "retired",
+  "challenge",
+  "taskBlocked",
+  "revealPending",
+  "isMainFrame",
+  "isSameDocument",
+  "visible",
+  "focused",
+  "minimized",
+  "destroyed",
+  "requestedVisible",
+  "forcedVisible",
+  "paused",
+  "validation",
+  "clicked",
+]);
+const HOSTS = new Set([
+  "security-center.kakaogames.com",
+  "pubsvc.kakaogames.com",
+  "member.kakaogames.com",
+  "poe.kakaogames.com",
+  "pathofexile.kakaogames.com",
+  "pathofexile2.kakaogames.com",
+  "accounts.kakao.com",
+  "logins.daum.net",
+  "service.kakaogames.com",
+]);
+const PATHS = new Set([
+  "/",
+  "/auth",
+  "/login",
+  "/login/",
+  "/login/simple",
+  "/main",
+  "/inspection",
+  "/gamestart/poe.html",
+  "/gamestart/poe2.html",
+  "/securitycenter/completed.html",
+  "/launcher/completed.html",
+]);
+
+export function summarizeKakaoDiagnosticUrl(value: string): string {
+  if (
+    ["https:[other]", "http:[other]", "[other-protocol]", "[invalid]"].includes(
+      value,
+    )
+  )
+    return value;
+  try {
+    const url = new URL(value);
+    if (url.protocol === "about:" && url.pathname === "blank")
+      return "about:blank";
+    if (["kakaogamestarter:", "daumgamestarter:"].includes(url.protocol))
+      return url.protocol;
+    if (!["http:", "https:"].includes(url.protocol)) return "[other-protocol]";
+    if (!HOSTS.has(url.hostname)) return `${url.protocol}[other]`;
+    return `${url.protocol}//${url.hostname}${PATHS.has(url.pathname) ? url.pathname : "/[other]"}`;
+  } catch {
+    return "[invalid]";
+  }
+}
+
+export type KakaoDiagnosticFields = Record<string, unknown>;
+export type KakaoDiagnosticSink = (
+  webContentsId: number,
+  event: string,
+  fields?: KakaoDiagnosticFields,
+) => void;
+
+export function formatKakaoDiagnostic(
+  event: string,
+  fields: KakaoDiagnosticFields = {},
+): string {
+  const safe: Record<string, string | number | boolean | null> = {
+    v: 1,
+    event: EVENTS.has(event) ? event : "invalid",
+  };
+  for (const [key, value] of Object.entries(fields)) {
+    if (
+      NUMBERS.has(key) &&
+      (value === null ||
+        (typeof value === "number" && Number.isSafeInteger(value)))
+    )
+      safe[key] = value;
+    else if (BOOLEANS.has(key) && typeof value === "boolean") safe[key] = value;
+    else if (ENUMS[key]?.includes(value as string)) safe[key] = value as string;
+    else if (
+      (key === "runId" || key === "appVersion") &&
+      typeof value === "string" &&
+      /^[a-zA-Z0-9.-]{1,64}$/.test(value)
+    )
+      safe[key] = value;
+    else if (key === "url" && typeof value === "string")
+      safe[key] = summarizeKakaoDiagnosticUrl(value);
+  }
+  return KAKAO_DIAGNOSTIC_PREFIX + JSON.stringify(safe);
+}
+
+export function parseKakaoDiagnostic(
+  content: string,
+): KakaoDiagnosticFields | null {
+  if (!content.startsWith(KAKAO_DIAGNOSTIC_PREFIX) || content.length > 4096)
+    return null;
+  try {
+    const parsed = JSON.parse(content.slice(KAKAO_DIAGNOSTIC_PREFIX.length));
+    if (!parsed || !EVENTS.has(parsed.event)) return null;
+    return JSON.parse(
+      formatKakaoDiagnostic(parsed.event, parsed).slice(
+        KAKAO_DIAGNOSTIC_PREFIX.length,
+      ),
+    );
+  } catch {
+    return null;
+  }
+}
+
+/** First occurrence and powers of two; no timers, bounded memory, distinct states retained. */
+export class KakaoDiagnosticLimiter {
+  private counts = new Map<
+    string,
+    { owner: unknown; fingerprint: string; count: number }
+  >();
+  include(event: string, fields: KakaoDiagnosticFields): number | null {
+    const identity = { ...fields };
+    delete identity.elapsedMs;
+    delete identity.occurrences;
+    const key = `${fields.webContentsId ?? "preload"}:${event}:${fields.handler ?? ""}:${fields.channel ?? ""}`;
+    const fingerprint = formatKakaoDiagnostic(event, identity);
+    const previous = this.counts.get(key);
+    const entry =
+      previous?.fingerprint === fingerprint
+        ? previous
+        : {
+            owner: fields.webContentsId,
+            fingerprint,
+            count: 0,
+          };
+    entry.count++;
+    if (this.counts.size >= 512 && !this.counts.has(key))
+      this.counts.delete(this.counts.keys().next().value!);
+    this.counts.set(key, entry);
+    return Number.isInteger(Math.log2(entry.count)) ? entry.count : null;
+  }
+  forget(webContentsId: number) {
+    for (const [key, entry] of this.counts)
+      if (entry.owner === webContentsId) this.counts.delete(key);
+  }
+}


### PR DESCRIPTION
## Summary

특정 상황에서 카카오 게임 시작이 진행되지 않을 때, 기존 반출 로그로 중단 지점과 원인을 분석할 수 있도록 진단 정보를 보강합니다.

- 표시 요청의 전송·억제·거절·적용, 페이지 이동·실패·복구, 보안센터 상태와 감시 종료를 실행·작업·창·문서 ID로 연결합니다.
- 새 진단 기록은 허용된 필드와 URL 분류만 저장하며 인증 정보·쿼리·페이지 내용을 제외하고 동일 상태 반복 기록을 제한합니다.
- Windows 테스트 262개, lint, 빌드, 분리 리뷰를 통과했습니다. 격리 Electron fixture의 기존 로그 파일에서 거절·복구·감시 종료·실제 창 닫힘 기록을 확인했으며 Windows x64 설치 파일도 빌드했습니다. 실제 사이트 로그인·게임 실행 및 인증창 표시 검증은 미실시입니다.

## Motivation

재설치 후 게임 시작 버튼만 비활성화되고 실행되지 않다가 지정 PC 등록 후 해결된 제보가 있었지만, 기존 로그만으로 표시 요청이 어느 단계에서 중단됐는지 확정할 수 없었습니다. 같은 상황이 재발하면 사용자가 반출한 로그에서 해당 흐름을 추적하기 위한 변경입니다.

이번 PR은 진단 로그 보강이며 실행 불가 문제의 원인 조치는 포함하지 않습니다. 게임 실행·인증 처리·시간 제한·DOM 셀렉터·IPC 인자와 설정은 유지합니다.
